### PR TITLE
vici: Handle closed sockets in the Ruby gem

### DIFF
--- a/src/libcharon/plugins/vici/ruby/lib/vici.rb
+++ b/src/libcharon/plugins/vici/ruby/lib/vici.rb
@@ -247,7 +247,11 @@ module Vici
     def recv_all(len)
       encoding = ""
       while encoding.length < len do
-        encoding << @socket.recv(len - encoding.length)
+        data = @socket.recv(len - encoding.length)
+        if data.empty?
+          raise TransportError, "connection closed"
+        end
+        encoding << data
       end
       encoding
     end


### PR DESCRIPTION
From recvfrom(2) (which UDPSocket#recv backs into):

  The return value will be 0 when the peer has performed an orderly
  shutdown.

(i.e. it will return an empty string)

Previously in this scenario, Vici::Transport#recv_all would spin
forever trying to pull more data off the socket. I'm not entirely
clear what happened that caused strongswan to shutdown the socket, but
it probably should cause vici Ruby apps to spin.