### PR TITLE
Add option to allow millisecond resolution in file logger

### DIFF
--- a/src/conftest/conftest.c
+++ b/src/conftest/conftest.c
@@ -382,15 +382,17 @@ static void load_log_levels(file_logger_t *logger, char *section)
  */
 static void load_logger_options(file_logger_t *logger, char *section)
 {
-	bool ike_name;
+	bool ike_name, use_millisecond;
 	char *time_format;
 
 	time_format = conftest->test->get_str(conftest->test,
 					"log.%s.time_format", NULL, section);
 	ike_name = conftest->test->get_bool(conftest->test,
 					"log.%s.ike_name", FALSE, section);
+	use_millisecond = conftest->test->get_bool(conftest->test,
+					"log.%s.use_millisecond", FALSE, section);
 
-	logger->set_options(logger, time_format, ike_name);
+	logger->set_options(logger, time_format, ike_name, use_millisecond);
 }
 
 /**
@@ -463,7 +465,7 @@ int main(int argc, char *argv[])
 	lib->credmgr->add_set(lib->credmgr, &conftest->creds->set);
 
 	logger = file_logger_create("stdout");
-	logger->set_options(logger, NULL, FALSE);
+	logger->set_options(logger, NULL, FALSE, FALSE);
 	logger->open(logger, FALSE, FALSE);
 	logger->set_level(logger, DBG_ANY, LEVEL_CTRL);
 	charon->bus->add_logger(charon->bus, &logger->logger);

--- a/src/libcharon/bus/listeners/file_logger.h
+++ b/src/libcharon/bus/listeners/file_logger.h
@@ -47,10 +47,13 @@ struct file_logger_t {
 	/**
 	 * Set options used by this logger
 	 *
-	 * @param time_format	format of timestamp prefix, as in strftime(), cloned
-	 * @param ike_name		TRUE to prefix the name of the IKE_SA
+	 * @param time_format		format of timestamp prefix, as in strftime(), cloned
+	 * @param ike_name			TRUE to prefix the name of the IKE_SA
+	 * @param use_millisecond	TRUE to prefix a millisecond time to the end of 
+	 *                        	the time_format. time_format should end with %H:%M:%S for 
+	 *                        	this to make sence
 	 */
-	void (*set_options) (file_logger_t *this, char *time_format, bool ike_name);
+	void (*set_options) (file_logger_t *this, char *time_format, bool ike_name, bool use_millisecond);
 
 	/**
 	 * Open (or reopen) the log file according to the given parameters

--- a/src/libcharon/daemon.c
+++ b/src/libcharon/daemon.c
@@ -324,11 +324,13 @@ static void load_file_logger(private_daemon_t *this, char *filename,
 	file_logger_t *file_logger;
 	debug_t group;
 	level_t def;
-	bool ike_name, flush_line, append;
+	bool ike_name, flush_line, append, use_millisecond;
 	char *time_format;
 
 	time_format = lib->settings->get_str(lib->settings,
 						"%s.filelog.%s.time_format", NULL, lib->ns, filename);
+	use_millisecond = lib->settings->get_bool(lib->settings,
+						"%s.filelog.%s.use_millisecond", FALSE, lib->ns, filename);
 	ike_name = lib->settings->get_bool(lib->settings,
 						"%s.filelog.%s.ike_name", FALSE, lib->ns, filename);
 	flush_line = lib->settings->get_bool(lib->settings,
@@ -337,7 +339,7 @@ static void load_file_logger(private_daemon_t *this, char *filename,
 						"%s.filelog.%s.append", TRUE, lib->ns, filename);
 
 	file_logger = add_file_logger(this, filename, current_loggers);
-	file_logger->set_options(file_logger, time_format, ike_name);
+	file_logger->set_options(file_logger, time_format, ike_name, use_millisecond);
 	file_logger->open(file_logger, flush_line, append);
 
 	def = lib->settings->get_int(lib->settings, "%s.filelog.%s.default", 1,


### PR DESCRIPTION
This adds an option use_millisecond to the file logger configuration. If set the millisecond will be added to the end of the time_format with a format .XXX. 

The actual use of this only makes sense if time_format ends with %S e.g. %H:%M:%S or %T. Either of these would result in a time output of something like 12:52:25.123
