### PR TITLE
Radius retry timer config

### DIFF
--- a/conf/plugins/eap-radius.opt
+++ b/conf/plugins/eap-radius.opt
@@ -80,6 +80,15 @@ charon.plugins.eap-radius.secret =
 charon.plugins.eap-radius.server =
 	IP/Hostname of RADIUS server.
 
+charon.plugins.eap-radius.retransmit_base = 1.4
+	Base to use for calculating exponential back off.
+
+charon.plugins.eap-radius.retransmit_timeout = 2
+	Timeout in seconds before sending first retransmit.
+
+charon.plugins.eap-radius.retransmit_tries = 4
+	Number of times to retransmit a packet before giving up.
+
 charon.plugins.eap-radius.servers {}
 	Section to specify multiple RADIUS servers.
 
@@ -88,7 +97,9 @@ charon.plugins.eap-radius.servers {}
 	specified for each server. A server's IP/Hostname can be configured using
 	the **address** option. The **acct_port** [1813] option can be used to
 	specify the port used for RADIUS accounting. For each RADIUS server a
-	priority can be specified using the **preference** [0] option.
+	priority can be specified using the **preference** [0] option. The 
+	retransmission time for each server can set set using **retransmit_base**,
+	**retransmit_timeout** and **retransmit_tries**.
 
 charon.plugins.eap-radius.sockets = 1
 	Number of sockets (ports) to use, increase for high load.

--- a/src/libcharon/plugins/eap_radius/eap_radius_plugin.c
+++ b/src/libcharon/plugins/eap_radius/eap_radius_plugin.c
@@ -119,7 +119,7 @@ static void load_configs(private_eap_radius_plugin_t *this)
 						"%s.plugins.eap-radius.sockets", 1, lib->ns);
 
 		num_request_attempts = lib->settings->get_int(lib->settings,
-						"%s.plugins.eap-radius.num_request_attempts", 5, lib->ns);
+						"%s.plugins.eap-radius.num_request_attempts", 4, lib->ns);
 		first_request_timeout = lib->settings->get_int(lib->settings,
 						"%s.plugins.eap-radius.first_request_timeout", 2000, lib->ns);
 		request_backoff_timeout = lib->settings->get_int(lib->settings,
@@ -184,7 +184,7 @@ static void load_configs(private_eap_radius_plugin_t *this)
 		num_request_attempts = lib->settings->get_int(lib->settings,
 				"%s.plugins.eap-radius.servers.%s.num_request_attempts",
 					lib->settings->get_int(lib->settings,
-						"%s.plugins.eap-radius.num_request_attempts", 5, lib->ns),
+						"%s.plugins.eap-radius.num_request_attempts", 4, lib->ns),
 				lib->ns, section);
 
 		first_request_timeout = lib->settings->get_int(lib->settings,

--- a/src/libcharon/plugins/eap_radius/eap_radius_plugin.c
+++ b/src/libcharon/plugins/eap_radius/eap_radius_plugin.c
@@ -211,13 +211,13 @@ static void load_configs(private_eap_radius_plugin_t *this)
 						"%s.plugins.eap-radius.retransmit_tries", 4, lib->ns),
 				lib->ns, section);
 
-		retransmit_timeout = lib->settings->get_int(lib->settings,
+		retransmit_timeout = lib->settings->get_double(lib->settings,
 				"%s.plugins.eap-radius.servers.%s.retransmit_timeout",
 					lib->settings->get_double(lib->settings,
 						"%s.plugins.eap-radius.retransmit_timeout", 2.0, lib->ns),
 				lib->ns, section);
 
-		retransmit_base = lib->settings->get_int(lib->settings,
+		retransmit_base = lib->settings->get_double(lib->settings,
 				"%s.plugins.eap-radius.servers.%s.retransmit_base",
 					lib->settings->get_double(lib->settings,
 						"%s.plugins.eap-radius.retransmit_base", 1.4, lib->ns),

--- a/src/libradius/radius_config.c
+++ b/src/libradius/radius_config.c
@@ -180,7 +180,9 @@ METHOD(radius_config_t, destroy, void,
 radius_config_t *radius_config_create(char *name, char *address,
 									  u_int16_t auth_port, u_int16_t acct_port,
 									  char *nas_identifier, char *secret,
-									  int sockets, int preference)
+									  int sockets, int preference,
+									  int num_request_attempts, int first_request_timeout,
+									  int request_backoff_timeout)
 {
 	private_radius_config_t *this;
 	radius_socket_t *socket;
@@ -209,7 +211,9 @@ radius_config_t *radius_config_create(char *name, char *address,
 	while (sockets--)
 	{
 		socket = radius_socket_create(address, auth_port, acct_port,
-									  chunk_create(secret, strlen(secret)));
+									  chunk_create(secret, strlen(secret)),
+									  num_request_attempts, first_request_timeout,
+									  request_backoff_timeout);
 		if (!socket)
 		{
 			destroy(this);

--- a/src/libradius/radius_config.c
+++ b/src/libradius/radius_config.c
@@ -13,6 +13,28 @@
  * for more details.
  */
 
+/*
+ * Copyright (C) 2015 Thom Troy
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
 #include "radius_config.h"
 
 #include <threading/mutex.h>
@@ -181,8 +203,8 @@ radius_config_t *radius_config_create(char *name, char *address,
 									  u_int16_t auth_port, u_int16_t acct_port,
 									  char *nas_identifier, char *secret,
 									  int sockets, int preference,
-									  int num_request_attempts, int first_request_timeout,
-									  int request_backoff_timeout)
+									  u_int retransmit_tries, double retransmit_timeout,
+									  double retransmit_base)
 {
 	private_radius_config_t *this;
 	radius_socket_t *socket;
@@ -212,8 +234,8 @@ radius_config_t *radius_config_create(char *name, char *address,
 	{
 		socket = radius_socket_create(address, auth_port, acct_port,
 									  chunk_create(secret, strlen(secret)),
-									  num_request_attempts, first_request_timeout,
-									  request_backoff_timeout);
+									  retransmit_tries, retransmit_timeout,
+									  retransmit_base);
 		if (!socket)
 		{
 			destroy(this);

--- a/src/libradius/radius_config.h
+++ b/src/libradius/radius_config.h
@@ -83,18 +83,23 @@ struct radius_config_t {
 /**
  * Create a radius_config_t instance.
  *
- * @param name				server name
- * @param address			server address
- * @param auth_port			server port for authentication
- * @param acct_port			server port for accounting
- * @param nas_identifier	NAS-Identifier to use with this server
- * @param secret			secret to use with this server
- * @param sockets			number of sockets to create in pool
- * @param preference		preference boost for this server
+ * @param name						server name
+ * @param address					server address
+ * @param auth_port					server port for authentication
+ * @param acct_port					server port for accounting
+ * @param nas_identifier			NAS-Identifier to use with this server
+ * @param secret					secret to use with this server
+ * @param sockets					number of sockets to create in pool
+ * @param preference				preference boost for this server
+ * @param num_request_attempts		number of attempts to try send a request
+ * @param first_request_timeout		time to wait for response first time
+ * @param request_backoff_timeout	backoff timeout for sending attempts
  */
 radius_config_t *radius_config_create(char *name, char *address,
 									  u_int16_t auth_port, u_int16_t acct_port,
 									  char *nas_identifier, char *secret,
-									  int sockets, int preference);
+									  int sockets, int preference,
+									  int num_request_attempts, int first_request_timeout,
+									  int request_backoff_timeout);
 
 #endif /** RADIUS_CONFIG_H_ @}*/

--- a/src/libradius/radius_config.h
+++ b/src/libradius/radius_config.h
@@ -13,6 +13,28 @@
  * for more details.
  */
 
+/*
+ * Copyright (C) 2015 Thom Troy
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
 /**
  * @defgroup radius_config radius_config
  * @{ @ingroup libradius
@@ -91,15 +113,15 @@ struct radius_config_t {
  * @param secret					secret to use with this server
  * @param sockets					number of sockets to create in pool
  * @param preference				preference boost for this server
- * @param num_request_attempts		number of attempts to try send a request
- * @param first_request_timeout		time to wait for response first time
- * @param request_backoff_timeout	backoff timeout for sending attempts
+ * @param retransmit_tries			number of times we retransmit messages
+ * @param retransmit_timeout		retransmission timeout
+ * @param retransmit_base			base to calculate retransmission timeout
  */
 radius_config_t *radius_config_create(char *name, char *address,
 									  u_int16_t auth_port, u_int16_t acct_port,
 									  char *nas_identifier, char *secret,
 									  int sockets, int preference,
-									  int num_request_attempts, int first_request_timeout,
-									  int request_backoff_timeout);
+									  u_int retransmit_tries, double retransmit_timeout,
+									  double retransmit_base);
 
 #endif /** RADIUS_CONFIG_H_ @}*/

--- a/src/libradius/radius_socket.h
+++ b/src/libradius/radius_socket.h
@@ -13,6 +13,28 @@
  * for more details.
  */
 
+/*
+ * Copyright (C) 2015 Thom Troy
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
 /**
  * @defgroup radius_socket radius_socket
  * @{ @ingroup libradius
@@ -66,14 +88,17 @@ struct radius_socket_t {
 /**
  * Create a radius_socket instance.
  *
- * @param address	server name
- * @param auth_port	server port for authentication
- * @param acct_port	server port for accounting
- * @param secret	RADIUS secret
+ * @param address					server name
+ * @param auth_port					server port for authentication
+ * @param acct_port					server port for accounting
+ * @param secret					RADIUS secret
+ * @param retransmit_tries			number of times we retransmit messages
+ * @param retransmit_timeout		retransmission timeout
+ * @param retransmit_base			base to calculate retransmission timeout
  */
 radius_socket_t *radius_socket_create(char *address, u_int16_t auth_port,
 									  u_int16_t acct_port, chunk_t secret,
-									  int num_request_attempts, int first_request_timeout,
-									  int request_backoff_timeout);
+									  u_int retransmit_tries, double retransmit_timeout,
+									  double retransmit_base);
 
 #endif /** RADIUS_SOCKET_H_ @}*/

--- a/src/libradius/radius_socket.h
+++ b/src/libradius/radius_socket.h
@@ -72,6 +72,8 @@ struct radius_socket_t {
  * @param secret	RADIUS secret
  */
 radius_socket_t *radius_socket_create(char *address, u_int16_t auth_port,
-									  u_int16_t acct_port, chunk_t secret);
+									  u_int16_t acct_port, chunk_t secret,
+									  int num_request_attempts, int first_request_timeout,
+									  int request_backoff_timeout);
 
 #endif /** RADIUS_SOCKET_H_ @}*/


### PR DESCRIPTION
This change makes the RADIUS retransmissions configurable in the radius plugin.

It creates the following settings 

num_request_attempts = 4
first_request_timeout = 2000
request_backoff_timeout = 1000

This recreates the current default behaviour to preserve backwards compatibility.  

num_request_attempts is the total number of requests that will be sent.
first_request_timeout. The timeout for the first radius request in ms
request_backoff_timeout. The timeout for calculating subsequent attempt backoffs in ms, calculated as first_request_timeout + (retransmissions_attempt * request_backoff_timeout).

Using the default settings the requests could be sent as:

first @ 0
second @ 2s
third @ 5s
fourth @ 9s
final timeout @ 14s