### PR TITLE
fix: segfault in command parsing: pki and swanctl

### DIFF
--- a/src/pki/command.c
+++ b/src/pki/command.c
@@ -208,7 +208,7 @@ int command_usage(char *error)
 	}
 	else
 	{
-		for (i = 0; cmds[active].line[i]; i++)
+		for (i = 0; i < sizeof(cmds[active].line) / sizeof(cmds[active].line[0]); i++)
 		{
 			if (i == 0)
 			{

--- a/src/swanctl/command.c
+++ b/src/swanctl/command.c
@@ -217,7 +217,7 @@ int command_usage(char *error, ...)
 	}
 	else
 	{
-		for (i = 0; cmds[active].line[i]; i++)
+		for (i = 0; i < sizeof(cmds[active].line) / sizeof(cmds[active].line[0]); i++)
 		{
 			if (i == 0)
 			{


### PR DESCRIPTION
description:
incorrect array iteration length check caused
segfault when calling 'pki --issue' without
further arguments.

reproducibility:
always

affected:
 - src/pki/command.c
 - src/swanctl/command.c

gdb trace:
(gdb) run --issue
Starting program: /usr/local/bin/pki --issue
[Thread debugging using libthread_db enabled]
Using host libthread_db library "/lib64/libthread_db.so.1".
Error: --cacert is required
strongSwan 5.3.5 PKI tool
usage:
  pki --issue [--in file] [--type pub|pkcs10|rsa|ecdsa|bliss] --cakey file|--cakeyid hex
               --cacert file [--dn subject-dn] [--san subjectAltName]+
              [--lifetime days] [--serial hex] [--ca] [--pathlen len]
              [--flag serverAuth|clientAuth|crlSign|ocspSigning|msSmartcardLogon]+
              [--crl uri [--crlissuer i]]+ [--ocsp uri]+ [--nc-permitted name]
              [--nc-excluded name] [--policy-mapping issuer-oid:subject-oid]
              [--policy-explicit len] [--policy-inhibit len] [--policy-any len]
              [--cert-policy oid [--cps-uri uri] [--user-notice text]]+
              [--digest md5|sha1|sha224|sha256|sha384|sha512|sha3_224|sha3_256|sha3_384|sha3_512]
              [--outform der|pem]
              help

Program received signal SIGSEGV, Segmentation fault.
0x00007ffff7807ea7 in vfprintf () from /lib64/libc.so.6
Missing separate debuginfos, use: debuginfo-install glibc-2.17-78.el7.x86_64 gmp-6.0.0-12.el7_1.x86_64
(gdb) bt
0  0x00007ffff7807ea7 in vfprintf () from /lib64/libc.so.6
1  0x00007ffff78097e1 in buffered_vfprintf () from /lib64/libc.so.6
2  0x00007ffff780471e in vfprintf () from /lib64/libc.so.6
3  0x00007ffff780eb77 in fprintf () from /lib64/libc.so.6
4  0x0000000000404271 in command_usage (error=error@entry=0x40cf09 "--cacert is required") at command.c:220
5  0x0000000000405610 in issue () at commands/issue.c:572
6  0x00007ffff77deaf5 in __libc_start_main () from /lib64/libc.so.6
7  0x000000000040392d in _start ()