### PR TITLE
configure: support systemd >= 209

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -941,13 +941,17 @@ if test x$systemd = xtrue; then
 		AC_MSG_ERROR([not found (try --with-systemdsystemunitdir)])
 	fi
 
-	PKG_CHECK_MODULES(systemd_daemon, [libsystemd-daemon])
-	AC_SUBST(systemd_daemon_CFLAGS)
-	AC_SUBST(systemd_daemon_LIBS)
+	PKG_CHECK_MODULES(systemd, [libsystemd >= 209],
+		[AC_SUBST(systemd_CFLAGS)
+		AC_SUBST(systemd_LIBS)],
+		[PKG_CHECK_MODULES(systemd_daemon, [libsystemd-daemon])
+		AC_SUBST(systemd_daemon_CFLAGS)
+		AC_SUBST(systemd_daemon_LIBS)
 
-	PKG_CHECK_MODULES(systemd_journal, [libsystemd-journal])
-	AC_SUBST(systemd_journal_CFLAGS)
-	AC_SUBST(systemd_journal_LIBS)
+		PKG_CHECK_MODULES(systemd_journal, [libsystemd-journal])
+		AC_SUBST(systemd_journal_CFLAGS)
+		AC_SUBST(systemd_journal_LIBS)
+		])
 fi
 
 if test x$tss = xtrousers; then

--- a/src/charon-systemd/Makefile.am
+++ b/src/charon-systemd/Makefile.am
@@ -9,11 +9,11 @@ charon_systemd_CPPFLAGS = \
 	-I$(top_srcdir)/src/libstrongswan \
 	-I$(top_srcdir)/src/libhydra \
 	-I$(top_srcdir)/src/libcharon \
-	$(systemd_daemon_CFLAGS) $(systemd_journal_CFLAGS) \
+	$(systemd_CFLAGS) $(systemd_daemon_CFLAGS) $(systemd_journal_CFLAGS) \
 	-DPLUGINS=\""${charon_plugins}\""
 
 charon_systemd_LDADD = \
 	$(top_builddir)/src/libstrongswan/libstrongswan.la \
 	$(top_builddir)/src/libhydra/libhydra.la \
 	$(top_builddir)/src/libcharon/libcharon.la \
-	$(systemd_daemon_LIBS) $(systemd_journal_LIBS) -lm $(PTHREADLIB) $(DLLIB)
+	$(systemd_LIBS) $(systemd_daemon_LIBS) $(systemd_journal_LIBS) -lm $(PTHREADLIB) $(DLLIB)


### PR DESCRIPTION
libsystemd-journal and libsystemd-daemon are now just
part of libsystemd.

Keep original systemd checks as a fallback.

Updates charon-systemd/Makefile.am accordingly.

Tested on:
- debian wheezy (systemd v44)
- ubuntu 15.10 (systemd v255).

Signed-off-by: Chris Patterson <pattersonc@ainfosec.com>