### PR TITLE
[RFC] stroke: print host ports

### DIFF
--- a/src/libcharon/plugins/stroke/stroke_list.c
+++ b/src/libcharon/plugins/stroke/stroke_list.c
@@ -114,7 +114,7 @@ static void log_ike_sa(FILE *out, ike_sa_t *ike_sa, bool all)
 		fprintf(out, " %V ago", &now, &established);
 	}
 
-	fprintf(out, ", %H[%Y]...%H[%Y]\n",
+	fprintf(out, ", %#H[%Y]...%#H[%Y]\n",
 			ike_sa->get_my_host(ike_sa), ike_sa->get_my_id(ike_sa),
 			ike_sa->get_other_host(ike_sa), ike_sa->get_other_id(ike_sa));
 
@@ -538,7 +538,7 @@ METHOD(stroke_list_t, status, void,
 		fprintf(out, "Listening IP addresses:\n");
 		while (enumerator->enumerate(enumerator, (void**)&host))
 		{
-			fprintf(out, "  %H\n", host);
+			fprintf(out, "  %#H\n", host);
 		}
 		enumerator->destroy(enumerator);
 


### PR DESCRIPTION
Print host ports to gather NAT source/destination port as in pluto.


Note: this might break existing third-party application relying on parsing the statusall output:

```
peer-10.10.2.3-tunnel-1[1]: ESTABLISHED 21 seconds ago, 10.10.2.2[500][10.10.2.2]...10.10.2.3[500][10.10.2.3]
```

vs. (original):

```
peer-10.10.2.3-tunnel-1[1]: ESTABLISHED 21 seconds ago, 10.10.2.2[10.10.2.2]...10.10.2.3[10.10.2.3]
```