### PR TITLE
Android client wrapper not setting IDr in IKE_AUTH request

### DIFF
--- a/src/frontends/android/app/src/main/jni/libandroidbridge/backend/android_service.c
+++ b/src/frontends/android/app/src/main/jni/libandroidbridge/backend/android_service.c
@@ -727,7 +727,7 @@ static job_requeue_t initiate(private_android_service_t *this)
 	auth = auth_cfg_create();
 	gateway = identification_create_from_string(server);
 	auth->add(auth, AUTH_RULE_IDENTITY, gateway);
-	auth->add(auth, AUTH_RULE_IDENTITY_LOOSE, TRUE);
+	auth->add(auth, AUTH_RULE_IDENTITY_LOOSE, FALSE);
 	auth->add(auth, AUTH_RULE_AUTH_CLASS, AUTH_CLASS_PUBKEY);
 	peer_cfg->add_auth_cfg(peer_cfg, auth, FALSE);
 


### PR DESCRIPTION
We discovered that the Android client does not set the remote ID parameter (IDr) when doing IKE_AUTH requests. It was turned off, so we simply activated this by setting the `AUTH_RULE_IDENTITY_LOOSE` value to `FALSE`. We don't expect that change to have any negative side effects, since it only gives the remote server more information for the connection attempt. Therefore it should not break compatibility for the Android client and various strongSwan servers already installed.

Issue: https://wiki.strongswan.org/issues/1268