### PR TITLE
android: add CFLAG depending on abi

### DIFF
--- a/src/frontends/android/app/src/main/jni/Android.mk
+++ b/src/frontends/android/app/src/main/jni/Android.mk
@@ -39,7 +39,6 @@ strongswan_CFLAGS := \
 	-DHAVE_ALLOCA \
 	-DHAVE_CLOCK_GETTIME \
 	-DHAVE_DLADDR \
-	-DHAVE_PTHREAD_COND_TIMEDWAIT_MONOTONIC \
 	-DHAVE_PRCTL \
 	-DHAVE_LINUX_UDP_H \
 	-DHAVE_STRUCT_SADB_X_POLICY_SADB_X_POLICY_PRIORITY \
@@ -65,6 +64,11 @@ strongswan_CFLAGS := \
 ifneq ($(strongswan_USE_BYOD),)
 strongswan_CFLAGS += -DUSE_BYOD
 endif
+
+ifneq ($(TARGET_ARCH_ABI), arm64-v8a)
+strongswan_CFLAGS += -DHAVE_PTHREAD_COND_TIMEDWAIT_MONOTONIC
+endif
+
 
 strongswan_BUILD := \
 	openssl \

--- a/src/frontends/android/app/src/main/jni/Application.mk
+++ b/src/frontends/android/app/src/main/jni/Application.mk
@@ -1,3 +1,3 @@
 # select the ABI(s) to build for (see CPU-ARCH-ABIS.html in the NDK docs).
-APP_ABI := armeabi x86 mips
+APP_ABI := armeabi x86 mips arm64-v8a
 APP_PLATFORM := android-19


### PR DESCRIPTION
Because HAVE_PTHREAD_COND_TIMEDWAIT_MONOTONIC is not working for pthreads on
arm64-v8a, compilation fails. This commit makes adding the flag conditional.
All non arm64-v8a build still include the flag.