### PR TITLE
android: make loose identity configurable

### DIFF
--- a/src/frontends/android/app/src/main/java/org/strongswan/android/logic/CharonVpnService.java
+++ b/src/frontends/android/app/src/main/java/org/strongswan/android/logic/CharonVpnService.java
@@ -232,6 +232,7 @@ public class CharonVpnService extends VpnService implements Runnable
 							writer.setValue("connection.port", mCurrentProfile.getPort());
 							writer.setValue("connection.username", mCurrentProfile.getUsername());
 							writer.setValue("connection.password", mCurrentProfile.getPassword());
+							writer.setValue("connection.loose_identity", true);
 							initiate(writer.serialize());
 						}
 						else

--- a/src/frontends/android/app/src/main/jni/libandroidbridge/backend/android_service.c
+++ b/src/frontends/android/app/src/main/jni/libandroidbridge/backend/android_service.c
@@ -681,8 +681,10 @@ static job_requeue_t initiate(private_android_service_t *this)
 		}
 	};
 	char *type, *server;
-	int port;
+	int port, loose_identity;
 
+	loose_identity = this->settings->get_int(this->settings, 
+								   "connection.loose_identity", TRUE);
 	server = this->settings->get_str(this->settings, "connection.server", NULL);
 	port = this->settings->get_int(this->settings, "connection.port",
 								   IKEV2_UDP_PORT);
@@ -727,7 +729,7 @@ static job_requeue_t initiate(private_android_service_t *this)
 	auth = auth_cfg_create();
 	gateway = identification_create_from_string(server);
 	auth->add(auth, AUTH_RULE_IDENTITY, gateway);
-	auth->add(auth, AUTH_RULE_IDENTITY_LOOSE, TRUE);
+	auth->add(auth, AUTH_RULE_IDENTITY_LOOSE, loose_identity);
 	auth->add(auth, AUTH_RULE_AUTH_CLASS, AUTH_CLASS_PUBKEY);
 	peer_cfg->add_auth_cfg(peer_cfg, auth, FALSE);
 


### PR DESCRIPTION
To allow the android client wrapper to set the IDr when necessary this commit
adds a new settings key. This key may be used in the CharonVpnService.java and
is used in android_service.c.

* new key "connection.loose_identity"
* default value still TRUE (as before)

related to Issue #1268