### PR TITLE
fix: gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,6 @@ coverage/
 .metadata/
 .settings/
 test-driver
+strongswan.config
+strongswan.files
+strongswan.includes


### PR DESCRIPTION
Adds stuff that is created by automake/configure:
    strongswan.config
    strongswan.files
    strongswan.includes