### PR TITLE
feat: call scripts in IPSEC_CONFDIR as pwd

### DIFF
--- a/src/libstrongswan/utils/process.c
+++ b/src/libstrongswan/utils/process.c
@@ -158,6 +158,7 @@ process_t* process_start(char *const argv[], char *const envp[],
 		return NULL;
 	}
 
+	char* ipsec_confdir = getenv("IPSEC_CONFDIR");
 	this->pid = fork();
 	switch (this->pid)
 	{
@@ -194,6 +195,10 @@ process_t* process_start(char *const argv[], char *const envp[],
 			if (close_all)
 			{
 				closefrom(3);
+			}
+			if (ipsec_confdir)
+			{
+				chdir(ipsec_confdir);
 			}
 			if (execve(argv[0], argv, envp ?: empty) == -1)
 			{

--- a/src/libstrongswan/utils/process.c
+++ b/src/libstrongswan/utils/process.c
@@ -196,9 +196,10 @@ process_t* process_start(char *const argv[], char *const envp[],
 			{
 				closefrom(3);
 			}
-			if (ipsec_confdir)
+			if (ipsec_confdir && chdir(ipsec_confdir) == -1)
 			{
-				chdir(ipsec_confdir);
+				DBG1(DBG_LIB, "chdir to IPSEC_CONFDIR=%s failed: %s",
+						ipsec_confdir, strerror(errno));
 			}
 			if (execve(argv[0], argv, envp ?: empty) == -1)
 			{


### PR DESCRIPTION
Enables relative script links in strongswan.conf and ipsec.conf.
Currently only absolute paths are working, which is unhandy for deployment.

This change does a 'chdir' to IPSEC_CONFDIR after forking and before
executing a shell.