### PR TITLE
Include required headers for FreeBSD

### DIFF
--- a/src/libcharon/plugins/duplicheck/duplicheck.c
+++ b/src/libcharon/plugins/duplicheck/duplicheck.c
@@ -19,8 +19,10 @@
 #include <stdlib.h>
 #include <stddef.h>
 #include <stdio.h>
+#include <string.h>
 #include <errno.h>
 #include <arpa/inet.h>
+#include <netinet/in.h>
 
 #include "duplicheck_msg.h"
 


### PR DESCRIPTION
duplicheck.c code fails to compile in FreeBSD due to lack of a include file. Also there are two warnings for undeclared functions.

```
duplicheck.c: In function 'make_connection':
duplicheck.c:34: error: field 'in' has incomplete type
duplicheck.c:42: error: 'INADDR_LOOPBACK' undeclared (first use in this function)
duplicheck.c:42: error: (Each undeclared identifier is reported only once
duplicheck.c:42: error: for each function it appears in.)
duplicheck.c:49: warning: incompatible implicit declaration of built-in function 'strcpy'
duplicheck.c:51: warning: incompatible implicit declaration of built-in function 'strlen'
```