### PR TITLE
appdata: add AppStream metadata

### DIFF
--- a/src/frontends/gnome/.gitignore
+++ b/src/frontends/gnome/.gitignore
@@ -9,3 +9,4 @@ nm-strongswan-service.name
 stamp-h1
 config.guess.cdbs-orig
 config.sub.cdbs-orig
+NetworkManager-strongswan.appdata.xml

--- a/src/frontends/gnome/Makefile.am
+++ b/src/frontends/gnome/Makefile.am
@@ -10,6 +10,11 @@ nmvpnservice_DATA = nm-strongswan-service.name
 
 @INTLTOOL_DESKTOP_RULE@
 
+appdatadir = $(datadir)/appdata
+appdata_DATA = $(appdata_in_files:.xml.in=.xml)
+appdata_in_files = NetworkManager-strongswan.appdata.xml.in
+@INTLTOOL_XML_RULE@
+
 nm-strongswan-service.name: $(srcdir)/nm-strongswan-service.name.in
 	$(AM_V_GEN) \
 	sed -e 's|[@]LIBEXECDIR[@]|$(libexecdir)|' \
@@ -17,11 +22,13 @@ nm-strongswan-service.name: $(srcdir)/nm-strongswan-service.name.in
 
 EXTRA_DIST = nm-strongswan-service.name.in \
     $(dbusservice_DATA)  \
+    $(appdata_in_files)  \
+    $(appdata_DATA)      \
     intltool-extract.in  \
     intltool-merge.in    \
     intltool-update.in
 
-CLEANFILES = $(nmvpnservice_DATA) *~
+CLEANFILES = $(nmvpnservice_DATA) $(appdata_DATA) *~
 DISTCLEANFILES = intltool-extract intltool-merge intltool-update
 
 ACLOCAL_AMFLAGS = -I m4

--- a/src/frontends/gnome/NetworkManager-strongswan.appdata.xml.in
+++ b/src/frontends/gnome/NetworkManager-strongswan.appdata.xml.in
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Copyright Lubomir Rintel 2016 -->
+<component type="addon">
+  <id>network-manager-strongswan</id>
+  <project_license>GPL-2.0+</project_license>
+  <metadata_license>CC0-1.0</metadata_license>
+  <extends>nm-connection-editor.desktop</extends>
+  <extends>gnome-control-center.desktop</extends>
+  <_name>strongSwan VPN client</_name>
+  <_summary>strongSwan based client for IPsec virtual private networks</_summary>
+
+  <keywords>
+    <keyword>network</keyword>
+    <keyword>manager</keyword>
+    <keyword>NetworkManager</keyword>
+    <keyword>connection</keyword>
+    <keyword>VPN</keyword>
+    <keyword>strongSwan</keyword>
+    <keyword>IPsec</keyword>
+    <keyword>IKEv2</keyword>
+  </keywords>
+
+  <description>
+    <_p>Support for configuring IPsec based virtual private network connections.</_p>
+    <_p>Compatible with IKEv2 key exchange and multiple authentication mechanisms.</_p>
+  </description>
+
+  <screenshots>
+    <screenshot type="default">
+      <image width="800" height="682">https://people.freedesktop.org/~lkundrak/strongswan.png</image>
+    </screenshot>
+  </screenshots>
+
+  <url type="homepage">https://wiki.strongswan.org/projects/strongswan/wiki/NetworkManager</url>
+  <url type="bugtracker">https://wiki.strongswan.org/projects/strongswan/wiki/FlawReporting</url>
+  <url type="help">https://www.strongswan.org/support.html</url>
+  <update_contact>info@strongswan.org</update_contact>
+  <translation type="gettext">NetworkManager-strongswan</translation>
+  <_developer_name>strongSwan Developers</_developer_name>
+</component>

--- a/src/frontends/gnome/po/POTFILES.in
+++ b/src/frontends/gnome/po/POTFILES.in
@@ -3,3 +3,4 @@
 properties/nm-strongswan.c
 [type: gettext/glade]properties/nm-strongswan-dialog.ui
 auth-dialog/main.c
+NetworkManager-strongswan.appdata.xml.in


### PR DESCRIPTION
This will ensure the strongSwan NetworkManager plugin will be easily
installable from the app stores such as GNOME Software.