### PR TITLE
gnome: don't do <deny send_interface="..." /> in dbus service file

### DIFF
--- a/src/frontends/gnome/nm-strongswan-service.conf
+++ b/src/frontends/gnome/nm-strongswan-service.conf
@@ -10,7 +10,6 @@
 	<policy context="default">
 		<deny own="org.freedesktop.NetworkManager.strongswan"/>
 		<deny send_destination="org.freedesktop.NetworkManager.strongswan"/>
-		<deny send_interface="org.freedesktop.NetworkManager.strongswan"/>
 	</policy>
 </busconfig>
 


### PR DESCRIPTION
It does more than intended; apart from denying messages to that
particular interface it also denies all messages non-qualified with an
interface globally. This blocks messages completely unrelated to
wpa_supplicant, such as NetworkManager communication with the VPN
plugins.

From the dbus-daemon manual:

  Be careful with send_interface/receive_interface, because the
  interface field in messages is optional. In particular, do NOT
  specify <deny send_interface="org.foo.Bar"/>! This will cause
  no-interface messages to be blocked for all services, which is
  almost certainly not what you intended. Always use rules of the form:

  <deny send_interface="org.foo.Bar" send_destination="org.foo.Service"/>

We can just safely remove those rules, since we're sufficiently
protected by the send_destination matches and method calls are
disallowed by default anyway.