### PR TITLE
Add CAP_NET_RAW to capabilities keep list

### DIFF
--- a/src/libcharon/plugins/connmark/connmark_plugin.c
+++ b/src/libcharon/plugins/connmark/connmark_plugin.c
@@ -90,6 +90,12 @@ plugin_t *connmark_plugin_create()
 		return NULL;
 	}
 
+	if (!lib->caps->keep(lib->caps, CAP_NET_RAW))
+	{
+		DBG1(DBG_NET, "connmark plugin requires CAP_NET_RAW capability");
+		return NULL;
+	}
+
 	INIT(this,
 		.public = {
 			.plugin = {


### PR DESCRIPTION
Fix for "Permission denied (you must be root)" error when calling iptc_init. This occurs when built with "--with-capabilities=libcap".

Issue could be created on:

- Debian testing (kernel 3.16.0, strongswan 5.5.0)
- Debian testing (kernel 4.7.0, strongswan 5.5.0)
- Ubuntu 16.04 (kernel 4.4.0, strongswan 5.3.5)

The options charon.user and charon.group are both not defined, and charon is running as root.

Having 'mark=%unique' in a connection definition results in the following:

> charon: 10[CFG] initializing iptables failed: Permission denied (you must be root)