### PR TITLE
vici: Check for strongswan closing connection in Python

### DIFF
--- a/src/libcharon/plugins/vici/python/vici/protocol.py
+++ b/src/libcharon/plugins/vici/python/vici/protocol.py
@@ -33,7 +33,10 @@ class Transport(object):
         """Ensure to read count bytes from the socket"""
         data = b""
         while len(data) < count:
-            data += self.socket.recv(count - len(data))
+            buf = self.socket.recv(count - len(data))
+            if not buf:
+                raise socket.error('Connection closed')
+            data += buf
         return data
 
 


### PR DESCRIPTION
The Python vici library does not check if the socket is closed.
If strongswan closes the connection, recv_all() spins forever.