### PR TITLE
NetworkManger-strongswan: user can custom remote identery when use CA certificate

### DIFF
--- a/src/charon-nm/nm/nm_service.c
+++ b/src/charon-nm/nm/nm_service.c
@@ -406,7 +406,7 @@ static gboolean connect_(NMVPNPlugin *plugin, NMConnection *connection,
 		 * certificate lookup and requires the configured IP/DNS to be
 		 * included in the gateway certificate. */
 		str = nm_setting_vpn_get_data_item(vpn, "remote-identity");
-		char* remote_id = str?str:(char*)address;
+		char* remote_id = str?(char*)str:(char*)address;
 		gateway = identification_create_from_string(remote_id);
 		DBG1(DBG_CFG, "using CA certificate, gateway identity '%Y'", gateway);
 		loose_gateway_id = TRUE;

--- a/src/charon-nm/nm/nm_service.c
+++ b/src/charon-nm/nm/nm_service.c
@@ -405,7 +405,9 @@ static gboolean connect_(NMVPNPlugin *plugin, NMConnection *connection,
 		 * of the gateway as its identity. This identity will be used for
 		 * certificate lookup and requires the configured IP/DNS to be
 		 * included in the gateway certificate. */
-		gateway = identification_create_from_string((char*)address);
+		str = nm_setting_vpn_get_data_item(vpn, "remote-identity");
+		char* remote_id = str?str:(char*)address;
+		gateway = identification_create_from_string(remote_id);
 		DBG1(DBG_CFG, "using CA certificate, gateway identity '%Y'", gateway);
 		loose_gateway_id = TRUE;
 	}

--- a/src/frontends/gnome/properties/nm-strongswan-dialog.ui
+++ b/src/frontends/gnome/properties/nm-strongswan-dialog.ui
@@ -351,6 +351,59 @@
           </packing>
         </child>
         <child>
+          <object class="GtkAlignment" id="remote-identity-alignement">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="left_padding">12</property>
+            <child>
+              <object class="GtkTable" id="remote-identity-table">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="n_rows">1</property>
+                <property name="n_columns">2</property>
+                <property name="column_spacing">6</property>
+                <property name="row_spacing">6</property>
+                <child>
+                  <object class="GtkLabel" id="remote-identity-label">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="xalign">0</property>
+                    <property name="label" translatable="yes">_Remote Identity:</property>
+                    <property name="use_underline">True</property>
+                    <property name="mnemonic_widget">remote-identity-entry</property>
+                  </object>
+                  <packing>
+                    <property name="x_options">GTK_FILL</property>
+                    <property name="y_options"/>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkEntry" id="remote-identity-entry">
+                    <property name="visible">True</property>
+                    <property name="can_focus">True</property>
+                    <property name="has_tooltip">True</property>
+                    <property name="tooltip_text" translatable="yes">Defaults to Gateway Address, Custom values are explicitly sent to the server and enforced during authentication.</property>
+                    <property name="primary_icon_activatable">False</property>
+                    <property name="secondary_icon_activatable">False</property>
+                    <property name="primary_icon_sensitive">True</property>
+                    <property name="secondary_icon_sensitive">True</property>
+                  </object>
+                  <packing>
+                    <property name="left_attach">1</property>
+                    <property name="right_attach">2</property>
+                    <property name="y_options"/>
+                  </packing>
+                </child>
+              </object>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">True</property>
+            <property name="fill">True</property>
+            <property name="position">1</property>
+          </packing>
+        </child>
+        <child>
           <object class="GtkAlignment" id="options-alignement">
             <property name="visible">True</property>
             <property name="can_focus">False</property>
@@ -416,7 +469,7 @@
           <packing>
             <property name="expand">True</property>
             <property name="fill">True</property>
-            <property name="position">1</property>
+            <property name="position">2</property>
           </packing>
         </child>
       </object>

--- a/src/frontends/gnome/properties/nm-strongswan.c
+++ b/src/frontends/gnome/properties/nm-strongswan.c
@@ -371,7 +371,13 @@ init_plugin_ui (StrongswanPluginUiWidget *self, NMConnection *connection, GError
 		gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(widget), TRUE);
 	}
 	g_signal_connect (G_OBJECT (widget), "toggled", G_CALLBACK (settings_changed_cb), self);
-
+	
+	widget = GTK_WIDGET (gtk_builder_get_object (priv->builder, "remote-identity-entry"));
+	value = nm_setting_vpn_get_data_item (settings, "remote-identity");
+	if (value)
+		gtk_entry_set_text (GTK_ENTRY (widget), value);
+	g_signal_connect (G_OBJECT (widget), "changed", G_CALLBACK (settings_changed_cb), self);
+	
 	return TRUE;
 }
 
@@ -506,7 +512,13 @@ update_connection (NMVpnEditor *iface,
 	widget = GTK_WIDGET (gtk_builder_get_object (priv->builder, "ipcomp-check"));
 	active = gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(widget));
 	nm_setting_vpn_add_data_item (settings, "ipcomp", active ? "yes" : "no");
-
+	
+	widget = GTK_WIDGET (gtk_builder_get_object (priv->builder, "remote-identity-entry"));
+	str = (char *) gtk_entry_get_text (GTK_ENTRY (widget));
+	if (str && strlen (str)) {
+		nm_setting_vpn_add_data_item (settings, "remote-identity", str);
+	}
+	
 	nm_connection_add_setting (connection, NM_SETTING (settings));
 	return TRUE;
 }


### PR DESCRIPTION
Android VPN Client can custom server identity, but linux users cannot do it.

Some iKEv2 VPN Service need this, if user not custom server identity,  error occurred.

"constraint check failed: identity * required"
