### PR TITLE
child-sa: Do not install mark on inbound kernel SA

### DIFF
--- a/src/libcharon/sa/child_sa.c
+++ b/src/libcharon/sa/child_sa.c
@@ -479,7 +479,7 @@ static status_t update_usebytes(private_child_sa_t *this, bool inbound)
 				.dst = this->my_addr,
 				.spi = this->my_spi,
 				.proto = proto_ike2ip(this->protocol),
-				.mark = this->mark_in,
+				.mark = {},
 			};
 			kernel_ipsec_query_sa_t query = {};
 
@@ -801,7 +801,7 @@ METHOD(child_sa_t, install, status_t,
 		.dst = dst,
 		.spi = spi,
 		.proto = proto_ike2ip(this->protocol),
-		.mark = inbound ? this->mark_in : this->mark_out,
+		.mark = inbound ? (mark_t){} : this->mark_out,
 	};
 	sa = (kernel_ipsec_add_sa_t){
 		.reqid = this->reqid,
@@ -1148,7 +1148,7 @@ METHOD(child_sa_t, update, status_t,
 				.dst = this->my_addr,
 				.spi = this->my_spi,
 				.proto = proto_ike2ip(this->protocol),
-				.mark = this->mark_in,
+				.mark = {},
 			};
 			kernel_ipsec_update_sa_t sa = {
 				.cpi = this->ipcomp != IPCOMP_NONE ? this->my_cpi : 0,
@@ -1323,7 +1323,7 @@ METHOD(child_sa_t, destroy, void,
 			.dst = this->my_addr,
 			.spi = this->my_spi,
 			.proto = proto_ike2ip(this->protocol),
-			.mark = this->mark_in,
+			.mark = {},
 		};
 		kernel_ipsec_del_sa_t sa = {
 			.cpi = this->my_cpi,


### PR DESCRIPTION
The SA ID (src, dst, proto, spi, encaps) is unique on ingress.

As such, explicit inbound marking is not needed to match an SA.

On the other hand, requiring inbound SAs to use marks forces the
installation of a mechanism for marking traffic (e.g. iptables) based
on some criteria.

Defining the criteria becomes complicated, for example when required to
support multiple SAs from the same src, especially when traffic is UDP
encapsulated.

This commit removes the assignment of the child_sa mark_in to the inbound SA.

Policies can be arbitrated by existing means - e.g, via netfilter policy
matching or using VTI interfaces - without the need to classify the flows prior
to state matching.

Since the reqid allocator regards the mark value, there is no risk of matching
the wrong policy.

And as explicit marking was required for route-based VPN to work before this
change, it should not cause regressions in existing setups.