### PR TITLE
Add option to force remote host as remote ts

### DIFF
--- a/conf/options/charon.opt
+++ b/conf/options/charon.opt
@@ -106,6 +106,13 @@ charon.flush_auth_cfg = no
 charon.follow_redirects = yes
 	Whether to follow IKEv2 redirects (RFC 5685).
 
+charon.force_host_ts = no
+	Force remote traffic selector to be the remote host when initiating a
+	CHILD_SA (IKEv2 only).
+
+	This is useful for transport mode connections with implementations that do
+	not support subnet range negotiation (eg. Windows).
+
 charon.fragment_size = 1280
 	Maximum size (complete IP datagram size in bytes) of a sent IKE fragment
 	when using proprietary IKEv1 or standardized IKEv2 fragmentation, defaults


### PR DESCRIPTION
This option forces the remote traffic selectors to be converted from subnet
ranges to the remote host when initiating a connection. It is useful for
making connections to the Windows IKEv2 implementation, which does not
support subnet ranges as traffic selectors in transport mode.