### PR TITLE
forecast: mark correct port in UDP NAT-T

### DIFF
--- a/src/libcharon/plugins/forecast/forecast_listener.c
+++ b/src/libcharon/plugins/forecast/forecast_listener.c
@@ -212,7 +212,7 @@ static bool manage_pre_esp_in_udp(struct iptc_handle *ipth,
 	ADD_STRUCT(pos, struct xt_udp,
 		.spts = {
 			entry->rhost->get_port(entry->rhost),
-			entry->rhost->get_port(entry->lhost)
+			entry->rhost->get_port(entry->rhost)
 		},
 		.dpts = {
 			entry->lhost->get_port(entry->lhost),


### PR DESCRIPTION
The current code sets up a mark rule with rport:lport as the source port range, which breaks routing (unless rport < lport).