### PR TITLE
Add Tea-CI

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1,0 +1,12 @@
+build:
+  image: teaci/msys$$arch
+  pull: true
+  shell: mingw$$arch
+  commands:
+    - TEST=win$$arch MONOLITHIC=yes ./scripts/test.sh deps
+    - TEST=win$$arch MONOLITHIC=yes ./scripts/test.sh pydeps
+    - TEST=win$$arch MONOLITHIC=yes ./scripts/test.sh
+matrix:
+  arch:
+    - 64
+    - 32


### PR DESCRIPTION
Add Tea-CI to build strongswan in mingw shells (32 and 64 bit)

Could also add windows command line tests in the future

example build: https://tea-ci.org/stephengroat/strongswan