### PR TITLE
Add option to install optionally-enforced polices

### DIFF
--- a/conf/plugins/kernel-netlink.opt
+++ b/conf/plugins/kernel-netlink.opt
@@ -38,6 +38,9 @@ charon.plugins.kernel-netlink.parallel_xfrm = no
 charon.plugins.kernel-netlink.policy_update = no
 	Whether to always use XFRM_MSG_UPDPOLICY to install policies.
 
+charon.plugins.kernel-netlink.policy_optional = no
+	Whether the policy level is 'use' instead of 'required'
+
 charon.plugins.kernel-netlink.port_bypass = no
 	Whether to use port or socket based IKE XFRM bypass policies.
 

--- a/src/libcharon/plugins/kernel_netlink/kernel_netlink_ipsec.c
+++ b/src/libcharon/plugins/kernel_netlink/kernel_netlink_ipsec.c
@@ -333,6 +333,11 @@ struct private_kernel_netlink_ipsec_t {
 	bool policy_update;
 
 	/**
+	 * Whether the policy level is 'use' instead of 'required'
+	 */
+	bool policy_optional;
+
+	/**
 	 * Installed port based IKE bypass policies, as bypass_t
 	 */
 	array_t *bypass;
@@ -2377,8 +2382,9 @@ static status_t add_policy_internal(private_kernel_netlink_ipsec_t *this,
 			tmpl->id.proto = protos[i].proto;
 			tmpl->aalgos = tmpl->ealgos = tmpl->calgos = ~0;
 			tmpl->mode = mode2kernel(proto_mode);
-			tmpl->optional = protos[i].proto == IPPROTO_COMP &&
-							 policy->direction != POLICY_OUT;
+			tmpl->optional = this->policy_optional ||
+							 (protos[i].proto == IPPROTO_COMP &&
+							 policy->direction != POLICY_OUT);
 			tmpl->family = ipsec->src->get_family(ipsec->src);
 
 			if (proto_mode == MODE_TUNNEL || proto_mode == MODE_BEET)
@@ -3204,6 +3210,8 @@ kernel_netlink_ipsec_t *kernel_netlink_ipsec_create()
 							  "kernel_netlink_get_priority_custom"),
 		.policy_update = lib->settings->get_bool(lib->settings,
 					"%s.plugins.kernel-netlink.policy_update", FALSE, lib->ns),
+		.policy_optional = lib->settings->get_bool(lib->settings,
+					"%s.plugins.kernel-netlink.policy_optional", FALSE, lib->ns),
 		.install_routes = lib->settings->get_bool(lib->settings,
 							"%s.install_routes", TRUE, lib->ns),
 		.proto_port_transport = lib->settings->get_bool(lib->settings,


### PR DESCRIPTION
Add an option to kernel-netlink to install policies with the level 'use'
instead of 'required'.

This is useful for introducing IPsec to an existing cluster.