### PR TITLE
Fix type error exception in Python3

### DIFF
--- a/src/libcharon/plugins/vici/python/vici/protocol.py
+++ b/src/libcharon/plugins/vici/python/vici/protocol.py
@@ -63,7 +63,7 @@ class Packet(object):
     @classmethod
     def _named_request(cls, request_type, request, message=None):
         requestdata = request.encode("UTF-8")
-        payload = struct.pack("!BB", request_type, len(request)) + request
+        payload = struct.pack("!BB", request_type, len(request)) + requestdata
         if message is not None:
             return payload + message
         else:

--- a/src/libcharon/plugins/vici/python/vici/protocol.py
+++ b/src/libcharon/plugins/vici/python/vici/protocol.py
@@ -62,8 +62,8 @@ class Packet(object):
 
     @classmethod
     def _named_request(cls, request_type, request, message=None):
-        requestdata = request.encode("UTF-8")
-        payload = struct.pack("!BB", request_type, len(request)) + requestdata
+        request = request.encode("UTF-8")
+        payload = struct.pack("!BB", request_type, len(request)) + request
         if message is not None:
             return payload + message
         else:


### PR DESCRIPTION
Line 66 yields "TypeError: can't concat bytes to str" using Python 3.4. Changing "request" to "requestdata" which is already prepared in line 65 fixes this. After the change, the code is still working in Python 2.7