### PR TITLE
Enable AES_GCM_ICV16, PRF_HMAC_SHA2_512, ECP_256_BIT in default proposal ESP.

### DIFF
--- a/src/libcharon/config/proposal.c
+++ b/src/libcharon/config/proposal.c
@@ -752,9 +752,6 @@ static bool proposal_add_supported_ike(private_proposal_t *this, bool aead)
 			switch (encryption)
 			{
 				case ENCR_AES_GCM_ICV16:
-					add_algorithm(this, ENCRYPTION_ALGORITHM, encryption, 128);
-					add_algorithm(this, ENCRYPTION_ALGORITHM, encryption, 256);
-					break;
 				case ENCR_AES_CCM_ICV16:
 				case ENCR_CAMELLIA_CCM_ICV16:
 					/* we assume that we support all AES/Camellia sizes */
@@ -890,8 +887,6 @@ static bool proposal_add_supported_ike(private_proposal_t *this, bool aead)
 			case PRF_HMAC_SHA2_256:
 			case PRF_HMAC_SHA2_384:
 			case PRF_HMAC_SHA2_512:
-				add_algorithm(this, PSEUDO_RANDOM_FUNCTION, prf, 0);
-				break;
 			case PRF_AES128_XCBC:
 			case PRF_AES128_CMAC:
 				add_algorithm(this, PSEUDO_RANDOM_FUNCTION, prf, 0);
@@ -925,8 +920,6 @@ static bool proposal_add_supported_ike(private_proposal_t *this, bool aead)
 		switch (group)
 		{
 			case ECP_256_BIT:
-				add_algorithm(this, DIFFIE_HELLMAN_GROUP, group, 0);
-				break;
 			case ECP_384_BIT:
 			case ECP_521_BIT:
 			case ECP_256_BP:


### PR DESCRIPTION
I'm one of the developers for [Algo VPN](https://github.com/trailofbits/algo).

> Algo VPN is a set of Ansible scripts that simplify the setup of a personal IPSEC VPN. It uses the most secure defaults available, works with common cloud providers, and does not require client software on most devices. 

We recently ran into the issue (https://github.com/trailofbits/algo/issues/263) that charon-nm does not permit custom cipher proposals. Unfortunately the default proposals for libcharon do not enable ciphers that meet our requirements.

Due to this it makes it impossible to use the NetworkManager strongswan plugin to establish connections to Algo deployments resulting in a poor user experience on Linux desktop clients. While I would like to implement custom proposal selection in charon-nm and the network manager strongswan plugin in the future; this initial PR focuses on a minimally invasive approach to solving the issue of supporting stronger proposal defaults.

