### PR TITLE
charon-nm IKE/ESP proposal support

### DIFF
--- a/src/charon-nm/nm/nm_service.c
+++ b/src/charon-nm/nm/nm_service.c
@@ -558,8 +558,6 @@ static gboolean connect_(NMVPNPlugin *plugin, NMConnection *connection,
 				g_set_error(err, NM_VPN_PLUGIN_ERROR,
 							NM_VPN_PLUGIN_ERROR_LAUNCH_FAILED,
 							"Unrecognized IKE proposal.");
-				DESTROY_IF(gateway);
-				DESTROY_IF(user);
 				DESTROY_IF(ike_cfg);
 				return FALSE;
 			}
@@ -607,10 +605,6 @@ static gboolean connect_(NMVPNPlugin *plugin, NMConnection *connection,
 				g_set_error(err, NM_VPN_PLUGIN_ERROR,
 							NM_VPN_PLUGIN_ERROR_LAUNCH_FAILED,
 							"Unrecognized ESP proposal.");
-				DESTROY_IF(gateway);
-				DESTROY_IF(user);
-				DESTROY_IF(ike_cfg);
-				DESTROY_IF(auth);
 				DESTROY_IF(peer_cfg);
 				DESTROY_IF(child_cfg);
 				return FALSE;

--- a/src/charon-nm/nm/nm_service.c
+++ b/src/charon-nm/nm/nm_service.c
@@ -554,9 +554,13 @@ static gboolean connect_(NMVPNPlugin *plugin, NMConnection *connection,
 			prop = proposal_create_from_string(PROTO_IKE, str);
 			if (!prop)
 			{
+
 				g_set_error(err, NM_VPN_PLUGIN_ERROR,
 							NM_VPN_PLUGIN_ERROR_LAUNCH_FAILED,
 							"Unrecognized IKE proposal.");
+				DESTROY_IF(gateway);
+				DESTROY_IF(user);
+				DESTROY_IF(ike_cfg);
 				return FALSE;
 			}
 			ike_cfg->add_proposal(ike_cfg, prop);
@@ -603,6 +607,12 @@ static gboolean connect_(NMVPNPlugin *plugin, NMConnection *connection,
 				g_set_error(err, NM_VPN_PLUGIN_ERROR,
 							NM_VPN_PLUGIN_ERROR_LAUNCH_FAILED,
 							"Unrecognized ESP proposal.");
+				DESTROY_IF(gateway);
+				DESTROY_IF(user);
+				DESTROY_IF(ike_cfg);
+				DESTROY_IF(auth);
+				DESTROY_IF(peer_cfg);
+				DESTROY_IF(child_cfg);
 				return FALSE;
 			}
 			child_cfg->add_proposal(child_cfg, prop);


### PR DESCRIPTION
Adds support for IKE/ESP proposals passed via vpn data.

vpn data parameters;
* `proposal` 
  * [ yes / no ]
* `esp` / `ike`
  *  A `;` delimited list of proposals, supporting the `!` suffix

Similar to `ipsec.conf` a `!` is accepted as a suffix to restrict proposals.

_Note: A `;` is used instead of a `,` as a delimiter due to nmcli's inability to pass `,` in values._

 

