### PR TITLE
af_alg: fix crypt() definition conflict

### DIFF
--- a/src/libstrongswan/plugins/af_alg/af_alg_ops.c
+++ b/src/libstrongswan/plugins/af_alg/af_alg_ops.c
@@ -107,7 +107,7 @@ METHOD(af_alg_ops_t, hash, bool,
 	return TRUE;
 }
 
-METHOD(af_alg_ops_t, crypt, bool,
+METHOD(af_alg_ops_t, crypt_, bool,
 	private_af_alg_ops_t *this, uint32_t type, chunk_t iv, chunk_t data,
 	char *out)
 {
@@ -224,7 +224,7 @@ af_alg_ops_t *af_alg_ops_create(char *type, char *alg)
 		.public = {
 			.hash = _hash,
 			.reset = _reset,
-			.crypt = _crypt,
+			.crypt = _crypt_,
 			.set_key = _set_key,
 			.destroy = _destroy,
 		},


### PR DESCRIPTION
Rename the crypt() method to avoid conflict with POSIX crypt(). Fixes the
following build failure with musl libc:

In file included from ../../../../src/libstrongswan/utils/utils.h:53:0,
                 from ../../../../src/libstrongswan/library.h:101,
                 from af_alg_ops.h:24,
                 from af_alg_ops.c:16:
af_alg_ops.c:110:22: error: conflicting types for 'crypt'
 METHOD(af_alg_ops_t, crypt, bool,
                      ^
../../../../src/libstrongswan/utils/utils/object.h:99:13: note: in definition of macro 'METHOD'
  static ret name(union {iface *_public; this;} \
             ^
In file included from af_alg_ops.c:18:0:
.../host/usr/x86_64-buildroot-linux-musl/sysroot/usr/include/unistd.h:144:7: note: previous declaration of 'crypt' was here
 char *crypt(const char *, const char *);
       ^