### PR TITLE
Store configure arguments in libstrongswan and extend swanctl to print it out

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -39,9 +39,8 @@ PKG_PROG_PKG_CONFIG
 
 # set configure arguments
 AC_CONFIGURE_ARGS=`echo "${ac_configure_args}" | sed "s/ //"`
-# | sed "s/'/\\\'/g"`
-AC_DEFINE_UNQUOTED(AC_CONFIGURE_ARGS, "$AC_CONFIGURE_ARGS", "")
 
+AC_DEFINE_UNQUOTED(AC_CONFIGURE_ARGS, "$AC_CONFIGURE_ARGS", "")
 
 m4_include(m4/macros/split-package-version.m4)
 SPLIT_PACKAGE_VERSION

--- a/configure.ac
+++ b/configure.ac
@@ -37,6 +37,12 @@ AC_CONFIG_HEADERS([config.h])
 AC_DEFINE([CONFIG_H_INCLUDED], [], [defined if config.h included])
 PKG_PROG_PKG_CONFIG
 
+# set configure arguments
+AC_CONFIGURE_ARGS=`echo "${ac_configure_args}" | sed "s/ //"`
+# | sed "s/'/\\\'/g"`
+AC_DEFINE_UNQUOTED(AC_CONFIGURE_ARGS, "$AC_CONFIGURE_ARGS", "")
+
+
 m4_include(m4/macros/split-package-version.m4)
 SPLIT_PACKAGE_VERSION
 

--- a/src/libstrongswan/library.c
+++ b/src/libstrongswan/library.c
@@ -66,6 +66,11 @@ struct private_library_t {
 	 * Number of times we have been initialized
 	 */
 	refcount_t ref;
+
+	/**
+	 * The configuration variables with which the library was built
+	 */
+	char *configuration_arguments;
 };
 
 #define MAX_NAMESPACES 5
@@ -220,6 +225,12 @@ METHOD(library_t, set, bool,
 	return this->objects->remove(this->objects, name) != NULL;
 }
 
+METHOD(library_t, get_configure_arguments, char*,
+	private_library_t *this)
+{
+	return this->configuration_arguments;
+}
+
 /**
  * Hashtable hash function
  */
@@ -305,7 +316,9 @@ bool library_init(char *settings, const char *namespace)
 			.set = _set,
 			.ns = strdup(namespace ?: "libstrongswan"),
 			.conf = strdupnull(settings ?: (getenv("STRONGSWAN_CONF") ?: STRONGSWAN_CONF)),
+			.get_configure_arguments = _get_configure_arguments,
 		},
+		.configuration_arguments = AC_CONFIGURE_ARGS,
 		.ref = 1,
 	);
 	lib = &this->public;

--- a/src/libstrongswan/library.h
+++ b/src/libstrongswan/library.h
@@ -155,6 +155,14 @@ struct library_t {
 	char *conf;
 
 	/**
+	 * Get the configuration arguments at build time.
+	 *
+	 * @return	string
+	 */
+
+	char *(*get_configure_arguments)(library_t *this);
+
+	/**
 	 * Printf hook registering facility
 	 */
 	printf_hook_t *printf_hook;

--- a/src/swanctl/Makefile.am
+++ b/src/swanctl/Makefile.am
@@ -23,6 +23,7 @@ swanctl_SOURCES = \
 	commands/version.c \
 	commands/stats.c \
 	commands/reload_settings.c \
+	commands/get_config_args.c \
 	swanctl.c swanctl.h
 
 swanctl_LDADD = \

--- a/src/swanctl/command.h
+++ b/src/swanctl/command.h
@@ -27,17 +27,17 @@
 /**
  * Maximum number of commands (+1).
  */
-#define MAX_COMMANDS 24
+#define MAX_COMMANDS 25
 
 /**
  * Maximum number of options in a command (+3)
  */
-#define MAX_OPTIONS 34
+#define MAX_OPTIONS 37
 
 /**
  * Maximum number of usage summary lines (+1)
  */
-#define MAX_LINES 10
+#define MAX_LINES 11
 
 typedef struct command_t command_t;
 typedef struct command_option_t command_option_t;

--- a/src/swanctl/commands/get_config_args.c
+++ b/src/swanctl/commands/get_config_args.c
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) 2017 Noel Kuntze
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+ #include "command.h"
+
+#include <errno.h>
+#include <unistd.h>
+
+ static int get_configure_arguments(vici_conn_t *conn)
+{
+
+	printf("configure arguments: %s\n", lib->get_configure_arguments(lib));
+
+	return 0;
+}
+
+/**
+ * Register the command.
+ */
+static void __attribute__ ((constructor))reg()
+{
+	command_register((command_t) {
+		get_configure_arguments, 'o', "get-config-args", "prints the ./configure arguments",
+		{"[--raw|--pretty]"},
+		{
+			{"help",		'h', 0, "show usage information"},
+			{"raw",			'r', 0, "dump raw response message. Doesn't do anything here."},
+			{"pretty",		'P', 0, "dump raw response message in pretty print. Doesn't do anything here."},
+		}
+	});
+}
+


### PR DESCRIPTION
This PR implements the following changes:

- Declare the configuration arguments as a preprocessor definition in config.h
- Store the arguments in an attribute to the private interface of libstrongswan
- Declare a method to get the configure arguments from libstrongswan
- Extend swanctl to print out the configure arguments using "--get-config-args" (-o)