### PR TITLE
child-sa: allow requesting different unique marks for in/out

### DIFF
--- a/conf/format-options.py
+++ b/conf/format-options.py
@@ -217,7 +217,7 @@ class TagReplacer:
 		return re.compile(r'''
 			(^|\s|(?P<brack>[(\[])) # prefix with optional opening bracket
 			(?P<tag>''' + tag + r''') # start tag
-			(?P<text>\w|\S.*?\S) # text
+			(?P<text>\S|\S.*?\S) # text
 			''' + tag + r''' # end tag
 			(?P<punct>([.,!:)\]]|\(\d+\))*) # punctuation
 			(?=$|\s) # suffix (don't consume it so that subsequent tags can match)

--- a/man/ipsec.conf.5.in
+++ b/man/ipsec.conf.5.in
@@ -1037,7 +1037,10 @@ mask of
 .B 0xffffffff
 is assumed. The special value
 .B %unique
-assigns a unique value to each newly created IPsec SA.
+assigns a unique value to each newly created IPsec SA. To additionally
+make the mark unique for each IPsec SA direction (in/out) the special value
+.B %unique-dir
+may be used.
 .TP
 .BR mark_in " = <value>[/<mask>]"
 sets an XFRM mark in the inbound IPsec SA and

--- a/src/libcharon/sa/child_sa.c
+++ b/src/libcharon/sa/child_sa.c
@@ -1719,7 +1719,7 @@ child_sa_t * child_sa_create(host_t *me, host_t* other,
 {
 	private_child_sa_t *this;
 	static refcount_t unique_id = 0, unique_mark = 0;
-	refcount_t mark;
+	refcount_t mark = 0;
 
 	INIT(this,
 		.public = {
@@ -1792,16 +1792,33 @@ child_sa_t * child_sa_create(host_t *me, host_t* other,
 	{
 		this->mark_out.value = mark_out;
 	}
-	if (this->mark_in.value == MARK_UNIQUE ||
-		this->mark_out.value == MARK_UNIQUE)
+
+	if (MARK_IS_UNIQUE(this->mark_in.value) ||
+		MARK_IS_UNIQUE(this->mark_out.value))
 	{
-		mark = ref_get(&unique_mark);
-		if (this->mark_in.value == MARK_UNIQUE)
+		bool strict;
+
+		strict = this->mark_in.value == MARK_UNIQUE_STRICT ||
+				 this->mark_out.value == MARK_UNIQUE_STRICT;
+
+		if (!strict)
 		{
+			mark = ref_get(&unique_mark);
+		}
+		if (MARK_IS_UNIQUE(this->mark_in.value))
+		{
+			if (strict)
+			{
+				mark = ref_get(&unique_mark);
+			}
 			this->mark_in.value = mark;
 		}
-		if (this->mark_out.value == MARK_UNIQUE)
+		if (MARK_IS_UNIQUE(this->mark_out.value))
 		{
+			if (strict)
+			{
+				mark = ref_get(&unique_mark);
+			}
 			this->mark_out.value = mark;
 		}
 	}

--- a/src/libcharon/sa/child_sa.c
+++ b/src/libcharon/sa/child_sa.c
@@ -1796,18 +1796,18 @@ child_sa_t * child_sa_create(host_t *me, host_t* other,
 	if (MARK_IS_UNIQUE(this->mark_in.value) ||
 		MARK_IS_UNIQUE(this->mark_out.value))
 	{
-		bool strict;
+		bool unique_dir;
 
-		strict = this->mark_in.value == MARK_UNIQUE_STRICT ||
-				 this->mark_out.value == MARK_UNIQUE_STRICT;
+		unique_dir = this->mark_in.value == MARK_UNIQUE_DIR ||
+				this->mark_out.value == MARK_UNIQUE_DIR;
 
-		if (!strict)
+		if (!unique_dir)
 		{
 			mark = ref_get(&unique_mark);
 		}
 		if (MARK_IS_UNIQUE(this->mark_in.value))
 		{
-			if (strict)
+			if (unique_dir)
 			{
 				mark = ref_get(&unique_mark);
 			}
@@ -1815,7 +1815,7 @@ child_sa_t * child_sa_create(host_t *me, host_t* other,
 		}
 		if (MARK_IS_UNIQUE(this->mark_out.value))
 		{
-			if (strict)
+			if (unique_dir)
 			{
 				mark = ref_get(&unique_mark);
 			}

--- a/src/libstrongswan/ipsec/ipsec_types.c
+++ b/src/libstrongswan/ipsec/ipsec_types.c
@@ -66,8 +66,21 @@ bool mark_from_string(const char *value, mark_t *mark)
 	}
 	if (strcasepfx(value, "%unique"))
 	{
-		mark->value = MARK_UNIQUE;
 		endptr = (char*)value + strlen("%unique");
+		if (strcasepfx(endptr, "-dir"))
+		{
+			mark->value = MARK_UNIQUE_STRICT;
+			endptr += strlen("-dir");
+		}
+		else if (!*endptr || *endptr == '/')
+		{
+			mark->value = MARK_UNIQUE;
+		}
+		else
+		{
+			DBG1(DBG_APP, "invalid mark value: %s", value);
+			return FALSE;
+		}
 	}
 	else
 	{

--- a/src/libstrongswan/ipsec/ipsec_types.c
+++ b/src/libstrongswan/ipsec/ipsec_types.c
@@ -69,7 +69,7 @@ bool mark_from_string(const char *value, mark_t *mark)
 		endptr = (char*)value + strlen("%unique");
 		if (strcasepfx(endptr, "-dir"))
 		{
-			mark->value = MARK_UNIQUE_STRICT;
+			mark->value = MARK_UNIQUE_DIR;
 			endptr += strlen("-dir");
 		}
 		else if (!*endptr || *endptr == '/')

--- a/src/libstrongswan/ipsec/ipsec_types.h
+++ b/src/libstrongswan/ipsec/ipsec_types.h
@@ -178,9 +178,11 @@ struct mark_t {
 };
 
 /**
- * Special mark value that uses a unique mark for each CHILD_SA
+ * Special mark value that uses a unique mark for each CHILD_SA (and direction)
  */
 #define MARK_UNIQUE (0xFFFFFFFF)
+#define MARK_UNIQUE_STRICT (0xFFFFFFFE)
+#define MARK_IS_UNIQUE(m) ((m) == MARK_UNIQUE || (m) == MARK_UNIQUE_STRICT)
 
 /**
  * Try to parse a mark_t from the given string of the form mark[/mask].

--- a/src/libstrongswan/ipsec/ipsec_types.h
+++ b/src/libstrongswan/ipsec/ipsec_types.h
@@ -181,8 +181,8 @@ struct mark_t {
  * Special mark value that uses a unique mark for each CHILD_SA (and direction)
  */
 #define MARK_UNIQUE (0xFFFFFFFF)
-#define MARK_UNIQUE_STRICT (0xFFFFFFFE)
-#define MARK_IS_UNIQUE(m) ((m) == MARK_UNIQUE || (m) == MARK_UNIQUE_STRICT)
+#define MARK_UNIQUE_DIR (0xFFFFFFFE)
+#define MARK_IS_UNIQUE(m) ((m) == MARK_UNIQUE || (m) == MARK_UNIQUE_DIR)
 
 /**
  * Try to parse a mark_t from the given string of the form mark[/mask].

--- a/src/swanctl/swanctl.opt
+++ b/src/swanctl/swanctl.opt
@@ -870,7 +870,9 @@ connections.<conn>.children.<child>.mark_in = 0/0x00000000
 	Netfilter mark and mask for input traffic. On Linux Netfilter may require
 	marks on each packet to match an SA having that option set. This allows
 	Netfilter rules to select specific tunnels for incoming traffic. The
-	special value _%unique_ sets a unique mark on each CHILD_SA instance.
+	special value _%unique_ sets a unique mark on each CHILD_SA instance,
+	beyond that the value _%unique-dir_ assigns a different unique mark for each
+	CHILD_SA direction (in/out).
 
 	An additional mask may be appended to the mark, separated by _/_. The
 	default mask if omitted is 0xffffffff.
@@ -881,7 +883,9 @@ connections.<conn>.children.<child>.mark_out = 0/0x00000000
 	Netfilter mark and mask for output traffic. On Linux Netfilter may require
 	marks on each packet to match a policy having that option set. This allows
 	Netfilter rules to select specific tunnels for outgoing traffic. The
-	special value _%unique_ sets a unique mark on each CHILD_SA instance.
+	special value _%unique_ sets a unique mark on each CHILD_SA instance,
+	beyond that the value _%unique-dir_ assigns a different unique mark for each
+	CHILD_SA direction (in/out).
 
 	An additional mask may be appended to the mark, separated by _/_. The
 	default mask if omitted is 0xffffffff.


### PR DESCRIPTION
When requiring unique flags for CHILD_SAs, allow the configuration to
request different marks for each direction by adding an exclamation point
to the %unique keyword.

This is useful when different marks are desired for each direction (e.g.
when 0.0.0.0/0 - 0.0.0.0/0 traffic selectors are used) but the number
of peers is not predefined.