### PR TITLE
Add some route-based VPN test scenarios

### DIFF
--- a/testing/config/kernel/config-4.13
+++ b/testing/config/kernel/config-4.13
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/x86 4.13.12 Kernel Configuration
+# Linux/x86 4.13.16 Kernel Configuration
 #
 CONFIG_64BIT=y
 CONFIG_X86_64=y
@@ -667,7 +667,7 @@ CONFIG_IP_ROUTE_CLASSID=y
 # CONFIG_NET_IPGRE_DEMUX is not set
 CONFIG_NET_IP_TUNNEL=y
 # CONFIG_SYN_COOKIES is not set
-# CONFIG_NET_IPVTI is not set
+CONFIG_NET_IPVTI=y
 CONFIG_NET_UDP_TUNNEL=y
 # CONFIG_NET_FOU is not set
 CONFIG_INET_AH=y

--- a/testing/scripts/function.sh
+++ b/testing/scripts/function.sh
@@ -50,7 +50,7 @@ execute()
 # $1 - command to execute
 execute_chroot()
 {
-	execute "chroot $LOOPDIR $@"
+	execute "chroot $LOOPDIR env PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin $@"
 }
 
 # write green status message to console

--- a/testing/testing.conf
+++ b/testing/testing.conf
@@ -24,11 +24,11 @@ fi
 : ${TESTDIR=/srv/strongswan-testing}
 
 # Kernel configuration
-: ${KERNELVERSION=4.10.17}
+: ${KERNELVERSION=4.13.16}
 : ${KERNEL=linux-$KERNELVERSION}
 : ${KERNELTARBALL=$KERNEL.tar.xz}
-: ${KERNELCONFIG=$DIR/../config/kernel/config-4.10}
-: ${KERNELPATCH=ha-4.4-abicompat.patch.bz2}
+: ${KERNELCONFIG=$DIR/../config/kernel/config-4.13}
+: ${KERNELPATCH=ha-4.13-abicompat.patch.bz2}
 
 # strongSwan version used in tests
 : ${SWANVERSION=5.6.1}

--- a/testing/tests/route-based/net2net-vti/description.txt
+++ b/testing/tests/route-based/net2net-vti/description.txt
@@ -1,0 +1,12 @@
+A connection between the subnets behind the gateways <b>moon</b> and <b>sun</b>
+is set up using VTI interfaces.
+<p/>
+The gateways use <b>route-based forwarding</b> with <b>VTI tunnels</b>, with
+firewall rules to allow traffic to pass. The IPsec traffic selector used is
+0.0.0.0/0, however specific routing is achieved with routes on the VTI
+interfaces. Charon is configured to not install routes with
+<em>charon.install_routes=0</em>, and static routes are installed for the
+target subnets on the VTI interfaces.
+<p/>
+Client <b>alice</b> behind gateway <b>moon</b> pings client <b>bob</b> located
+behind gateway <b>sun</b>.

--- a/testing/tests/route-based/net2net-vti/evaltest.dat
+++ b/testing/tests/route-based/net2net-vti/evaltest.dat
@@ -1,0 +1,5 @@
+moon:: swanctl --list-sas --ike-id 1 --raw 2> /dev/null::rw.*version=2 state=ESTABLISHED local-host=PH_IP_MOON local-port=4500 local-id=moon.strongswan.org remote-host=PH_IP_SUN remote-port=4500 remote-id=sun.strongswan.org.*child-sas.*net.*reqid=1 state=INSTALLED mode=TUNNEL.*ESP.*local-ts=\[0.0.0.0/0] remote-ts=\[0.0.0.0/0]
+sun:: swanctl --list-sas --ike-id 1 --raw 2> /dev/null::rw.*version=2 state=ESTABLISHED local-host=PH_IP_SUN local-port=4500 local-id=sun.strongswan.org remote-host=PH_IP_MOON remote-port=4500 remote-id=moon.strongswan.org.*child-sas.*net.*reqid=1 state=INSTALLED mode=TUNNEL.*ESP.*local-ts=\[0.0.0.0/0] remote-ts=\[0.0.0.0/0]
+alice::ping -c 1 PH_IP_BOB::64 bytes from PH_IP_BOB: icmp_.eq=1::YES
+sun::tcpdump::IP moon.strongswan.org > sun.strongswan.org: ESP::YES
+sun::tcpdump::IP sun.strongswan.org > moon.strongswan.org: ESP::YES

--- a/testing/tests/route-based/net2net-vti/hosts/moon/etc/strongswan.conf
+++ b/testing/tests/route-based/net2net-vti/hosts/moon/etc/strongswan.conf
@@ -1,0 +1,13 @@
+# /etc/strongswan.conf - strongSwan configuration file
+
+swanctl {
+  load = pem pkcs1 x509 revocation constraints pubkey openssl random
+}
+
+charon-systemd {
+  load = random nonce aes sha1 sha2 pem pkcs1 curve25519 gmp x509 curl revocation hmac vici kernel-netlink socket-default updown
+}
+
+charon {
+  install_routes = 0
+}

--- a/testing/tests/route-based/net2net-vti/hosts/moon/etc/swanctl/swanctl.conf
+++ b/testing/tests/route-based/net2net-vti/hosts/moon/etc/swanctl/swanctl.conf
@@ -1,0 +1,29 @@
+connections {
+
+   gw-gw {
+      local_addrs  = PH_IP_MOON
+      remote_addrs = PH_IP_SUN
+
+      local {
+         auth = pubkey
+         certs = moonCert.pem
+         id = moon.strongswan.org
+      }
+      remote {
+         auth = pubkey
+         id = sun.strongswan.org
+      }
+      children {
+         net2net {
+            local_ts  = 0.0.0.0/0
+            remote_ts = 0.0.0.0/0
+            mark_in = 42
+            mark_out = 42
+
+            esp_proposals = aes128gcm128-x25519
+         }
+      }
+      version = 2
+      proposals = aes128-sha256-x25519
+   }
+}

--- a/testing/tests/route-based/net2net-vti/hosts/sun/etc/strongswan.conf
+++ b/testing/tests/route-based/net2net-vti/hosts/sun/etc/strongswan.conf
@@ -1,0 +1,13 @@
+# /etc/strongswan.conf - strongSwan configuration file
+
+swanctl {
+  load = pem pkcs1 x509 revocation constraints pubkey openssl random
+}
+
+charon-systemd {
+  load = random nonce aes sha1 sha2 pem pkcs1 curve25519 gmp x509 curl revocation hmac vici kernel-netlink socket-default updown
+}
+
+charon {
+  install_routes = 0
+}

--- a/testing/tests/route-based/net2net-vti/hosts/sun/etc/swanctl/swanctl.conf
+++ b/testing/tests/route-based/net2net-vti/hosts/sun/etc/swanctl/swanctl.conf
@@ -1,0 +1,29 @@
+connections {
+
+   gw-gw {
+      local_addrs  = PH_IP_SUN
+      remote_addrs = PH_IP_MOON
+
+      local {
+         auth = pubkey
+         certs = sunCert.pem
+         id = sun.strongswan.org
+      }
+      remote {
+         auth = pubkey
+         id = moon.strongswan.org
+      }
+      children {
+         net2net {
+            local_ts  = 0.0.0.0/0
+            remote_ts = 0.0.0.0/0
+            mark_in = 1337
+            mark_out = 1337
+
+            esp_proposals = aes128gcm128-x25519
+         }
+      }
+      version = 2
+      proposals = aes128-sha256-x25519
+   }
+}

--- a/testing/tests/route-based/net2net-vti/posttest.dat
+++ b/testing/tests/route-based/net2net-vti/posttest.dat
@@ -1,0 +1,8 @@
+moon::swanctl --terminate --ike gw-gw
+sun::swanctl --terminate --ike gw-gw
+moon::systemctl stop strongswan-swanctl
+sun::systemctl stop strongswan-swanctl
+moon::iptables-restore < /etc/iptables.flush
+sun::iptables-restore < /etc/iptables.flush
+moon::ip tunnel del vti-moon
+sun::ip tunnel del vti-sun

--- a/testing/tests/route-based/net2net-vti/pretest.dat
+++ b/testing/tests/route-based/net2net-vti/pretest.dat
@@ -1,0 +1,18 @@
+moon::iptables-restore < /etc/iptables.rules
+sun::iptables-restore < /etc/iptables.rules
+moon::ip tunnel add vti-moon local PH_IP_MOON remote PH_IP_SUN mode vti key 42
+moon::ip link set vti-moon up
+moon::ip route add 10.2.0.0/16 dev vti-moon
+moon::iptables -A FORWARD -i vti-moon -j ACCEPT
+moon::iptables -A FORWARD -o vti-moon -j ACCEPT
+sun::ip tunnel add vti-sun local PH_IP_SUN remote PH_IP_MOON mode vti key 1337
+sun::ip link set vti-sun up
+sun::ip route add 10.1.0.0/16 dev vti-sun
+sun::iptables -A FORWARD -i vti-sun -j ACCEPT
+sun::iptables -A FORWARD -o vti-sun -j ACCEPT
+moon::systemctl start strongswan-swanctl
+sun::systemctl start strongswan-swanctl
+moon::expect-connection gw-gw
+sun::expect-connection gw-gw
+moon::swanctl --initiate --child net2net
+sun::swanctl --initiate --child net2net

--- a/testing/tests/route-based/net2net-vti/test.conf
+++ b/testing/tests/route-based/net2net-vti/test.conf
@@ -1,0 +1,25 @@
+#!/bin/bash
+#
+# This configuration file provides information on the
+# guest instances used for this test
+
+# All guest instances that are required for this test
+#
+VIRTHOSTS="alice moon winnetou sun bob"
+
+# Corresponding block diagram
+#
+DIAGRAM="a-m-w-s-b.png"
+
+# Guest instances on which tcpdump is to be started
+#
+TCPDUMPHOSTS="sun"
+
+# Guest instances on which IPsec is started
+# Used for IPsec logging purposes
+#
+IPSECHOSTS="moon sun"
+
+# charon controlled by swanctl
+#
+SWANCTL=1

--- a/testing/tests/route-based/rw-shared-vti-ip4-in-ip6/description.txt
+++ b/testing/tests/route-based/rw-shared-vti-ip4-in-ip6/description.txt
@@ -1,0 +1,11 @@
+The roadwarriors <b>carol</b> and <b>dave</b> set up an IPv6-in-IPv4 connection each to
+gateway <b>moon</b>. Both <b>carol</b> and <b>dave</b> request an IPv6 <b>virtual
+IP</b> via the IKEv2 configuration payload.
+<p/>
+The gateway <b>moon</b> uses <b>route-based forwarding</b> with <b>VTI
+tunnels</b>, with firewall rules to allow traffic to pass. Charon is configured
+to not install routes with <em>charon.install_routes=0</em>, and a static route
+is installed for the IPv6 virtual IP subnet on the VTI device.
+<p/>
+Both <b>carol</b> and <b>dave</b> ping the client <b>alice</b> behind the
+gateway <b>moon</b>.

--- a/testing/tests/route-based/rw-shared-vti-ip4-in-ip6/evaltest.dat
+++ b/testing/tests/route-based/rw-shared-vti-ip4-in-ip6/evaltest.dat
@@ -1,0 +1,10 @@
+carol::swanctl --list-sas --raw 2> /dev/null::home.*version=2 state=ESTABLISHED local-host=PH_IP_CAROL local-port=4500 local-id=carol@strongswan.org remote-host=PH_IP_MOON remote-port=4500 remote-id=moon.strongswan.org initiator=yes.*local-vips=\[fec3:\:1] child-sas.*home.*reqid=1 state=INSTALLED mode=TUNNEL protocol=ESP.*local-ts=\[fec3:\:1/128] remote-ts=\[fec1:\:/16]
+dave::swanctl --list-sas --raw 2> /dev/null::home.*version=2 state=ESTABLISHED local-host=PH_IP_DAVE local-port=4500 local-id=dave@strongswan.org remote-host=PH_IP_MOON remote-port=4500 remote-id=moon.strongswan.org initiator=yes.*local-vips=\[fec3:\:2] child-sas.*home.*reqid=1 state=INSTALLED mode=TUNNEL protocol=ESP.*local-ts=\[fec3:\:2/128] remote-ts=\[fec1:\:/16]
+moon::swanctl --list-sas --ike-id 2 --raw 2> /dev/null::rw.*version=2 state=ESTABLISHED local-host=PH_IP_MOON.168.0.1 local-port=4500 local-id=moon.strongswan.org remote-host=PH_IP_CAROL remote-port=4500 remote-id=carol@strongswan.org.*remote-vips=\[fec3:\:2] child-sas.*net.*reqid=2 state=INSTALLED mode=TUNNEL protocol=ESP.*local-ts=\[fec1:\:/16] remote-ts=\[fec3:\:2/128]
+moon::swanctl --list-sas --ike-id 1 --raw 2> /dev/null::rw.*version=2 state=ESTABLISHED local-host=PH_IP_MOON local-port=4500 local-id=moon.strongswan.org remote-host=PH_IP_DAVE remote-port=4500 remote-id=dave@strongswan.org.*remote-vips=\[fec3:\:1] child-sas.*net.*reqid=1 state=INSTALLED mode=TUNNEL protocol=ESP.*local-ts=\[fec1:\:/16] remote-ts=\[fec3:\:1/128]
+carol::ping6 -c 1 ip6-alice.strongswan.org::64 bytes from ip6-alice.strongswan.org: icmp_seq=1::YES
+dave:: ping6 -c 1 ip6-alice.strongswan.org::64 bytes from ip6-alice.strongswan.org: icmp_seq=1::YES
+moon::tcpdump::carol.strongswan.org > moon.strongswan.org: ESP::YES
+moon::tcpdump::moon.strongswan.org > carol.strongswan.org: ESP::YES
+moon::tcpdump::dave.strongswan.org > moon.strongswan.org: ESP::YES
+moon::tcpdump::moon.strongswan.org > dave.strongswan.org: ESP::YES

--- a/testing/tests/route-based/rw-shared-vti-ip4-in-ip6/hosts/carol/etc/ip6tables.rules
+++ b/testing/tests/route-based/rw-shared-vti-ip4-in-ip6/hosts/carol/etc/ip6tables.rules
@@ -1,0 +1,20 @@
+*filter
+
+# default policy is DROP
+-P INPUT DROP
+-P OUTPUT DROP
+-P FORWARD DROP
+
+# allow ICMPv6 neighbor-solicitations
+-A INPUT  -p icmpv6 --icmpv6-type neighbor-solicitation -j ACCEPT
+-A OUTPUT -p icmpv6 --icmpv6-type neighbor-solicitation -j ACCEPT
+
+# allow ICMPv6 neighbor-advertisements
+-A INPUT  -p icmpv6 --icmpv6-type neighbor-advertisement -j ACCEPT
+-A OUTPUT -p icmpv6 --icmpv6-type neighbor-advertisement -j ACCEPT
+
+# log dropped packets
+-A INPUT  -j LOG --log-prefix " IN: "
+-A OUTPUT -j LOG --log-prefix " OUT: "
+
+COMMIT

--- a/testing/tests/route-based/rw-shared-vti-ip4-in-ip6/hosts/carol/etc/strongswan.conf
+++ b/testing/tests/route-based/rw-shared-vti-ip4-in-ip6/hosts/carol/etc/strongswan.conf
@@ -1,0 +1,9 @@
+# /etc/strongswan.conf - strongSwan configuration file
+
+swanctl {
+  load = pem pkcs1 x509 revocation constraints pubkey openssl random
+}
+
+charon-systemd {
+  load = random nonce aes sha1 sha2 hmac pem pkcs1 x509 revocation curve25519 gmp curl kernel-netlink socket-default updown vici
+}

--- a/testing/tests/route-based/rw-shared-vti-ip4-in-ip6/hosts/carol/etc/swanctl/swanctl.conf
+++ b/testing/tests/route-based/rw-shared-vti-ip4-in-ip6/hosts/carol/etc/swanctl/swanctl.conf
@@ -1,0 +1,28 @@
+connections {
+
+   home {
+      local_addrs  = PH_IP_CAROL
+      remote_addrs = PH_IP_MOON
+      vips = ::
+
+      local {
+         auth = pubkey
+         certs = carolCert.pem
+         id = carol@strongswan.org
+      }
+      remote {
+         auth = pubkey
+         id = moon.strongswan.org 
+      }
+      children {
+         home {
+            remote_ts = fec1::/16
+
+            updown = /usr/local/libexec/ipsec/_updown iptables
+            esp_proposals = aes128gcm128-x25519
+         }
+      }
+      version = 2
+      proposals = aes128-sha256-x25519
+   }
+}

--- a/testing/tests/route-based/rw-shared-vti-ip4-in-ip6/hosts/dave/etc/ip6tables.rules
+++ b/testing/tests/route-based/rw-shared-vti-ip4-in-ip6/hosts/dave/etc/ip6tables.rules
@@ -1,0 +1,20 @@
+*filter
+
+# default policy is DROP
+-P INPUT DROP
+-P OUTPUT DROP
+-P FORWARD DROP
+
+# allow ICMPv6 neighbor-solicitations
+-A INPUT  -p icmpv6 --icmpv6-type neighbor-solicitation -j ACCEPT
+-A OUTPUT -p icmpv6 --icmpv6-type neighbor-solicitation -j ACCEPT
+
+# allow ICMPv6 neighbor-advertisements
+-A INPUT  -p icmpv6 --icmpv6-type neighbor-advertisement -j ACCEPT
+-A OUTPUT -p icmpv6 --icmpv6-type neighbor-advertisement -j ACCEPT
+
+# log dropped packets
+-A INPUT  -j LOG --log-prefix " IN: "
+-A OUTPUT -j LOG --log-prefix " OUT: "
+
+COMMIT

--- a/testing/tests/route-based/rw-shared-vti-ip4-in-ip6/hosts/dave/etc/strongswan.conf
+++ b/testing/tests/route-based/rw-shared-vti-ip4-in-ip6/hosts/dave/etc/strongswan.conf
@@ -1,0 +1,9 @@
+# /etc/strongswan.conf - strongSwan configuration file
+
+swanctl {
+  load = pem pkcs1 x509 revocation constraints pubkey openssl random
+}
+
+charon-systemd {
+  load = random nonce aes sha1 sha2 hmac pem pkcs1 x509 revocation curve25519 gmp curl kernel-netlink socket-default updown vici
+}

--- a/testing/tests/route-based/rw-shared-vti-ip4-in-ip6/hosts/dave/etc/swanctl/swanctl.conf
+++ b/testing/tests/route-based/rw-shared-vti-ip4-in-ip6/hosts/dave/etc/swanctl/swanctl.conf
@@ -1,0 +1,28 @@
+connections {
+
+   home {
+      local_addrs  = PH_IP_DAVE
+      remote_addrs = PH_IP_MOON
+      vips = ::
+
+      local {
+         auth = pubkey
+         certs = daveCert.pem
+         id = dave@strongswan.org
+      }
+      remote {
+         auth = pubkey
+         id = moon.strongswan.org 
+      }
+      children {
+         home {
+            remote_ts = fec1::/16
+
+            updown = /usr/local/libexec/ipsec/_updown iptables
+            esp_proposals = aes128gcm128-x25519
+         }
+      }
+      version = 2
+      proposals = aes128-sha256-x25519
+   }
+}

--- a/testing/tests/route-based/rw-shared-vti-ip4-in-ip6/hosts/moon/etc/ip6tables.rules
+++ b/testing/tests/route-based/rw-shared-vti-ip4-in-ip6/hosts/moon/etc/ip6tables.rules
@@ -1,0 +1,20 @@
+*filter
+
+# default policy is DROP
+-P INPUT DROP
+-P OUTPUT DROP
+-P FORWARD DROP
+
+# allow ICMPv6 neighbor-solicitations
+-A INPUT  -p icmpv6 --icmpv6-type neighbor-solicitation -j ACCEPT
+-A OUTPUT -p icmpv6 --icmpv6-type neighbor-solicitation -j ACCEPT
+
+# allow ICMPv6 neighbor-advertisements
+-A INPUT  -p icmpv6 --icmpv6-type neighbor-advertisement -j ACCEPT
+-A OUTPUT -p icmpv6 --icmpv6-type neighbor-advertisement -j ACCEPT
+
+# log dropped packets
+-A INPUT  -j LOG --log-prefix " IN: "
+-A OUTPUT -j LOG --log-prefix " OUT: "
+
+COMMIT

--- a/testing/tests/route-based/rw-shared-vti-ip4-in-ip6/hosts/moon/etc/strongswan.conf
+++ b/testing/tests/route-based/rw-shared-vti-ip4-in-ip6/hosts/moon/etc/strongswan.conf
@@ -1,0 +1,13 @@
+# /etc/strongswan.conf - strongSwan configuration file
+
+swanctl {
+  load = pem pkcs1 x509 revocation constraints pubkey openssl random
+}
+
+charon-systemd {
+  load = random nonce aes sha1 sha2 pem pkcs1 curve25519 gmp x509 curl revocation hmac vici kernel-netlink socket-default updown
+}
+
+charon {
+  install_routes = 0
+}

--- a/testing/tests/route-based/rw-shared-vti-ip4-in-ip6/hosts/moon/etc/swanctl/swanctl.conf
+++ b/testing/tests/route-based/rw-shared-vti-ip4-in-ip6/hosts/moon/etc/swanctl/swanctl.conf
@@ -1,0 +1,33 @@
+connections {
+
+   rw {
+      local_addrs  = PH_IP_MOON
+      pools = rw_pool
+
+      local {
+         auth = pubkey
+         certs = moonCert.pem
+         id = moon.strongswan.org
+      }
+      remote {
+         auth = pubkey
+      }
+      children {
+         net {
+            local_ts  = fec1::/16
+            mark_in = 42
+            mark_out = 42
+
+            esp_proposals = aes128gcm128-x25519
+         }
+      }
+      version = 2
+      proposals = aes128-sha256-x25519
+   }
+}
+
+pools {
+    rw_pool {
+        addrs = fec3::/120
+    }
+}

--- a/testing/tests/route-based/rw-shared-vti-ip4-in-ip6/posttest.dat
+++ b/testing/tests/route-based/rw-shared-vti-ip4-in-ip6/posttest.dat
@@ -1,0 +1,13 @@
+carol::swanctl --terminate --ike home
+dave::swanctl --terminate --ike home
+moon::systemctl stop strongswan-swanctl
+carol::systemctl stop strongswan-swanctl
+dave::systemctl stop strongswan-swanctl
+moon::iptables-restore < /etc/iptables.flush
+carol::iptables-restore < /etc/iptables.flush
+dave::iptables-restore < /etc/iptables.flush
+moon::ip6tables-restore < /etc/iptables.flush
+carol::ip6tables-restore < /etc/iptables.flush
+dave::ip6tables-restore < /etc/iptables.flush
+moon::ip tunnel del vti0
+alice::"ip route del fec3:\:/16 via fec1:\:1"

--- a/testing/tests/route-based/rw-shared-vti-ip4-in-ip6/pretest.dat
+++ b/testing/tests/route-based/rw-shared-vti-ip4-in-ip6/pretest.dat
@@ -1,0 +1,20 @@
+moon::iptables-restore < /etc/iptables.rules
+carol::iptables-restore < /etc/iptables.rules
+dave::iptables-restore < /etc/iptables.rules
+moon::ip6tables-restore < /etc/ip6tables.rules
+carol::ip6tables-restore < /etc/ip6tables.rules
+dave::ip6tables-restore < /etc/ip6tables.rules
+alice::"ip route add fec3:\:/16 via fec1:\:1"
+moon::ip tunnel add vti0 local PH_IP_MOON remote 0.0.0.0 mode vti key 42
+moon::ip link set vti0 up
+moon::"ip route add fec3:\:/16 dev vti0"
+moon::ip6tables -A FORWARD -i vti0 -j ACCEPT
+moon::ip6tables -A FORWARD -o vti0 -j ACCEPT
+moon::systemctl start strongswan-swanctl
+carol::systemctl start strongswan-swanctl
+dave::systemctl start strongswan-swanctl
+moon::expect-connection rw
+carol::expect-connection home
+dave::expect-connection home
+carol::swanctl --initiate --child home
+dave::swanctl --initiate --child home

--- a/testing/tests/route-based/rw-shared-vti-ip4-in-ip6/test.conf
+++ b/testing/tests/route-based/rw-shared-vti-ip4-in-ip6/test.conf
@@ -1,0 +1,29 @@
+#!/bin/bash
+#
+# This configuration file provides information on the
+# guest instances used for this test
+
+# All guest instances that are required for this test
+#
+VIRTHOSTS="alice moon carol winnetou dave"
+
+# Corresponding block diagram
+#
+DIAGRAM="a-m-c-w-d-ip6.png"
+
+# Guest instances on which tcpdump is to be started
+#
+TCPDUMPHOSTS="moon"
+
+# Guest instances on which IPsec is started
+# Used for IPsec logging purposes
+#
+IPSECHOSTS="moon carol dave"
+
+# IP protocol used by IPsec is IPv6
+#
+IPV6=1
+
+# charon controlled by swanctl
+#
+SWANCTL=1

--- a/testing/tests/route-based/rw-shared-vti/description.txt
+++ b/testing/tests/route-based/rw-shared-vti/description.txt
@@ -1,0 +1,12 @@
+The roadwarriors <b>carol</b> and <b>dave</b> set up a connection each to
+gateway <b>moon</b>. Both <b>carol</b> and <b>dave</b> request a <b>virtual
+IP</b> via the IKEv2 configuration payload.
+<p/>
+The gateway <b>moon</b> uses <b>route-based forwarding</b> with <b>VTI
+tunnels</b>, with firewall rules to allow traffic to pass. Charon is configured
+to not install routes with <em>charon.install_routes=0</em>, and a static route
+is installed for the virtual IP subnet on the VTI device.
+<p/>
+Both <b>carol</b> and <b>dave</b> ping the client <b>alice</b> behind the
+gateway <b>moon</b>. The source IP addresses of the two pings will be the
+virtual IPs <b>carol1</b> and <b>dave1</b>, respectively.

--- a/testing/tests/route-based/rw-shared-vti/evaltest.dat
+++ b/testing/tests/route-based/rw-shared-vti/evaltest.dat
@@ -1,0 +1,10 @@
+carol::swanctl --list-sas --raw 2> /dev/null::home.*version=2 state=ESTABLISHED local-host=PH_IP_CAROL local-port=4500 local-id=carol@strongswan.org remote-host=PH_IP_MOON remote-port=4500 remote-id=moon.strongswan.org initiator=yes.*child-sas.*home.*state=INSTALLED mode=TUNNEL.*ESP.*local-ts=\[10.3.0.1/32] remote-ts=\[10.1.0.0/16]::YES
+dave:: swanctl --list-sas --raw 2> /dev/null::home.*version=2 state=ESTABLISHED local-host=PH_IP_DAVE local-port=4500 local-id=dave@strongswan.org remote-host=PH_IP_MOON remote-port=4500 remote-id=moon.strongswan.org initiator=yes.*child-sas.*home.*state=INSTALLED mode=TUNNEL.*ESP.*local-ts=\[10.3.0.2/32] remote-ts=\[10.1.0.0/16]::YES
+moon:: swanctl --list-sas --ike-id 1 --raw 2> /dev/null::rw.*version=2 state=ESTABLISHED local-host=PH_IP_MOON local-port=4500 local-id=moon.strongswan.org remote-host=PH_IP_CAROL remote-port=4500 remote-id=carol@strongswan.org.*child-sas.*net.*reqid=1 state=INSTALLED mode=TUNNEL.*ESP.*local-ts=\[10.1.0.0/16] remote-ts=\[10.3.0.1/32]
+moon:: swanctl --list-sas --ike-id 2 --raw 2> /dev/null::rw.*version=2 state=ESTABLISHED local-host=PH_IP_MOON local-port=4500 local-id=moon.strongswan.org remote-host=PH_IP_DAVE remote-port=4500 remote-id=dave@strongswan.org.*child-sas.*net.*reqid=2 state=INSTALLED mode=TUNNEL.*ESP.*local-ts=\[10.1.0.0/16] remote-ts=\[10.3.0.2/32]
+carol::ping -c 1 PH_IP_ALICE::64 bytes from PH_IP_ALICE: icmp_.eq=1::YES
+dave::ping -c 1 PH_IP_ALICE::64 bytes from PH_IP_ALICE: icmp_.eq=1::YES
+moon::tcpdump::IP moon.strongswan.org > carol.strongswan.org: ESP::YES
+moon::tcpdump::IP carol.strongswan.org > moon.strongswan.org: ESP::YES
+moon::tcpdump::IP moon.strongswan.org > dave.strongswan.org: ESP::YES
+moon::tcpdump::IP dave.strongswan.org > moon.strongswan.org: ESP::YES

--- a/testing/tests/route-based/rw-shared-vti/hosts/carol/etc/strongswan.conf
+++ b/testing/tests/route-based/rw-shared-vti/hosts/carol/etc/strongswan.conf
@@ -1,0 +1,9 @@
+# /etc/strongswan.conf - strongSwan configuration file
+
+swanctl {
+  load = pem pkcs1 x509 revocation constraints pubkey openssl random
+}
+
+charon-systemd {
+  load = random nonce aes sha1 sha2 hmac pem pkcs1 x509 revocation curve25519 gmp curl kernel-netlink socket-default updown vici
+}

--- a/testing/tests/route-based/rw-shared-vti/hosts/carol/etc/swanctl/swanctl.conf
+++ b/testing/tests/route-based/rw-shared-vti/hosts/carol/etc/swanctl/swanctl.conf
@@ -1,0 +1,28 @@
+connections {
+
+   home {
+      local_addrs  = PH_IP_CAROL
+      remote_addrs = PH_IP_MOON
+      vips = 0.0.0.0 
+
+      local {
+         auth = pubkey
+         certs = carolCert.pem
+         id = carol@strongswan.org
+      }
+      remote {
+         auth = pubkey
+         id = moon.strongswan.org 
+      }
+      children {
+         home {
+            remote_ts = 10.1.0.0/16 
+
+            updown = /usr/local/libexec/ipsec/_updown iptables
+            esp_proposals = aes128gcm128-x25519
+         }
+      }
+      version = 2
+      proposals = aes128-sha256-x25519
+   }
+}

--- a/testing/tests/route-based/rw-shared-vti/hosts/dave/etc/strongswan.conf
+++ b/testing/tests/route-based/rw-shared-vti/hosts/dave/etc/strongswan.conf
@@ -1,0 +1,9 @@
+# /etc/strongswan.conf - strongSwan configuration file
+
+swanctl {
+  load = pem pkcs1 x509 revocation constraints pubkey openssl random
+}
+
+charon-systemd {
+  load = random nonce aes sha1 sha2 hmac pem pkcs1 x509 revocation curve25519 gmp curl kernel-netlink socket-default updown vici
+}

--- a/testing/tests/route-based/rw-shared-vti/hosts/dave/etc/swanctl/swanctl.conf
+++ b/testing/tests/route-based/rw-shared-vti/hosts/dave/etc/swanctl/swanctl.conf
@@ -1,0 +1,28 @@
+connections {
+
+   home {
+      local_addrs  = PH_IP_DAVE
+      remote_addrs = PH_IP_MOON
+      vips = 0.0.0.0 
+
+      local {
+         auth = pubkey
+         certs = daveCert.pem
+         id = dave@strongswan.org
+      }
+      remote {
+         auth = pubkey
+         id = moon.strongswan.org 
+      }
+      children {
+         home {
+            remote_ts = 10.1.0.0/16 
+
+            updown = /usr/local/libexec/ipsec/_updown iptables
+            esp_proposals = aes128gcm128-x25519
+         }
+      }
+      version = 2
+      proposals = aes128-sha256-x25519
+   }
+}

--- a/testing/tests/route-based/rw-shared-vti/hosts/moon/etc/strongswan.conf
+++ b/testing/tests/route-based/rw-shared-vti/hosts/moon/etc/strongswan.conf
@@ -1,0 +1,13 @@
+# /etc/strongswan.conf - strongSwan configuration file
+
+swanctl {
+  load = pem pkcs1 x509 revocation constraints pubkey openssl random
+}
+
+charon-systemd {
+  load = random nonce aes sha1 sha2 pem pkcs1 curve25519 gmp x509 curl revocation hmac vici kernel-netlink socket-default updown
+}
+
+charon {
+  install_routes = 0
+}

--- a/testing/tests/route-based/rw-shared-vti/hosts/moon/etc/swanctl/swanctl.conf
+++ b/testing/tests/route-based/rw-shared-vti/hosts/moon/etc/swanctl/swanctl.conf
@@ -1,0 +1,33 @@
+connections {
+
+   rw {
+      local_addrs  = PH_IP_MOON
+      pools = rw_pool
+
+      local {
+         auth = pubkey
+         certs = moonCert.pem
+         id = moon.strongswan.org
+      }
+      remote {
+         auth = pubkey
+      }
+      children {
+         net {
+            local_ts  = 10.1.0.0/16
+            mark_in = 42
+            mark_out = 42
+
+            esp_proposals = aes128gcm128-x25519
+         }
+      }
+      version = 2
+      proposals = aes128-sha256-x25519
+   }
+}
+
+pools {
+    rw_pool {
+        addrs = 10.3.0.0/28
+    }
+}

--- a/testing/tests/route-based/rw-shared-vti/posttest.dat
+++ b/testing/tests/route-based/rw-shared-vti/posttest.dat
@@ -1,0 +1,9 @@
+carol::swanctl --terminate --ike home
+dave::swanctl --terminate --ike home
+moon::systemctl stop strongswan-swanctl
+carol::systemctl stop strongswan-swanctl
+dave::systemctl stop strongswan-swanctl
+moon::iptables-restore < /etc/iptables.flush
+carol::iptables-restore < /etc/iptables.flush
+dave::iptables-restore < /etc/iptables.flush
+moon::ip tunnel del vti0

--- a/testing/tests/route-based/rw-shared-vti/pretest.dat
+++ b/testing/tests/route-based/rw-shared-vti/pretest.dat
@@ -1,0 +1,16 @@
+moon::iptables-restore < /etc/iptables.rules
+carol::iptables-restore < /etc/iptables.rules
+dave::iptables-restore < /etc/iptables.rules
+moon::ip tunnel add vti0 local PH_IP_MOON remote 0.0.0.0 mode vti key 42
+moon::ip link set vti0 up
+moon::ip route add 10.3.0.0/28 dev vti0
+moon::iptables -A FORWARD -i vti0 -j ACCEPT
+moon::iptables -A FORWARD -o vti0 -j ACCEPT
+moon::systemctl start strongswan-swanctl
+carol::systemctl start strongswan-swanctl
+dave::systemctl start strongswan-swanctl
+moon::expect-connection rw
+carol::expect-connection home
+dave::expect-connection home
+carol::swanctl --initiate --child home
+dave::swanctl --initiate --child home

--- a/testing/tests/route-based/rw-shared-vti/test.conf
+++ b/testing/tests/route-based/rw-shared-vti/test.conf
@@ -1,0 +1,25 @@
+#!/bin/bash
+#
+# This configuration file provides information on the
+# guest instances used for this test
+
+# All guest instances that are required for this test
+#
+VIRTHOSTS="alice moon carol winnetou dave"
+
+# Corresponding block diagram
+#
+DIAGRAM="a-m-c-w-d.png"
+
+# Guest instances on which tcpdump is to be started
+#
+TCPDUMPHOSTS="moon"
+
+# Guest instances on which IPsec is started
+# Used for IPsec logging purposes
+#
+IPSECHOSTS="moon carol dave"
+
+# charon controlled by swanctl
+#
+SWANCTL=1


### PR DESCRIPTION
To complement https://wiki.strongswan.org/projects/strongswan/wiki/RouteBasedVPN, I've created some route-based VPN test scenarios. I also fixed a small issue with the PATH environment variable in the testing build chroot, which was stopping me from running the tests on my machine.

Let me know if putting these tests in a new directory was the wrong decision, and they should instead be distributed amongst {ikev2,ipv6}. I may add more tests later, e.g. VTI6 tests (IPv6 IPsec), or GRE tests.