### PR TITLE
nm: allow disabling libnm-glib

### DIFF
--- a/src/frontends/gnome/Makefile.am
+++ b/src/frontends/gnome/Makefile.am
@@ -12,6 +12,7 @@ appdata_DATA = $(appdata_in_files:.xml.in=.xml)
 appdata_in_files = NetworkManager-strongswan.appdata.xml.in
 @INTLTOOL_XML_RULE@
 
+if WITH_LIBNM_GLIB
 # Install a file with full path to plugins for an old gnome-shell
 # https://bugzilla.gnome.org/show_bug.cgi?id=693590
 install-data-hook:
@@ -26,6 +27,7 @@ install-data-hook:
 
 uninstall-hook:
 	 rm -f $(DESTDIR)$(sysconfdir)/NetworkManager/VPN/nm-strongswan-service.name
+endif
 
 nm-strongswan-service.name: $(srcdir)/nm-strongswan-service.name.in
 	$(AM_V_GEN) \

--- a/src/frontends/gnome/configure.ac
+++ b/src/frontends/gnome/configure.ac
@@ -46,14 +46,6 @@ AM_GLIB_GNU_GETTEXT
 PKG_CHECK_MODULES(GTK, gtk+-3.0 >= 3.0)
 PKG_CHECK_MODULES(LIBSECRET, libsecret-1)
 
-PKG_CHECK_MODULES(LIBNM_GLIB, NetworkManager >= 1.1.0 libnm-util libnm-glib libnm-glib-vpn)
-PKG_CHECK_MODULES(LIBNM_GTK, libnm-gtk >= 1.1.0)
-PKG_CHECK_MODULES(LIBNMA, libnma >= 1.1.0)
-
-PKG_CHECK_MODULES(LIBNM, libnm >= 1.1.0)
-LIBNM_CFLAGS="$LIBNM_CFLAGS -DNM_VERSION_MIN_REQUIRED=NM_VERSION_1_2"
-LIBNM_CFLAGS="$LIBNM_CFLAGS -DNM_VERSION_MAX_ALLOWED=NM_VERSION_1_2"
-
 AC_ARG_WITH(
 	[charon],
 	AS_HELP_STRING([--with-charon=file],[path to the strongSwan charon NetworkManager backend"]),
@@ -64,6 +56,24 @@ AC_ARG_ENABLE(
 	[nm-absolute-paths],
 	AS_HELP_STRING([--enable-nm-absolute-paths],[use absolute paths for NM plugins in the .name file])
 )
+AC_ARG_WITH(
+	[libnm-glib],
+	AS_HELP_STRING([--without-libnm-glib], [Build NetworkManager-strongswan without libnm-glib comatibility]),
+	[with_libnm_glib=no],
+	[with_libnm_glib=yes]
+)
+
+AM_CONDITIONAL(WITH_LIBNM_GLIB, test "$with_libnm_glib" != no)
+
+PKG_CHECK_MODULES(LIBNM, libnm >= 1.1.0)
+LIBNM_CFLAGS="$LIBNM_CFLAGS -DNM_VERSION_MIN_REQUIRED=NM_VERSION_1_2"
+LIBNM_CFLAGS="$LIBNM_CFLAGS -DNM_VERSION_MAX_ALLOWED=NM_VERSION_1_2"
+PKG_CHECK_MODULES(LIBNMA, libnma >= 1.1.0)
+
+if test x"$with_libnm_glib" != xno; then
+	PKG_CHECK_MODULES(LIBNM_GLIB, NetworkManager >= 1.1.0 libnm-util libnm-glib libnm-glib-vpn)
+	PKG_CHECK_MODULES(LIBNM_GTK, libnm-gtk >= 1.1.0)
+fi
 
 nm_libexecdir=$($PKG_CONFIG --variable=libgnome_serverdir NetworkManager)
 AC_SUBST(nm_libexecdir)

--- a/src/frontends/gnome/properties/Makefile.am
+++ b/src/frontends/gnome/properties/Makefile.am
@@ -1,5 +1,8 @@
 nm_plugin_LTLIBRARIES = libnm-vpn-plugin-strongswan.la
+
+if WITH_LIBNM_GLIB
 nm_plugin_LTLIBRARIES += libnm-strongswan-properties.la
+endif
 
 libnm_vpn_plugin_strongswan_la_SOURCES = \
 	nm-strongswan.c \


### PR DESCRIPTION
The distros are eventually going to drop it, allow omitting it.