### PR TITLE
ipsec_types: do not mask the configured mark value if it is one of th…

### DIFF
--- a/src/libstrongswan/ipsec/ipsec_types.c
+++ b/src/libstrongswan/ipsec/ipsec_types.c
@@ -104,7 +104,10 @@ bool mark_from_string(const char *value, mark_t *mark)
 	{
 		mark->mask = 0xffffffff;
 	}
-	/* apply the mask to ensure the value is in range */
-	mark->value &= mark->mask;
+	if (!MARK_IS_UNIQUE(mark->value))
+	{
+		/* apply the mask to ensure the value is in range */
+		mark->value &= mark->mask;
+	}
 	return TRUE;
 }

--- a/src/libstrongswan/tests/suites/test_utils.c
+++ b/src/libstrongswan/tests/suites/test_utils.c
@@ -857,6 +857,9 @@ END_TEST
  * mark_from_string
  */
 
+#define _STRINGIFY(s) #s
+#define STRINGIFY(s) _STRINGIFY s
+
 static struct {
 	char *s;
 	bool ok;
@@ -877,8 +880,11 @@ static struct {
 	{"/0xff",		TRUE,  { 0, 0xff }},
 	{"/x",			FALSE, { 0 }},
 	{"x/x",			FALSE, { 0 }},
-	{"0xffffffff/0x0000ffff",	TRUE, { 0x0000ffff, 0x0000ffff }},
-	{"0xffffffff/0xffffffff",	TRUE, { 0xffffffff, 0xffffffff }},
+	{"0xfffffff0/0x0000ffff",	TRUE, { 0x0000fff0, 0x0000ffff }},
+	{STRINGIFY(MARK_UNIQUE) "/0x0000ffff", TRUE, { MARK_UNIQUE, 0x0000ffff }},
+	{STRINGIFY(MARK_UNIQUE) "/0xffffffff", TRUE, { MARK_UNIQUE, 0xffffffff }},
+	{STRINGIFY(MARK_UNIQUE_DIR) "/0x0000ffff", TRUE, { MARK_UNIQUE_DIR, 0x0000ffff }},
+	{STRINGIFY(MARK_UNIQUE_DIR) "/0xffffffff", TRUE, { MARK_UNIQUE_DIR, 0xffffffff }},
 };
 
 START_TEST(test_mark_from_string)


### PR DESCRIPTION
…e 'unique' values

Support for mark=%unique/%unique-dir is implemented by using designated
magic mark values.

Use of masks is orthogonal to the 'unique' feature, as it is useful to be
able to designate portions of the packet mark for other purposes, while
still using different marks for different connections.

When these magic values are masked, their magic meaning is lost.

Perform masking only on explicit mark values.