### PR TITLE
Update SA based on change in priority routing rule

### DIFF
--- a/conf/plugins/kernel-netlink.opt
+++ b/conf/plugins/kernel-netlink.opt
@@ -116,3 +116,19 @@ charon.plugins.kernel-netlink.xfrm_acq_expires = 165
 	allocated by the kernel. The default value equals the total	retransmission
 	timeout for IKE messages, see IKEv2 RETRANSMISSION in
 	**strongswan.conf**(5).
+
+charon.plugins.kernel-netlink.preferred_rule_prio =
+	Priority of routing rule pointing to the routing table of the current
+	preferred network
+
+	On multihomed hosts, it is common to prioritize one network over the
+	other(s) (for example a modem with LTE over one with 2G). If policy
+	routing is used, this option can be set to the priority of the preferred
+	routing rule. I.e., the rule that points to the routing table of the
+	current preferred interface. When the rule is updated, the SAs will try
+	to be updated with MOBIKE using the preferred path. In order for this
+	option to have an effect, MOBIKE must be supported and enabled, and
+	charon.prefer_best_path set to yes.
+
+	Implementing the policy for which interface should be preferred and
+	updating the rule, is up to other applications.


### PR DESCRIPTION
On multihomed hosts, it is common to prioritize one network over the
other(s). For example, an LTE modem over a 2G modem, or a fixed
connection over a satellite connection. Typically, the system has no way
of knowing which interface to prioritize, as the actual network
interfaces looks the same (naming follows the same pattern, etc.). Also,
policies for selecting the preferred interface can be complex and use
multiple inputs (metadata, active checks, configuration options, etc.,
etc.)

Policy routing is commonly used on  multihomed hosts. The routes for the
different interfaces are placed in separate tables, and rules are used
to select which routing table(s) to check for a packet. This PR adds
support for specifying the priority of what I have called a preferred
rule. This rule will always point to the routing table of the preferred
network interface, and the rule is assumed to be updated by the tool
responsible for enforcing the network selection policy.

The feature is currently only available on Linux, and requires MOBIKE to
be enabled and "prefer_best_path" to be set to yes. When a rule with the
given priority is updated (i.e., a NEWRULE is received), a roam event is
triggered. Before the preferred route lookup is performed, a lookup for
the current priority table is done. Routes in this table is placed at
the front of the list that is used to select the preferred route.

The reason for not acting on DELRULE messages, is that I have assumed
that there can only be one preferred rule. Thus, if the rule is deleted,
then there is no preferred network and we can stay with the current one.

Signed-off-by: Kristian Evensen <kristian.evensen@gmail.com>