### PR TITLE
perl/Vici-Session: fix recv code and improve error handling

### DIFF
--- a/src/libcharon/plugins/vici/perl/Vici-Session/lib/Vici/Message.pm
+++ b/src/libcharon/plugins/vici/perl/Vici-Session/lib/Vici/Message.pm
@@ -107,13 +107,15 @@ sub parse {
                  }
                 else
                 {
-                    die "message parsing error: ", $type, "\n"
+                    $hash->{success} = 'no';
+                    $hash->{errmsg}  = 'message parsing error: '. $type;
                 }
             }
         }
         else
         {
-            die "message parsing error: ", $type, "\n"
+            $hash->{success} = 'no';
+            $hash->{errmsg}  = 'message parsing error: '. $type;
         }
     }
     return $data;

--- a/src/libcharon/plugins/vici/perl/Vici-Session/lib/Vici/Transport.pm
+++ b/src/libcharon/plugins/vici/perl/Vici-Session/lib/Vici/Transport.pm
@@ -21,13 +21,29 @@ sub send {
 
 sub receive {
     my $self = shift;
-    my $packet_header;
+    my $packet_header = "";
     my $data;
 
-    $self->{'Socket'}->recv($packet_header, 4);
+    my $header_len = 4;
+    while ($header_len) {
+        my $buf;
+        $self->{'Socket'}->recv($buf, $header_len);
+        return undef
+            unless length($buf);
+        $header_len -= length($buf);
+        $packet_header .= $buf;
+    }
     my $packet_len = unpack('N', $packet_header);
-    $self->{'Socket'}->recv($data, $packet_len);
-	return $data;
+    while ($packet_len) {
+        my $buf;
+        $self->{'Socket'}->recv($buf, $packet_len);
+        return undef
+            unless length($buf);
+        $packet_len -= length($buf);
+        $data //= "";
+        $data .= $buf;
+    }
+    return $data;
 }
 
 1;


### PR DESCRIPTION
the recv code now considers the situation of incomplete reads
(e.g. due to some interrupts).

error handling is improved to avoid termination of perl programs that
use the vici perl module.