### PR TITLE
child-delete: avoid duplicate calls of child_updown

### DIFF
--- a/src/libcharon/bus/bus.c
+++ b/src/libcharon/bus/bus.c
@@ -827,7 +827,7 @@ METHOD(bus_t, ike_updown, void,
 		enumerator = ike_sa->create_child_sa_enumerator(ike_sa);
 		while (enumerator->enumerate(enumerator, (void**)&child_sa))
 		{
-			if (child_sa->get_state(child_sa) != CHILD_REKEYED)
+			if (child_sa->get_state(child_sa) != CHILD_REKEYED && !child_sa->get_already_rekeyed(child_sa))
 			{
 				child_updown(this, child_sa, FALSE);
 			}

--- a/src/libcharon/sa/child_sa.c
+++ b/src/libcharon/sa/child_sa.c
@@ -1836,7 +1836,7 @@ child_sa_t * child_sa_create(host_t *me, host_t* other,
 		.mark_out = config->get_mark(config, FALSE),
 		.install_time = time_monotonic(NULL),
 		.policies_fwd_out = config->has_option(config, OPT_FWD_OUT_POLICIES),
-		.child_updown_called = false,
+		.already_rekeyed = false,
 	);
 
 	this->config = config;

--- a/src/libcharon/sa/child_sa.c
+++ b/src/libcharon/sa/child_sa.c
@@ -251,6 +251,11 @@ struct private_child_sa_t {
 	 * last number of outbound bytes
 	 */
 	uint64_t other_usepackets;
+
+	/**
+	 * TRUE if CHILD_SA is already rekeyed
+	 */
+	bool already_rekeyed;
 };
 
 /**
@@ -1625,6 +1630,16 @@ METHOD(child_sa_t, update, status_t,
 	return SUCCESS;
 }
 
+METHOD(child_sa_t, set_already_rekeyed, void, private_child_sa_t *this, bool v)
+{
+	this->already_rekeyed = v;
+}
+
+METHOD(child_sa_t, get_already_rekeyed, bool, private_child_sa_t *this)
+{
+	return this->already_rekeyed;
+}
+
 METHOD(child_sa_t, destroy, void,
 	   private_child_sa_t *this)
 {
@@ -1803,6 +1818,8 @@ child_sa_t * child_sa_create(host_t *me, host_t* other,
 			.create_ts_enumerator = _create_ts_enumerator,
 			.create_policy_enumerator = _create_policy_enumerator,
 			.destroy = _destroy,
+			.set_already_rekeyed = _set_already_rekeyed,
+			.get_already_rekeyed = _get_already_rekeyed,
 		},
 		.encap = encap,
 		.ipcomp = IPCOMP_NONE,
@@ -1819,6 +1836,7 @@ child_sa_t * child_sa_create(host_t *me, host_t* other,
 		.mark_out = config->get_mark(config, FALSE),
 		.install_time = time_monotonic(NULL),
 		.policies_fwd_out = config->has_option(config, OPT_FWD_OUT_POLICIES),
+		.child_updown_called = false,
 	);
 
 	this->config = config;

--- a/src/libcharon/sa/child_sa.h
+++ b/src/libcharon/sa/child_sa.h
@@ -493,7 +493,24 @@ struct child_sa_t {
 	 */
 	status_t (*update)(child_sa_t *this, host_t *me, host_t *other,
 					   linked_list_t *vips, bool encap);
+
+        /**
+         * Set this flag to remember that this CHILD_SA has already been rekeyed.
+	 * Relevant when calling child_updown.
+	 *
+	 * @param v		TRUE to indicate that this CHILD_SA is rekeyed
+         */
+        void (*set_already_rekeyed)(child_sa_t *this, bool v);
+
 	/**
+	 * Check if this CHILD_SA was already replaced via rekeying.
+	 * Even if not in state REKEYED anymore.
+	 *
+	 * @return		TRUE if rekeyed
+	 */
+        bool (*get_already_rekeyed)(child_sa_t *this);
+
+        /**
 	 * Destroys a child_sa.
 	 */
 	void (*destroy) (child_sa_t *this);

--- a/src/libcharon/sa/ikev2/tasks/child_delete.c
+++ b/src/libcharon/sa/ikev2/tasks/child_delete.c
@@ -472,8 +472,9 @@ METHOD(task_t, build_i, status_t,
 	log_children(this);
 	build_payloads(this, message);
 
-	if (!entry->rekeyed && this->expired)
-	{
+	if (entry->rekeyed) {
+		child_sa->set_already_rekeyed(child_sa, true);
+	} else if (this->expired){
 		child_cfg_t *child_cfg;
 
 		DBG1(DBG_IKE, "scheduling CHILD_SA recreate after hard expire");


### PR DESCRIPTION
if a CHILD_SA is rekeyed after the beginning of a ike_reauth()
there is a chance that the rekeyed CHILD_SA ends up in state DELETING.
This is due to charon.delete_rekeyed_delay being set to a high
value (like 100) in combination with make_before_break = yes.

In the course of completing ike_reauth() the old IKE_SA
gets destroyed via a call to ike_updown(). This implies calls to
child_updown() but in this situation the fact that the CHILD_SA
is already rekeyed cannot be identified anymore because the state
is already DELETING.