### PR TITLE
Use unused return value of C_GetMechanismList

### DIFF
--- a/src/libstrongswan/plugins/pkcs11/pkcs11_library.c
+++ b/src/libstrongswan/plugins/pkcs11/pkcs11_library.c
@@ -899,7 +899,7 @@ METHOD(pkcs11_library_t, create_mechanism_enumerator, enumerator_t*,
 		return enumerator_create_empty();
 	}
 	enumerator->mechs = malloc(sizeof(CK_MECHANISM_TYPE) * enumerator->count);
-	enumerator->lib->f->C_GetMechanismList(slot, enumerator->mechs,
+	rv = enumerator->lib->f->C_GetMechanismList(slot, enumerator->mechs,
 										   &enumerator->count);
 	if (rv != CKR_OK)
 	{


### PR DESCRIPTION
The pkcs11 plugin does not use the return value of the second `C_GetMechanismList` call, and thus won't detect if it failed.