### PR TITLE
Disable roaming (MOBIKE) for IKEv1

### DIFF
--- a/src/libcharon/processing/jobs/roam_job.c
+++ b/src/libcharon/processing/jobs/roam_job.c
@@ -69,13 +69,6 @@ METHOD(job_t, execute, job_requeue_t,
 		ike_sa = charon->ike_sa_manager->checkout(charon->ike_sa_manager, id);
 		if (ike_sa)
 		{
-			if (ike_sa->get_version(ike_sa) == IKEV1)
-			{
-				DBG2(DBG_IKE, "RFC4555 is only specified for IKEv2.");
-				charon->ike_sa_manager->checkin(charon->ike_sa_manager, ike_sa);
-				continue;
-			}
-
 			if (ike_sa->roam(ike_sa, this->address) == DESTROY_ME)
 			{
 				charon->ike_sa_manager->checkin_and_destroy(

--- a/src/libcharon/processing/jobs/roam_job.c
+++ b/src/libcharon/processing/jobs/roam_job.c
@@ -69,6 +69,13 @@ METHOD(job_t, execute, job_requeue_t,
 		ike_sa = charon->ike_sa_manager->checkout(charon->ike_sa_manager, id);
 		if (ike_sa)
 		{
+			if (ike_sa->get_version(ike_sa) == IKEV1)
+			{
+				DBG2(DBG_IKE, "RFC4555 is only specified for IKEv2.");
+				charon->ike_sa_manager->checkin(charon->ike_sa_manager, ike_sa);
+				continue;
+			}
+
 			if (ike_sa->roam(ike_sa, this->address) == DESTROY_ME)
 			{
 				charon->ike_sa_manager->checkin_and_destroy(

--- a/src/libcharon/sa/ike_sa.c
+++ b/src/libcharon/sa/ike_sa.c
@@ -2583,9 +2583,15 @@ METHOD(ike_sa_t, roam, status_t,
 		return SUCCESS;
 	}
 
+	if (!this->version == IKEV1)
+	{ 	/* ignore roam events for IKEv1 where we don't have MOBIKE and would
+		 * have to reestablish from scratch */
+		return SUCCESS;
+	}
+
 	/* ignore roam events if MOBIKE is not supported/enabled and the local
 	 * address is statically configured */
-	if (this->version == IKEV2 && !supports_extension(this, EXT_MOBIKE) &&
+	if (!supports_extension(this, EXT_MOBIKE) &&
 		ike_cfg_has_address(this->ike_cfg, this->my_host, TRUE))
 	{
 		DBG2(DBG_IKE, "keeping statically configured path %H - %H",

--- a/src/libcharon/sa/ike_sa.c
+++ b/src/libcharon/sa/ike_sa.c
@@ -2583,7 +2583,7 @@ METHOD(ike_sa_t, roam, status_t,
 		return SUCCESS;
 	}
 
-	if (!this->version == IKEV1)
+	if (this->version == IKEV1)
 	{ 	/* ignore roam events for IKEv1 where we don't have MOBIKE and would
 		 * have to reestablish from scratch */
 		return SUCCESS;


### PR DESCRIPTION
Hey guys,

I've encountered a problem where charon tries to roam a IKEv1 connection to another WAN Uplink.

Setup:
* I have two WAN Uplinks:
 1. static IP
 2. DHCP assigned IP
*I configure an IKEv1 connection with the config value for `left` with the IP address of the DHCP assigned interface. 
* charon correctly established the connection with the DHCP-assigned IP as source
* I force a DHCP-lease renewal for the DHCP-WAN interface
* charon tries to roam the connection to the second WAN Interface with the static IP

This leads to problems in our setups, since WAN1 and WAN2 are in different vlans.
Also RFC4555 (MOBIKE) is only specified for IKEv2, so i think this is a bug in charons IKEv1 implementation when it tries to roam IKEv1 too.

The roam_job is scheduled from the `kernel_iph_net.c` in case ` static void update_addrs(private_kernel_iph_net_t*, iface_t*, IP_ADAPTER_ADDRESSES*, bool)` is called (eg. when i force a DHCP-lease renewal on the WAN-Interface.

To prevent this, i submit this patch, which skips IKEv1 IKE-SAs in the `roam_job->execute()` method.

Kind Regards,
Cedric Kienzler
Software Engineer, Sophos

For further Questions, feel free to contact me at any time using cedric.kienzler@sophos.com