### PR TITLE
starter: dont lose signals 

### DIFF
--- a/src/starter/starter.c
+++ b/src/starter/starter.c
@@ -650,6 +650,7 @@ int main (int argc, char **argv)
 		 */
 		if (_action_ & FLAG_ACTION_RELOAD)
 		{
+			_action_ &= ~FLAG_ACTION_RELOAD;
 			if (starter_charon_pid())
 			{
 				for (conn = cfg->conn_first; conn; conn = conn->next)
@@ -679,7 +680,6 @@ int main (int argc, char **argv)
 					}
 				}
 			}
-			_action_ &= ~FLAG_ACTION_RELOAD;
 		}
 
 		/*
@@ -687,6 +687,7 @@ int main (int argc, char **argv)
 		 */
 		if (_action_ & FLAG_ACTION_UPDATE)
 		{
+			_action_ &= ~FLAG_ACTION_UPDATE;
 			DBG2(DBG_APP, "Reloading config...");
 			new_cfg = confread_load(config_file);
 
@@ -767,7 +768,6 @@ int main (int argc, char **argv)
 					confread_free(new_cfg);
 				}
 			}
-			_action_ &= ~FLAG_ACTION_UPDATE;
 			last_reload = time_monotonic(NULL);
 		}
 
@@ -776,6 +776,7 @@ int main (int argc, char **argv)
 		 */
 		if (_action_ & FLAG_ACTION_START_CHARON)
 		{
+			_action_ &= ~FLAG_ACTION_START_CHARON;
 			if (!starter_charon_pid())
 			{
 				DBG2(DBG_APP, "Attempting to start %s...", daemon_name);
@@ -786,7 +787,6 @@ int main (int argc, char **argv)
 				}
 				starter_stroke_configure(cfg);
 			}
-			_action_ &= ~FLAG_ACTION_START_CHARON;
 
 			for (ca = cfg->ca_first; ca; ca = ca->next)
 			{
@@ -853,6 +853,14 @@ int main (int argc, char **argv)
 					}
 				}
 			}
+		}
+
+ 		/*
+		 * Run again if there's pending action
+		 */
+		if (_action_)
+		{
+			continue;
 		}
 
 		/*

--- a/src/starter/starter.c
+++ b/src/starter/starter.c
@@ -855,14 +855,6 @@ int main (int argc, char **argv)
 			}
 		}
 
- 		/*
-		 * Run again if there's pending action
-		 */
-		if (_action_)
-		{
-			continue;
-		}
-
 		/*
 		 * If auto_update activated, when to stop select
 		 */


### PR DESCRIPTION
The starter will lose update / reload commands when there is a second signal coming in when the previous is still processed.

this can happen more easily with big configurations.