### PR TITLE
add support for typed ASN.1 DN strings

### DIFF
--- a/src/libstrongswan/utils/identification.c
+++ b/src/libstrongswan/utils/identification.c
@@ -98,6 +98,32 @@ static const x501rdn_t x501rdns[] = {
 	{"TCGID", 				OID_TCGID,					ASN1_PRINTABLESTRING}
 };
 
+
+/**
+ * coding of Tagged ASN1 Strings
+ */
+typedef struct {
+	const char* str;
+	size_t str_len;
+	asn1_t type;
+} asn1_string_type_t;
+
+static const asn1_string_type_t asn1_string_types[] = {
+	{ "UTF8STRING:",		11, ASN1_UTF8STRING			},
+	{ "NUMERICSTRING:",		14, ASN1_NUMERICSTRING 		},
+	{ "PRINTABLESTRING:",	16, ASN1_PRINTABLESTRING	},
+	{ "T61STRING:",			10, ASN1_T61STRING			},
+	{ "IA5STRING:",			10, ASN1_IA5STRING			},
+	{ "GRAPHICSTRING:",		14, ASN1_GRAPHICSTRING		},
+	{ "VISIBLESTRING:",		14, ASN1_VISIBLESTRING		},
+	{ "GENERALSTRING:",		14, ASN1_GENERALSTRING		},
+	{ "UNIVERSALSTRING:",	16, ASN1_UNIVERSALSTRING	},
+	{ "BMPSTRING:",			10, ASN1_BMPSTRING			},
+};
+
+
+#define ASN1_STRING_TYPE_COUNT (sizeof(asn1_string_types)/sizeof(asn1_string_types[0]))
+
 /**
  * maximum number of RDNs in atodn()
  */
@@ -407,7 +433,8 @@ static status_t atodn(char *src, chunk_t *dn)
 	int dn_len = 0;
 	int whitespace = 0;
 	int i = 0;
-	asn1_t rdn_type;
+	int j = 0;
+	asn1_t rdn_type = ASN1_INVALID;
 	state_t state = SEARCH_OID;
 	status_t status = SUCCESS;
 	char sep = '\0';
@@ -469,6 +496,16 @@ static status_t atodn(char *src, chunk_t *dn)
 				}
 				else if (*src != sep && *src != '\0')
 				{
+					for (j = 0; j < ASN1_STRING_TYPE_COUNT; j++)
+					{
+						asn1_string_type_t name_type = asn1_string_types[j];
+						if (strncmp(src, name_type.str, name_type.str_len) == 0)
+						{
+							rdn_type = name_type.type;
+							src += name_type.str_len;
+							break;
+						}
+					}
 					name.ptr = src;
 					name.len = 1;
 					whitespace = 0;
@@ -491,10 +528,12 @@ static status_t atodn(char *src, chunk_t *dn)
 				else
 				{
 					name.len -= whitespace;
-					rdn_type = (x501rdns[i].type == ASN1_PRINTABLESTRING
-								&& !asn1_is_printablestring(name))
-								? ASN1_UTF8STRING : x501rdns[i].type;
-
+					if (rdn_type == ASN1_INVALID)
+					{
+						rdn_type = (x501rdns[i].type == ASN1_PRINTABLESTRING
+									&& !asn1_is_printablestring(name))
+									? ASN1_UTF8STRING : x501rdns[i].type;
+					}
 					if (rdn_count < RDN_MAX)
 					{
 						chunk_t rdn_oid;


### PR DESCRIPTION
This change extends the atodn() function so it is capable of parsing
ASCII ASN.1 DN strings that tag the RDNs with its type.
Distinguished name strings of that sort can be produced with openssl:

	openssl x509 -nameopt RFC2253,show_type ...

this is needed if the guessed type by charon is wrong,
which will result in a not working connection.