### PR TITLE
Enable macOS native AES_GCM_ICV16 support

### DIFF
--- a/src/libcharon/plugins/kernel_pfkey/kernel_pfkey_ipsec.c
+++ b/src/libcharon/plugins/kernel_pfkey/kernel_pfkey_ipsec.c
@@ -891,6 +891,9 @@ static kernel_algorithm_t encryption_algs[] = {
 	{ENCR_AES_GCM_ICV12,		SADB_X_EALG_AES_GCM_ICV12	},
 	{ENCR_AES_GCM_ICV16,		SADB_X_EALG_AES_GCM_ICV16	},
 #endif
+#ifdef SADB_X_EALG_AES_GCM
+	{ENCR_AES_GCM_ICV16,		SADB_X_EALG_AES_GCM		},
+#endif
 #ifdef SADB_X_EALG_CAMELLIACBC
 	{ENCR_CAMELLIA_CBC,			SADB_X_EALG_CAMELLIACBC		},
 #endif


### PR DESCRIPTION
macOS seems to support AES_GCM_ICV16 natively using pfkey.

This change enables AES_GCM if the corresponding definition is detected in the ipsec headers.
With this change it is no longer necessary to use the `libipsec` module to use AES_GCM_ICV16 on macOS.

NOTE:
Because the Apple Configurator section for the native IKEv2 implementation had an option for AES_GCM I tried selecting this pfkey encryption method for AES_GCM_ICV16 and concluded that it worked after some simple testing. I tested this on an IPv4 tunnel, saw that the peer on the other side correctly identified my connection as aes-gcm-256, and was able to ping and ssh various computers on the remote network.

If there is some limitation to this implementation that makes it unfit to be included with strongswan yet, please disregard this PR.