### PR TITLE
charon-nm: Parse any type of private key in need_secrets

### DIFF
--- a/src/charon-nm/nm/nm_service.c
+++ b/src/charon-nm/nm/nm_service.c
@@ -698,7 +698,7 @@ static gboolean need_secrets(NMVpnServicePlugin *plugin, NMConnection *connectio
 
 				/* try to load/decrypt the private key */
 				key = lib->creds->create(lib->creds, CRED_PRIVATE_KEY,
-								KEY_RSA, BUILD_FROM_FILE, path, BUILD_END);
+								KEY_ANY, BUILD_FROM_FILE, path, BUILD_END);
 				if (key)
 				{
 					key->destroy(key);


### PR DESCRIPTION
Using the NetworkManager plugin, when the user supplies an ECDSA key for key authentication, the user is always asked to provide a password, even if the key is not encrypted. This patch fixes the issue.
Complement of 954f73e.