### PR TITLE
mysql: Replace in_use bool with rwlock

### DIFF
--- a/src/libstrongswan/plugins/mysql/mysql_database.c
+++ b/src/libstrongswan/plugins/mysql/mysql_database.c
@@ -264,7 +264,7 @@ static conn_t *conn_get(private_mysql_database_t *this, transaction_t **trans)
 			/* There is no more connection alive, so broadcast on the condvar
 			 * to resume execution of all threads that were waiting for a connection to be freed.
 			 */
-			if (this->pools->get_count(this->pools) == 0)
+			if (this->pool->get_count(this->pool) == 0)
 			{
 				this->mutex_condvar->lock(this->mutex_condvar);
 				this->condvar->broadcast(this->condvar);


### PR DESCRIPTION
This fixes a race condition in the driver which causes segfaults and mysql client libary errors due to uncoordinated usage of MYSQL structs.

There is a second issue that I discovered, that this patch does not deal with:
Some versions of the mysql client library (libmysqlclient and libmariadbclient) do not write to the buffer, even though the SELECT query executed successfully. Debugging that is hard, because the buffer then contains unitialised memory. To "fix" that, one could replace the malloc() calls for the buffers with calloc() and then, before returning the virtual IP in attr-sql, check if the IP is all zeroes and if it is (so the mysql client library is faulty), return an error instead.