### PR TITLE
dhcp: use "knl" subsystem for logging of RNG failure, not "cfg"

### DIFF
--- a/src/libcharon/plugins/dhcp/dhcp_socket.c
+++ b/src/libcharon/plugins/dhcp/dhcp_socket.c
@@ -746,7 +746,7 @@ dhcp_socket_t *dhcp_socket_create()
 
 	if (!this->rng)
 	{
-		DBG1(DBG_CFG, "unable to create RNG");
+		DBG1(DBG_KNL, "unable to create RNG");
 		destroy(this);
 		return NULL;
 	}


### PR DESCRIPTION
Follow example set in src/charon-tkm/src/tkm/tkm_kernel_ipsec.c

This is not a configuration error.