### PR TITLE
OpenSSL plugin invalid bounds check

### DIFF
--- a/src/libstrongswan/plugins/openssl/openssl_plugin.c
+++ b/src/libstrongswan/plugins/openssl/openssl_plugin.c
@@ -370,7 +370,7 @@ static private_key_t *openssl_private_key_connect(key_type_t type,
 #ifndef OPENSSL_NO_ENGINE
 	char *engine_id = NULL;
 	char keyname[BUF_LEN];
-	chunk_t keyid = chunk_empty;;
+	chunk_t keyid = chunk_empty;
 	EVP_PKEY *key;
 	ENGINE *engine;
 	int slot = -1;

--- a/src/libstrongswan/plugins/openssl/openssl_plugin.c
+++ b/src/libstrongswan/plugins/openssl/openssl_plugin.c
@@ -395,7 +395,7 @@ static private_key_t *openssl_private_key_connect(key_type_t type,
 		}
 		break;
 	}
-	if (!keyid.len || keyid.len > 40)
+	if (!keyid.len)
 	{
 		return NULL;
 	}

--- a/src/libstrongswan/plugins/openssl/openssl_plugin.c
+++ b/src/libstrongswan/plugins/openssl/openssl_plugin.c
@@ -405,7 +405,7 @@ static private_key_t *openssl_private_key_connect(key_type_t type,
 	{
 		snprintf(keyname, sizeof(keyname), "%d:", slot);
 	}
-	if (sizeof(keyname) - strlen(keyname) <= keyid.len * 4 / 3 + 1)
+	if (sizeof(keyname) - strlen(keyname) <= keyid.len * 2 + 1)
 	{
 		return NULL;
 	}


### PR DESCRIPTION
The openssl plugin contains an invalid length check.

It checks if a given `keyid` would fit into the `keyname` buffer in base64 encoding, however then the `keyid` is serialized in hex, resulting in a possible buffer overflow:

```C
       if (sizeof(keyname) - strlen(keyname) <= keyid.len * 4 / 3 + 1)
       {
                return NULL;
       }
       chunk_to_hex(keyid, keyname + strlen(keyname), FALSE);
```

Additionally I removed the `keyid.len > 40` bounds check as it's done implicitly by checking if the `keyid` would fit in the buffer.

Furthermore I removed the extra semicolon on line 373.
