### PR TITLE
Adopt child tasks

### DIFF
--- a/src/libcharon/sa/ike_sa.c
+++ b/src/libcharon/sa/ike_sa.c
@@ -2737,6 +2737,15 @@ METHOD(ike_sa_t, queue_task_delayed, void,
 	this->task_manager->queue_task_delayed(this->task_manager, task, delay);
 }
 
+METHOD(ike_sa_t, adopt_child_tasks, void,
+	private_ike_sa_t *this, ike_sa_t *other_public)
+{
+	private_ike_sa_t *other = (private_ike_sa_t*)other_public;
+
+	this->task_manager->adopt_child_tasks(this->task_manager,
+										  other->task_manager);
+}
+
 METHOD(ike_sa_t, inherit_pre, void,
 	private_ike_sa_t *this, ike_sa_t *other_public)
 {
@@ -3055,6 +3064,7 @@ ike_sa_t * ike_sa_create(ike_sa_id_t *ike_sa_id, bool initiator,
 			.flush_queue = _flush_queue,
 			.queue_task = _queue_task,
 			.queue_task_delayed = _queue_task_delayed,
+			.adopt_child_tasks = _adopt_child_tasks,
 #ifdef ME
 			.act_as_mediation_server = _act_as_mediation_server,
 			.get_server_reflexive_host = _get_server_reflexive_host,

--- a/src/libcharon/sa/ike_sa.c
+++ b/src/libcharon/sa/ike_sa.c
@@ -1747,6 +1747,12 @@ METHOD(ike_sa_t, remove_child_sa, void,
 	array_remove_at(this->child_sas, ce->inner);
 }
 
+METHOD(ike_sa_t, remove_child_tasks, linked_list_t *,
+	private_ike_sa_t *this)
+{
+	return this->task_manager->remove_child_tasks(this->task_manager);
+}
+
 METHOD(ike_sa_t, rekey_child_sa, status_t,
 	private_ike_sa_t *this, protocol_id_t protocol, uint32_t spi)
 {
@@ -3040,6 +3046,7 @@ ike_sa_t * ike_sa_create(ike_sa_id_t *ike_sa_id, bool initiator,
 			.get_child_count = _get_child_count,
 			.create_child_sa_enumerator = _create_child_sa_enumerator,
 			.remove_child_sa = _remove_child_sa,
+			.remove_child_tasks = _remove_child_tasks,
 			.rekey_child_sa = _rekey_child_sa,
 			.delete_child_sa = _delete_child_sa,
 			.destroy_child_sa = _destroy_child_sa,

--- a/src/libcharon/sa/ike_sa.h
+++ b/src/libcharon/sa/ike_sa.h
@@ -1148,6 +1148,13 @@ struct ike_sa_t {
 	void (*queue_task_delayed)(ike_sa_t *this, task_t *task, uint32_t delay);
 
 	/**
+	 * Adopt child creating tasks from the given IKE_SA.
+	 *
+	 * @param other			other IKE_SA to adopt tasks from
+	 */
+	void (*adopt_child_tasks)(ike_sa_t *this, ike_sa_t *other);
+
+	/**
 	 * Inherit required attributes to new SA before rekeying.
 	 *
 	 * Some properties of the SA must be applied before starting IKE_SA

--- a/src/libcharon/sa/ike_sa.h
+++ b/src/libcharon/sa/ike_sa.h
@@ -968,6 +968,13 @@ struct ike_sa_t {
 	void (*remove_child_sa) (ike_sa_t *this, enumerator_t *enumerator);
 
 	/**
+	 * Remove all active or queued CHILD_SA-creating tasks from this' manager.
+	 *
+	 * @return linked_list
+	 */
+	linked_list_t* (*remove_child_tasks)(ike_sa_t *this);
+
+	/**
 	 * Rekey the CHILD SA with the specified reqid.
 	 *
 	 * Looks for a CHILD SA owned by this IKE_SA, and start the rekeing.

--- a/src/libcharon/sa/ike_sa_manager.c
+++ b/src/libcharon/sa/ike_sa_manager.c
@@ -1967,6 +1967,8 @@ static void adopt_children_and_vips(ike_sa_t *old, ike_sa_t *new)
 	}
 	enumerator->destroy(enumerator);
 
+	new->adopt_child_tasks(new, old);
+
 	enumerator = old->create_virtual_ip_enumerator(old, FALSE);
 	while (enumerator->enumerate(enumerator, &vip))
 	{

--- a/src/libcharon/sa/task_manager.h
+++ b/src/libcharon/sa/task_manager.h
@@ -228,6 +228,14 @@ struct task_manager_t {
 	void (*adopt_tasks) (task_manager_t *this, task_manager_t *other);
 
 	/**
+	 * Remove all active or queued CHILD_SA-creating tasks from this
+	 *
+	 * The tasks are not yet migrate to any new IKE_SA. The caller is responsible
+	 * to free the list.
+	 */
+	linked_list_t * (*remove_child_tasks) (task_manager_t *this);
+
+	/**
 	 * Migrate all active or queued CHILD_SA-creating tasks from other to this.
 	 *
 	 * @param other			manager which gives away its tasks


### PR DESCRIPTION
@tobiasbrunner Could you please review the changes, in my tests adoption of tasks is working now.

Whats required?
Configure a connection with about 100 CHILD_SA's. While the initiator is processing the QUICK_MODE tasks, trigger an IKE rekeying/reauth on responder side.
The new IKE_SA should adopt the outstanding QUICK_MODE tasks and take over their processing from its predecessor.