### PR TITLE
add missing calls to ENGINE_finish()

### DIFF
--- a/src/libstrongswan/plugins/openssl/openssl_plugin.c
+++ b/src/libstrongswan/plugins/openssl/openssl_plugin.c
@@ -439,6 +439,7 @@ static private_key_t *openssl_private_key_connect(key_type_t type,
 	if (!login(engine, keyid))
 	{
 		DBG1(DBG_LIB, "login to engine '%s' failed", engine_id);
+		ENGINE_finish(engine);
 		ENGINE_free(engine);
 		return NULL;
 	}
@@ -447,9 +448,11 @@ static private_key_t *openssl_private_key_connect(key_type_t type,
 	{
 		DBG1(DBG_LIB, "failed to load private key with ID '%s' from "
 			 "engine '%s'", keyname, engine_id);
+		ENGINE_finish(engine);
 		ENGINE_free(engine);
 		return NULL;
 	}
+	ENGINE_finish(engine);
 	ENGINE_free(engine);
 
 	switch (EVP_PKEY_base_id(key))


### PR DESCRIPTION
see https://www.openssl.org/docs/man1.1.0/crypto/ENGINE_finish.html
for details.

Without calls to ENGINE_finish() memory is leaked.