### PR TITLE
swanctl: Add env var for swanctl conf dir

### DIFF
--- a/src/swanctl/commands/load_all.c
+++ b/src/swanctl/commands/load_all.c
@@ -31,7 +31,7 @@ static int load_all(vici_conn_t *conn)
 	bool clear = FALSE, noprompt = FALSE;
 	command_format_options_t format = COMMAND_FORMAT_NONE;
 	settings_t *cfg;
-	char *arg, *file = SWANCTL_CONF;
+	char *arg, *file = swanctl_conf();
 	int ret = 0;
 
 	while (TRUE)

--- a/src/swanctl/commands/load_authorities.c
+++ b/src/swanctl/commands/load_authorities.c
@@ -56,7 +56,7 @@ static bool add_file_key_value(vici_req_t *req, char *key, char *value)
 	{
 		path = buf;
 		snprintf(path, PATH_MAX, "%s%s%s",
-				 SWANCTL_X509CADIR, DIRECTORY_SEPARATOR, value);
+				 swanctl_x509ca_dir(), DIRECTORY_SEPARATOR, value);
 	}
 	map = chunk_map(path, FALSE);
 
@@ -310,7 +310,7 @@ static int load_authorities(vici_conn_t *conn)
 {
 	command_format_options_t format = COMMAND_FORMAT_NONE;
 	settings_t *cfg;
-	char *arg, *file = SWANCTL_CONF;
+	char *arg, *file = swanctl_conf();
 	int ret;
 
 	while (TRUE)

--- a/src/swanctl/commands/load_conns.c
+++ b/src/swanctl/commands/load_conns.c
@@ -121,19 +121,19 @@ static bool add_file_list_key(vici_req_t *req, char *key, char *value)
 				if (streq(key, "certs"))
 				{
 					snprintf(buf, sizeof(buf), "%s%s%s",
-							 SWANCTL_X509DIR, DIRECTORY_SEPARATOR, token);
+							 swanctl_x509_dir(), DIRECTORY_SEPARATOR, token);
 					token = buf;
 				}
 				else if (streq(key, "cacerts"))
 				{
 					snprintf(buf, sizeof(buf), "%s%s%s",
-							 SWANCTL_X509CADIR, DIRECTORY_SEPARATOR, token);
+							 swanctl_x509ca_dir(), DIRECTORY_SEPARATOR, token);
 					token = buf;
 				}
 				else if (streq(key, "pubkeys"))
 				{
 					snprintf(buf, sizeof(buf), "%s%s%s",
-							 SWANCTL_PUBKEYDIR, DIRECTORY_SEPARATOR, token);
+							 swanctl_pubkey_dir(), DIRECTORY_SEPARATOR, token);
 					token = buf;
 				}
 			}
@@ -425,7 +425,7 @@ static int load_conns(vici_conn_t *conn)
 {
 	command_format_options_t format = COMMAND_FORMAT_NONE;
 	settings_t *cfg;
-	char *arg, *file = SWANCTL_CONF;
+	char *arg, *file = swanctl_conf();
 	int ret;
 
 	while (TRUE)

--- a/src/swanctl/commands/load_creds.c
+++ b/src/swanctl/commands/load_creds.c
@@ -908,21 +908,21 @@ int load_creds_cfg(vici_conn_t *conn, command_format_options_t format,
 
 	get_creds(&ctx);
 
-	load_certs(&ctx, "x509",     SWANCTL_X509DIR);
-	load_certs(&ctx, "x509ca",   SWANCTL_X509CADIR);
-	load_certs(&ctx, "x509ocsp", SWANCTL_X509OCSPDIR);
-	load_certs(&ctx, "x509aa",   SWANCTL_X509AADIR);
-	load_certs(&ctx, "x509ac",   SWANCTL_X509ACDIR);
-	load_certs(&ctx, "x509crl",  SWANCTL_X509CRLDIR);
-	load_certs(&ctx, "pubkey",   SWANCTL_PUBKEYDIR);
+	load_certs(&ctx, "x509",     swanctl_x509_dir());
+	load_certs(&ctx, "x509ca",   swanctl_x509ca_dir());
+	load_certs(&ctx, "x509ocsp", swanctl_x509ocsp_dir());
+	load_certs(&ctx, "x509aa",   swanctl_x509aa_dir());
+	load_certs(&ctx, "x509ac",   swanctl_x509ac_dir());
+	load_certs(&ctx, "x509crl",  swanctl_x509crl_dir());
+	load_certs(&ctx, "pubkey",   swanctl_pubkey_dir());
 
-	load_keys(&ctx, "private", SWANCTL_PRIVATEDIR);
-	load_keys(&ctx, "rsa",     SWANCTL_RSADIR);
-	load_keys(&ctx, "ecdsa",   SWANCTL_ECDSADIR);
-	load_keys(&ctx, "bliss",   SWANCTL_BLISSDIR);
-	load_keys(&ctx, "pkcs8",   SWANCTL_PKCS8DIR);
+	load_keys(&ctx, "private", swanctl_private_dir());
+	load_keys(&ctx, "rsa",     swanctl_rsa_dir());
+	load_keys(&ctx, "ecdsa",   swanctl_ecdsa_dir());
+	load_keys(&ctx, "bliss",   swanctl_bliss_dir());
+	load_keys(&ctx, "pkcs8",   swanctl_pkcs8_dir());
 
-	load_containers(&ctx, "pkcs12", SWANCTL_PKCS12DIR);
+	load_containers(&ctx, "pkcs12", swanctl_pkcs12_dir());
 
 	load_tokens(&ctx);
 
@@ -946,7 +946,7 @@ static int load_creds(vici_conn_t *conn)
 	bool clear = FALSE, noprompt = FALSE;
 	command_format_options_t format = COMMAND_FORMAT_NONE;
 	settings_t *cfg;
-	char *arg, *file = SWANCTL_CONF;
+	char *arg, *file = swanctl_conf();
 	int ret;
 
 	while (TRUE)

--- a/src/swanctl/commands/load_pools.c
+++ b/src/swanctl/commands/load_pools.c
@@ -251,7 +251,7 @@ static int load_pools(vici_conn_t *conn)
 {
 	command_format_options_t format = COMMAND_FORMAT_NONE;
 	settings_t *cfg;
-	char *arg, *file = SWANCTL_CONF;
+	char *arg, *file = swanctl_conf();
 	int ret;
 
 	while (TRUE)

--- a/src/swanctl/swanctl.c
+++ b/src/swanctl/swanctl.c
@@ -13,11 +13,15 @@
  * for more details.
  */
 
+#include "swanctl.h"
 #include "command.h"
 
 #include <unistd.h>
 
 #include <library.h>
+
+/* Root directory for swanctl conf files */
+char *swanctl_dir;
 
 /**
  * Cleanup library atexit()
@@ -34,6 +38,7 @@ static void cleanup()
 int main(int argc, char *argv[])
 {
 	atexit(cleanup);
+	swanctl_dir = getenv("SWANCTL_DIR") ?: SWANCTLDIR;
 	if (!library_init(NULL, "swanctl"))
 	{
 		exit(SS_RC_LIBSTRONGSWAN_INTEGRITY);

--- a/src/swanctl/swanctl.h
+++ b/src/swanctl/swanctl.h
@@ -22,77 +22,167 @@
  * @{
  */
 
+#define _GNU_SOURCE
+#include <stdio.h>
+#include <unistd.h>
+
 #ifndef SWANCTL_H_
 #define SWANCTL_H_
+
+extern char *swanctl_dir;
 
 /**
  * Configuration file for connections, etc.
  */
-#define SWANCTL_CONF SWANCTLDIR "/swanctl.conf"
+static inline char *swanctl_conf() {
+  static char *path;
+  if (path == NULL && asprintf(&path, "%s/swanctl.conf", swanctl_dir) == -1) {
+    exit(1);
+  }
+  return path;
+}
 
 /**
  * Directory for X.509 end entity certs
  */
-#define SWANCTL_X509DIR SWANCTLDIR "/x509"
+static inline char *swanctl_x509_dir() {
+  static char *path;
+  if (path == NULL && asprintf(&path, "%s/x509", swanctl_dir) == -1) {
+    exit(1);
+  }
+  return path;
+}
 
 /**
  * Directory for X.509 CA certs
  */
-#define SWANCTL_X509CADIR SWANCTLDIR "/x509ca"
+static inline char *swanctl_x509ca_dir() {
+  static char *path;
+  if (path == NULL && asprintf(&path, "%s/x509ca", swanctl_dir) == -1) {
+    exit(1);
+  }
+  return path;
+}
 
 /**
  * Directory for X.509 Attribute Authority certs
  */
-#define SWANCTL_X509AADIR SWANCTLDIR "/x509aa"
+static inline char *swanctl_x509aa_dir() {
+  static char *path;
+  if (path == NULL && asprintf(&path, "%s/x509aa", swanctl_dir) == -1) {
+    exit(1);
+  }
+  return path;
+}
 
 /**
  * Directory for X.509 OCSP Signer certs
  */
-#define SWANCTL_X509OCSPDIR SWANCTLDIR "/x509ocsp"
+static inline char *swanctl_x509ocsp_dir() {
+  static char *path;
+  if (path == NULL && asprintf(&path, "%s/x509ocsp", swanctl_dir) == -1) {
+    exit(1);
+  }
+  return path;
+}
 
 /**
  * Directory for X.509 CRLs
  */
-#define SWANCTL_X509CRLDIR SWANCTLDIR "/x509crl"
+static inline char *swanctl_x509crl_dir() {
+  static char *path;
+  if (path == NULL && asprintf(&path, "%s/x509crl", swanctl_dir) == -1) {
+    exit(1);
+  }
+  return path;
+}
 
 /**
  * Directory for X.509 Attribute certificates
  */
-#define SWANCTL_X509ACDIR SWANCTLDIR "/x509ac"
+static inline char *swanctl_x509ac_dir() {
+  static char *path;
+  if (path == NULL && asprintf(&path, "%s/x509ac", swanctl_dir) == -1) {
+    exit(1);
+  }
+  return path;
+}
 
 /**
  * Directory for raw public keys
  */
-#define SWANCTL_PUBKEYDIR SWANCTLDIR "/pubkey"
+static inline char *swanctl_pubkey_dir() {
+  static char *path;
+  if (path == NULL && asprintf(&path, "%s/pubkey", swanctl_dir) == -1) {
+    exit(1);
+  }
+  return path;
+}
 
 /**
  * Directory for private keys
  */
-#define SWANCTL_PRIVATEDIR SWANCTLDIR "/private"
+static inline char *swanctl_private_dir() {
+  static char *path;
+  if (path == NULL && asprintf(&path, "%s/private", swanctl_dir) == -1) {
+    exit(1);
+  }
+  return path;
+}
 
 /**
  * Directory for RSA private keys
  */
-#define SWANCTL_RSADIR SWANCTLDIR "/rsa"
+static inline char *swanctl_rsa_dir() {
+  static char *path;
+  if (path == NULL && asprintf(&path, "%s/rsa", swanctl_dir) == -1) {
+    exit(1);
+  }
+  return path;
+}
 
 /**
  * Directory for ECDSA private keys
  */
-#define SWANCTL_ECDSADIR SWANCTLDIR "/ecdsa"
+static inline char *swanctl_ecdsa_dir() {
+  static char *path;
+  if (path == NULL && asprintf(&path, "%s/ecdsa", swanctl_dir) == -1) {
+    exit(1);
+  }
+  return path;
+}
 
 /**
  * Directory for BLISS private keys
  */
-#define SWANCTL_BLISSDIR SWANCTLDIR "/bliss"
+static inline char *swanctl_bliss_dir() {
+  static char *path;
+  if (path == NULL && asprintf(&path, "%s/bliss", swanctl_dir) == -1) {
+    exit(1);
+  }
+  return path;
+}
 
 /**
  * Directory for PKCS#8 encoded private keys
  */
-#define SWANCTL_PKCS8DIR SWANCTLDIR "/pkcs8"
+static inline char *swanctl_pkcs8_dir() {
+  static char *path;
+  if (path == NULL && asprintf(&path, "%s/pkcs8", swanctl_dir) == -1) {
+    exit(1);
+  }
+  return path;
+}
 
 /**
  * Directory for PKCS#12 containers
  */
-#define SWANCTL_PKCS12DIR SWANCTLDIR "/pkcs12"
+static inline char *swanctl_pkcs12_dir() {
+  static char *path;
+  if (path == NULL && asprintf(&path, "%s/pkcs12", swanctl_dir) == -1) {
+    exit(1);
+  }
+  return path;
+}
 
 #endif /** SWANCTL_H_ @}*/


### PR DESCRIPTION
Currently, `SWANCTLDIR` is set at compile time. This hinders the distribution of any strongswan binary utilizing `swanctl` e.g `charon-systemd`. In contrast, `STRONGSWAN_CONF`, which holds the path to `strongswan.conf`, is set at runtime.

To fix this, this PR adds the environment variable `SWANCTL_DIR` to hold the path to the `swanctl` directory. This variable overrides `SWANCTLDIR`. 