### PR TITLE
libtpmtss: Read public key exponent instead of assuming its value.

### DIFF
--- a/src/libtpmtss/tpm_tss_tss2_v1.c
+++ b/src/libtpmtss/tpm_tss_tss2_v1.c
@@ -481,14 +481,23 @@ METHOD(tpm_tss_t, get_public, chunk_t,
 			TPM2B_PUBLIC_KEY_RSA *rsa;
 			TPMT_RSA_SCHEME *scheme;
 			chunk_t aik_exponent, aik_modulus;
+			uint32_t exponent;
 
 			scheme = &public.t.publicArea.parameters.rsaDetail.scheme;
 			sig_alg   = scheme->scheme;
 			digest_alg = scheme->details.anySig.hashAlg;
+			exponent = public.t.publicArea.parameters.rsaDetail.exponent;
 
 			rsa = &public.t.publicArea.unique.rsa;
 			aik_modulus = chunk_create(rsa->t.buffer, rsa->t.size);
-			aik_exponent = chunk_from_chars(0x01, 0x00, 0x01);
+			if (exponent == 0)
+			{
+				aik_exponent = chunk_from_chars(0x01, 0x00, 0x01);
+			}
+			else
+			{
+				aik_exponent = chunk_from_thing(exponent);
+			}
 
 			/* subjectPublicKeyInfo encoding of RSA public key */
 			if (!lib->encoding->encode(lib->encoding, PUBKEY_SPKI_ASN1_DER,

--- a/src/libtpmtss/tpm_tss_tss2_v2.c
+++ b/src/libtpmtss/tpm_tss_tss2_v2.c
@@ -435,14 +435,23 @@ METHOD(tpm_tss_t, get_public, chunk_t,
 			TPM2B_PUBLIC_KEY_RSA *rsa;
 			TPMT_RSA_SCHEME *scheme;
 			chunk_t aik_exponent, aik_modulus;
+			uint32_t exponent;
 
 			scheme = &public.publicArea.parameters.rsaDetail.scheme;
 			sig_alg   = scheme->scheme;
 			digest_alg = scheme->details.anySig.hashAlg;
+			exponent = public.publicArea.parameters.rsaDetail.exponent;
 
 			rsa = &public.publicArea.unique.rsa;
 			aik_modulus = chunk_create(rsa->buffer, rsa->size);
-			aik_exponent = chunk_from_chars(0x01, 0x00, 0x01);
+			if (exponent == 0)
+			{
+				aik_exponent = chunk_from_chars(0x01, 0x00, 0x01);
+			}
+			else
+			{
+				aik_exponent = chunk_from_thing(exponent);
+			}
 
 			/* subjectPublicKeyInfo encoding of RSA public key */
 			if (!lib->encoding->encode(lib->encoding, PUBKEY_SPKI_ASN1_DER,


### PR DESCRIPTION
Up to now it was assumed that the RSA public key exponent is equal to 2^16+1. Although this is probably true in the most if not all cases, it is not correct according to the TPM specification.

This patch fixes that by reading the exponent from an appropriate of the structure returned by TPM2_ReadPublic.

The above mentioned standard can be find [here](https://trustedcomputinggroup.org/wp-content/uploads/TPM-Rev-2.0-Part-2-Structures-01.38.pdf#page=149).