### PR TITLE
Support reloading in strongswan.service

### DIFF
--- a/init/systemd/strongswan.service.in
+++ b/init/systemd/strongswan.service.in
@@ -4,6 +4,7 @@ After=syslog.target network-online.target
 
 [Service]
 ExecStart=@SBINDIR@/@IPSEC_SCRIPT@ start --nofork
+ExecReload=@SBINDIR@/@IPSEC_SCRIPT@ reload
 StandardOutput=syslog
 Restart=on-abnormal
 


### PR DESCRIPTION
strongSwan supports reloading config without disrupting connections via `ipsec reload`. Outside of strongSwan, the most popular service–agnostic way to reload a service is via `systemctl reload <foo>.service`.

By adding an `ExecReload=` line to the systemd unit file, we can trivially support this use case too.