### PR TITLE
ikev1: don't trigger updown events for redundant QMs

### DIFF
--- a/src/libcharon/sa/child_sa.c
+++ b/src/libcharon/sa/child_sa.c
@@ -1901,3 +1901,24 @@ child_sa_t * child_sa_create(host_t *me, host_t* other,
 	}
 	return &this->public;
 }
+
+/**
+ * Described in header.
+ */
+bool child_sa_have_equal_ts(child_sa_t *child1, child_sa_t *child2, bool local)
+{
+	enumerator_t *e1, *e2;
+	traffic_selector_t *ts1, *ts2;
+	bool equal = FALSE;
+
+	e1 = child1->create_ts_enumerator(child1, local);
+	e2 = child2->create_ts_enumerator(child2, local);
+	if (e1->enumerate(e1, &ts1) && e2->enumerate(e2, &ts2))
+	{
+		equal = ts1->equals(ts1, ts2);
+	}
+	e2->destroy(e2);
+	e1->destroy(e1);
+
+	return equal;
+}

--- a/src/libcharon/sa/child_sa.h
+++ b/src/libcharon/sa/child_sa.h
@@ -520,4 +520,16 @@ child_sa_t * child_sa_create(host_t *me, host_t *other, child_cfg_t *config,
 							 uint32_t reqid, bool encap,
 							 u_int mark_in, u_int mark_out);
 
+/**
+ * Check if two CHILD_SAs have the same traffic selector.
+ *
+ * @param child1			first child_sa_t object to compare
+ * @param child2			second child_sa_t object to compare
+ * @param local				TRUE to to compare local traffic selector, FALSE for remote
+ * @return					TRUE if both chidl_sa_t objects have the same
+ *						traffic selectors
+ */
+
+bool child_sa_have_equal_ts(child_sa_t *child1, child_sa_t *child2, bool local);
+
 #endif /** CHILD_SA_H_ @}*/


### PR DESCRIPTION
With charon.delete_rekeyed=no redundant QMs might result
in an unenven number of updown calls. E.g. too many down
calls.

To solve this, the idea is update the state for redundant
Child SA to CHILD_REKEYED only if charon.delete_rekeyed is
enabled. This should also maintain the original behavior
as intended by commit a01eb5e4, to avoid another updown
hook trigger.

Additionally a redundant QM check is required for incoming QM
delete requests, to avoid again an unintended updown call.

Fixes #2902.