### PR TITLE
workaround for MySQL problem where mysql_stmt_fetch_column() fails to…

### DIFF
--- a/src/libstrongswan/plugins/mysql/mysql_database.c
+++ b/src/libstrongswan/plugins/mysql/mysql_database.c
@@ -207,6 +207,7 @@ static conn_t *conn_get(private_mysql_database_t *this, transaction_t **trans)
 	conn_t *current, *found = NULL;
 	enumerator_t *enumerator;
 	transaction_t *transaction;
+	my_bool no = 0;
 
 	thread_initialize();
 
@@ -256,6 +257,9 @@ static conn_t *conn_get(private_mysql_database_t *this, transaction_t **trans)
 			.in_use = TRUE,
 			.mysql = mysql_init(NULL),
 		);
+
+		mysql_options(found->mysql, MYSQL_REPORT_DATA_TRUNCATION, &no);
+
 		if (!mysql_real_connect(found->mysql, this->host, this->username,
 								this->password, this->database, this->port,
 								NULL, 0))


### PR DESCRIPTION
… retrieve fields from a set row previously fetched but not stored locally

Hello folks,

I ran into the following issue, for which this pull request would provide a solution. A simple attempt to use the sql plugin based on the example sql configuration provided under [strongswan data.sql](https://wiki.strongswan.org/projects/strongswan/repository/entry/testing/tests/sql/ip-pool-db/hosts/moon/etc/ipsec.d/data.sql) resulted in the following problem:


    Feb  5 12:46:13 ip-172-24-1-179 charon: 17[LIB] resolving '?' failed: Temporary failure in name resolution

This is referring to the `local` and `remote` addresses configured in the `ike_configs` table. Then I checked the configured connections as pulled from the SQL database:

```
Connections:
           ?:  ?...?  IKEv2, dpddelay=120s
           ?:   local:  [%any] uses public key authentication
           ?:   remote: [80:00:00:b0:d6] uses any authentication
          @?:   child:  10.1.0.0/16 === dynamic TUNNEL, dpdaction=clear
Security Associations (0 up, 0 connecting):
  none
```

Those `?` threw me off.. so I dug deeper.. I could see that the SQL query issued to the database:

```
mysql> SELECT c.id, c.certreq, c.force_encap, c.local, c.remote FROM ike_configs AS c;
+----+---------+-------------+---------+---------+
| id | certreq | force_encap | local   | remote  |
+----+---------+-------------+---------+---------+
|  1 |       1 |           0 | 0.0.0.0 | 0.0.0.0 |
+----+---------+-------------+---------+---------+
```

Looks fine for my test purposes.. so.. digging deeper, it appears that the problem was here:

`src/libstrongswan/plugins/mysql/mysql_database.c:507`:

```case MYSQL_TYPE_STRING:
                        {
                                char **value = va_arg(args, char**);
                                this->bind[i].buffer = malloc(this->length[i]+1);
                                this->bind[i].buffer_length = this->length[i];
                                *value = this->bind[i].buffer;
                                mysql_stmt_fetch_column(this->stmt, &this->bind[i], i, 0);
                                ((char*)this->bind[i].buffer)[this->length[i]] = '\0';
                                break;
                        }
```

I could see that the call to `mysql_stmt_fetch_column` didn't fill in the value of the string into the bound buffer.  After some googling, it appears that I ran into a MySQL problem where unless one fetches the entire result set into local memory with `mysql_stmt_store_result()` after the call to `mysql_stmt_bind()` , the above mentioned function will fail to fill in the data as expected. One workaround appears to be turning off the `MYSQL_REPORT_DATA_TRUNCATION` connection option. Indeed, I did that and voila!:

```Connections:
         mac:  0.0.0.0...0.0.0.0  IKEv2, dpddelay=120s
         mac:   local:  [%any] uses public key authentication
         mac:   remote: [erick] uses any authentication
         mac:   child:  10.1.0.0/16 === dynamic TUNNEL, dpdaction=clear
```

The local and remote addresses are retrieved as configured in the SQL database.

So this pull request sets this option. The only thing I don't understand is why is this happening only to me and no one else has noticed.. the example I am trying is straight from the example set and my sql version is anything but obscure

`mysql  Ver 14.14 Distrib 5.7.24, for Linux (x86_64) using  EditLine wrapper`

Thanks!