### PR TITLE
sqlplugin fails on unspecified Remote Id

### DIFF
--- a/src/libcharon/plugins/sql/sql_cred.c
+++ b/src/libcharon/plugins/sql/sql_cred.c
@@ -300,7 +300,7 @@ METHOD(credential_set_t, create_shared_enumerator, enumerator_t*,
 				"JOIN identities AS m ON sm.identity = m.id "
 				"JOIN shared_secret_identity AS so ON s.id = so.shared_secret "
 				"JOIN identities AS o ON so.identity = o.id "
-				"WHERE m.type = ? AND m.data = ? AND o.type = ? AND o.data = ? "
+				"WHERE m.type = ? AND m.data = IFNULL(?,'%any') AND o.type = ? AND o.data = ? "
 				"AND (? OR s.type = ?)",
 				DB_INT, me->get_type(me), DB_BLOB, me->get_encoding(me),
 				DB_INT, other->get_type(other), DB_BLOB, other->get_encoding(other),


### PR DESCRIPTION
Hi,
I'm facing a problem while using the sql plugin. 

In my case strongswan acts as a responder and should fetch a pre-shared-key from MySQL.
The problem arises if the sender lets the Remote Identity unspecified in IKE AUTH.
i.e
```
 charon: 07[CFG] looking for peer configs matching 192.168.26.55[%any]...172.24.0.91[172.24.0.91]
```


the sql plugin issues then a query like this:

`
SELECT s.type, s.data FROM shared_secrets AS s JOIN shared_secret_identity AS sm ON s.id = sm.shared_secret JOIN identities AS m ON sm.identity = m.id JOIN shared_secret_identity AS so ON s.id = so.shared_secret JOIN identities AS o ON so.identity = o.id WHERE m.type = 0 AND m.data = NULL AND o.type = 1 AND o.data = '�\0[' AND (0 OR s.type = 1) 
`

note the `m.data = NULL `here, which prevents the query from returning the psk.
Subsequently the authentication fails

```
charon: 13[IKE] no shared key found for '%any' - '172.24.0.91'
```

This patch takes advantage of the IFNULL function which is available in both SQLite and MySQL.

I suspect that there are different situations that might fail in the same way and there might be better ways to fix this than this. 
However since I'm fairly new to the strongswan codebase, I'm thinking that it's better to have someone with more insight looking over this early.


