### PR TITLE
Remove temporary DROP policy using same parameters as when added.

### DIFF
--- a/src/libcharon/sa/child_sa.c
+++ b/src/libcharon/sa/child_sa.c
@@ -1592,7 +1592,7 @@ METHOD(child_sa_t, update, status_t,
 				del_policies_outbound(this, this->my_addr, this->other_addr,
 						old_my_ts ?: my_ts, old_other_ts ?: other_ts,
 						&my_sa, &other_sa, POLICY_DROP,
-						POLICY_PRIORITY_DEFAULT, 0);
+						POLICY_PRIORITY_DEFAULT, manual_prio);
 			}
 
 			DESTROY_IF(old_my_ts);


### PR DESCRIPTION
A temporary DROP policy is added to avoid traffic leak
while the SA is being updated. It is added with
manual_prio set but when the temporary policy is removed
it is removed with manual_prio parameter set to 0.
The call to del_policies_outbound does not match the original
policy and we end up with an ever increasing refcount.

If we try to manually remove the policy, it is not removed
due to the positive refcount. Then new SA requests fail with
"unable to install policy out for reqid 1618,
the same policy for reqid 1528 exists"