### PR TITLE
trap-manager: Wait for install to finish before uninstalling

### DIFF
--- a/src/libcharon/sa/trap_manager.c
+++ b/src/libcharon/sa/trap_manager.c
@@ -352,6 +352,11 @@ METHOD(trap_manager_t, uninstall, bool,
 	entry_t *entry, *found = NULL;
 
 	this->lock->write_lock(this->lock);
+	while (this->installing)
+	{
+		this->condvar->wait(this->condvar, this->lock);
+	}
+
 	enumerator = this->traps->create_enumerator(this->traps);
 	while (enumerator->enumerate(enumerator, &entry))
 	{


### PR DESCRIPTION
There was a race condition between install() and uninstall()
where one thread was in the process of installing a trap
entry, and the child_sa destroyed previously, while the other
thread was uninstalling the same trap entry and ended up
trying to destroy the already destroyed child_sa, resulting
in a segmentation fault in the destroy_entry() function.

The uninstall() function needs to wait until all the threads
are done with the installing before proceeding to uninstall
a trap entry.