### PR TITLE
configure: Add config option for external signal handling

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -320,6 +320,7 @@ ARG_ENABL_SET([leak-detective], [enable malloc hooks to find memory leaks.])
 ARG_ENABL_SET([lock-profiler],  [enable lock/mutex profiling code.])
 ARG_ENABL_SET([log-thread-ids], [use thread ID, if available, instead of an incremented value starting from 1, to identify threads.])
 ARG_ENABL_SET([monolithic],     [build monolithic version of libstrongswan that includes all enabled plugins. Similarly, the plugins of charon are assembled in libcharon.])
+ARG_ENABL_SET([ext-sig-hdlr],   [enable external handling of SIGSEGV, SIGILL, and SIGBUS signals raised by threads])
 
 # ===================================
 #  option to disable default options
@@ -1783,6 +1784,9 @@ if test x$fuzzing = xtrue; then
 fi
 if test x$imc_swima = xtrue -o x$imv_swima = xtrue; then
 	AC_DEFINE([USE_JSON], [], [build code for JSON])
+fi
+if test x$ext_sig_hdlr = xtrue; then
+	AC_DEFINE([USE_EXT_SIG_HANDLER], [], [enable external handling of SIGSEGV, SIGILL, and SIGBUS signals])
 fi
 
 # ====================================================

--- a/configure.ac
+++ b/configure.ac
@@ -320,7 +320,6 @@ ARG_ENABL_SET([leak-detective], [enable malloc hooks to find memory leaks.])
 ARG_ENABL_SET([lock-profiler],  [enable lock/mutex profiling code.])
 ARG_ENABL_SET([log-thread-ids], [use thread ID, if available, instead of an incremented value starting from 1, to identify threads.])
 ARG_ENABL_SET([monolithic],     [build monolithic version of libstrongswan that includes all enabled plugins. Similarly, the plugins of charon are assembled in libcharon.])
-ARG_ENABL_SET([ext-sig-hdlr],   [enable external handling of SIGSEGV, SIGILL, and SIGBUS signals raised by threads])
 
 # ===================================
 #  option to disable default options
@@ -1784,9 +1783,6 @@ if test x$fuzzing = xtrue; then
 fi
 if test x$imc_swima = xtrue -o x$imv_swima = xtrue; then
 	AC_DEFINE([USE_JSON], [], [build code for JSON])
-fi
-if test x$ext_sig_hdlr = xtrue; then
-	AC_DEFINE([USE_EXT_SIG_HANDLER], [], [enable external handling of SIGSEGV, SIGILL, and SIGBUS signals])
 fi
 
 # ====================================================

--- a/src/charon-cmd/charon-cmd.c
+++ b/src/charon-cmd/charon-cmd.c
@@ -174,6 +174,7 @@ static bool lookup_uid_gid()
 	return TRUE;
 }
 
+#ifndef DISABLE_SIGNAL_HANDLER
 /**
  * Handle SIGSEGV/SIGILL signals raised by threads
  */
@@ -189,6 +190,7 @@ static void segv_handler(int signal)
 	DBG1(DBG_DMN, "killing ourself, received critical signal");
 	abort();
 }
+#endif /* DISABLE_SIGNAL_HANDLER */
 
 /**
  * Print command line usage and exit
@@ -374,16 +376,24 @@ int main(int argc, char *argv[])
 
 	/* add handler for SEGV and ILL,
 	 * INT, TERM and HUP are handled by sigwaitinfo() in run() */
-	action.sa_handler = segv_handler;
 	action.sa_flags = 0;
 	sigemptyset(&action.sa_mask);
 	sigaddset(&action.sa_mask, SIGINT);
 	sigaddset(&action.sa_mask, SIGTERM);
 	sigaddset(&action.sa_mask, SIGHUP);
 	sigaddset(&action.sa_mask, SIGUSR1);
+
+	/*
+	 * Let the external system handle the SIGSEGV, SIGILL, and SIGBUS
+	 * signals if DISABLE_SIGNAL_HANDLER is defined.
+	 */
+#ifndef DISABLE_SIGNAL_HANDLER
+	action.sa_handler = segv_handler;
 	sigaction(SIGSEGV, &action, NULL);
 	sigaction(SIGILL, &action, NULL);
 	sigaction(SIGBUS, &action, NULL);
+#endif /* DISABLE_SIGNAL_HANDLER */
+
 	action.sa_handler = SIG_IGN;
 	sigaction(SIGPIPE, &action, NULL);
 

--- a/src/charon-nm/charon-nm.c
+++ b/src/charon-nm/charon-nm.c
@@ -109,6 +109,7 @@ static void run()
 	}
 }
 
+#ifndef DISABLE_SIGNAL_HANDLER
 /**
  * Handle SIGSEGV/SIGILL signals raised by threads
  */
@@ -124,6 +125,7 @@ static void segv_handler(int signal)
 	DBG1(DBG_DMN, "killing ourself, received critical signal");
 	abort();
 }
+#endif /* DISABLE_SIGNAL_HANDLER */
 
 /**
  * Lookup UID and GID
@@ -227,14 +229,22 @@ int main(int argc, char *argv[])
 
 	/* add handler for SEGV and ILL,
 	 * INT and TERM are handled by sigwaitinfo() in run() */
-	action.sa_handler = segv_handler;
 	action.sa_flags = 0;
 	sigemptyset(&action.sa_mask);
 	sigaddset(&action.sa_mask, SIGINT);
 	sigaddset(&action.sa_mask, SIGTERM);
+
+	/*
+	 * Let the external system handle the SIGSEGV, SIGILL, and SIGBUS
+	 * signals if DISABLE_SIGNAL_HANDLER is defined.
+	 */
+#ifndef DISABLE_SIGNAL_HANDLER
+	action.sa_handler = segv_handler;
 	sigaction(SIGSEGV, &action, NULL);
 	sigaction(SIGILL, &action, NULL);
 	sigaction(SIGBUS, &action, NULL);
+#endif /* DISABLE_SIGNAL_HANDLER */
+
 	action.sa_handler = SIG_IGN;
 	sigaction(SIGPIPE, &action, NULL);
 

--- a/src/charon-tkm/src/charon-tkm.c
+++ b/src/charon-tkm/src/charon-tkm.c
@@ -133,6 +133,7 @@ static void run()
 	}
 }
 
+#ifndef DISABLE_SIGNAL_HANDLER
 /**
  * Handle SIGSEGV/SIGILL signals raised by threads
  */
@@ -148,6 +149,7 @@ static void segv_handler(int signal)
 	DBG1(DBG_DMN, "killing ourself, received critical signal");
 	abort();
 }
+#endif /* DISABLE_SIGNAL_HANDLER */
 
 /**
  * Lookup UID and GID
@@ -374,14 +376,22 @@ int main(int argc, char *argv[])
 
 	/* add handler for SEGV and ILL,
 	 * INT and TERM are handled by sigwaitinfo() in run() */
-	action.sa_handler = segv_handler;
 	action.sa_flags = 0;
 	sigemptyset(&action.sa_mask);
 	sigaddset(&action.sa_mask, SIGINT);
 	sigaddset(&action.sa_mask, SIGTERM);
+
+	/*
+	 * Let the external system handle the SIGSEGV, SIGILL, and SIGBUS
+	 * signals if DISABLE_SIGNAL_HANDLER is defined.
+	 */
+#ifndef DISABLE_SIGNAL_HANDLER
+	action.sa_handler = segv_handler;
 	sigaction(SIGSEGV, &action, NULL);
 	sigaction(SIGILL, &action, NULL);
 	sigaction(SIGBUS, &action, NULL);
+#endif /* DISABLE_SIGNAL_HANDLER */
+
 	action.sa_handler = SIG_IGN;
 	sigaction(SIGPIPE, &action, NULL);
 

--- a/src/charon/charon.c
+++ b/src/charon/charon.c
@@ -446,9 +446,18 @@ int main(int argc, char *argv[])
 	sigaddset(&action.sa_mask, SIGINT);
 	sigaddset(&action.sa_mask, SIGTERM);
 	sigaddset(&action.sa_mask, SIGHUP);
+
+	/*
+	 * By default, charon internally handles the SIGSEGV, SIGILL, and SIGBUS
+	 * signals raised by threads (segv_handler). Make this configurable so
+	 * that the signal handling can be done either internally or externally.
+	 */
+#ifndef USE_EXT_SIG_HANDLER
 	sigaction(SIGSEGV, &action, NULL);
 	sigaction(SIGILL, &action, NULL);
 	sigaction(SIGBUS, &action, NULL);
+#endif /* USE_EXT_SIG_HANDLER */
+
 	action.sa_handler = SIG_IGN;
 	sigaction(SIGPIPE, &action, NULL);
 


### PR DESCRIPTION
By default, charon internally handles the SIGSEGV,
SIGILL, and SIGBUS signals raised by threads
(segv_handler). Make this configurable so that the
signal handling can be done either internally or
externally.