### PR TITLE
ikev1: Don't trigger child_updown UP event on redundant Child_SAs

### DIFF
--- a/src/libcharon/sa/ikev1/tasks/quick_mode.c
+++ b/src/libcharon/sa/ikev1/tasks/quick_mode.c
@@ -49,6 +49,7 @@
 #include <encoding/payloads/ke_payload.h>
 #include <encoding/payloads/id_payload.h>
 #include <encoding/payloads/payload.h>
+#include <sa/ikev1/task_manager_v1.h>
 #include <sa/ikev1/tasks/informational.h>
 #include <sa/ikev1/tasks/quick_delete.h>
 #include <processing/jobs/inactivity_job.h>
@@ -420,7 +421,7 @@ static bool install(private_quick_mode_t *this)
 								this->rekey, TRUE, FALSE));
 		}
 	}
-	else
+	else if (!ikev1_child_sa_is_redundant(this->ike_sa, this->child_sa, NULL))
 	{
 		charon->bus->child_updown(charon->bus, this->child_sa, TRUE);
 	}

--- a/src/starter/starter.c
+++ b/src/starter/starter.c
@@ -687,7 +687,7 @@ int main (int argc, char **argv)
 					{
 						for (conn2 = new_cfg->conn_first; conn2; conn2 = conn2->next)
 						{
-							if (conn2->state == STATE_TO_ADD && starter_cmp_conn(conn, conn2))
+							if (streq(conn2->name, conn->name))
 							{
 								conn->state = STATE_REPLACED;
 								conn2->state = STATE_ADDED;


### PR DESCRIPTION
Avoids calling updown child-up script for redundant CHILD_SAs after IKEv1
QM collision.

In constrast to 7f5cef5d1c this handles non-rekey QM collisions, which
might on the initial connection attempt, right after establishin MainMode.

fixes #3060