### PR TITLE
fix some wrong

### DIFF
--- a/src/libcharon/plugins/stroke/stroke_ca.c
+++ b/src/libcharon/plugins/stroke/stroke_ca.c
@@ -208,6 +208,11 @@ CALLBACK(certs_filter, bool,
 					return TRUE;
 				}
 			}
+			else
+			{
+				public->destroy(public);
+				continue;
+			}
 			public->destroy(public);
 		}
 		else if (data->key != KEY_ANY)

--- a/src/libcharon/sa/ikev1/tasks/main_mode.c
+++ b/src/libcharon/sa/ikev1/tasks/main_mode.c
@@ -412,13 +412,13 @@ METHOD(task_t, process_r, status_t,
 
 			if (!this->ph1->create_hasher(this->ph1))
 			{
-				return send_notify(this, INVALID_KEY_INFORMATION);
+				return send_notify(this, NO_PROPOSAL_CHOSEN);
 			}
 			if (!this->proposal->get_algorithm(this->proposal,
 										DIFFIE_HELLMAN_GROUP, &group, NULL))
 			{
 				DBG1(DBG_IKE, "DH group selection failed");
-				return send_notify(this, INVALID_KEY_INFORMATION);
+				return send_notify(this, NO_PROPOSAL_CHOSEN);
 			}
 			if (!this->ph1->create_dh(this->ph1, group))
 			{

--- a/src/libcharon/sa/ikev1/tasks/main_mode.c
+++ b/src/libcharon/sa/ikev1/tasks/main_mode.c
@@ -685,7 +685,7 @@ METHOD(task_t, process_i, status_t,
 			{
 				DBG1(DBG_IKE, "IDir payload missing");
 				charon->bus->alert(charon->bus, ALERT_PEER_AUTH_FAILED);
-				return send_notify(this, INVALID_PAYLOAD_TYPE);
+				return send_delete(this);
 			}
 			id = id_payload->get_identification(id_payload);
 			cid = this->ph1->get_id(this->ph1, this->peer_cfg, FALSE);

--- a/src/libcharon/sa/ikev1/tasks/main_mode.c
+++ b/src/libcharon/sa/ikev1/tasks/main_mode.c
@@ -685,7 +685,7 @@ METHOD(task_t, process_i, status_t,
 			{
 				DBG1(DBG_IKE, "IDir payload missing");
 				charon->bus->alert(charon->bus, ALERT_PEER_AUTH_FAILED);
-				return send_delete(this);
+				return send_notify(this, INVALID_PAYLOAD_TYPE);
 			}
 			id = id_payload->get_identification(id_payload);
 			cid = this->ph1->get_id(this->ph1, this->peer_cfg, FALSE);

--- a/src/libstrongswan/credentials/sets/mem_cred.c
+++ b/src/libstrongswan/credentials/sets/mem_cred.c
@@ -108,6 +108,11 @@ CALLBACK(certs_filter, bool,
 					return TRUE;
 				}
 			}
+			else
+			{
+				public->destroy(public);
+				continue;
+			}
 			public->destroy(public);
 		}
 		else if (data->key != KEY_ANY)


### PR DESCRIPTION
fix a wrong in certs_filter. When traversing a certificate, if you specify a public key type but do not specify  id, a certificate with a different public key type is returned.