### PR TITLE
fix an error

### DIFF
--- a/src/libcharon/plugins/stroke/stroke_ca.c
+++ b/src/libcharon/plugins/stroke/stroke_ca.c
@@ -208,6 +208,11 @@ CALLBACK(certs_filter, bool,
 					return TRUE;
 				}
 			}
+			else
+			{
+				public->destroy(public);
+				continue;
+			}
 			public->destroy(public);
 		}
 		else if (data->key != KEY_ANY)

--- a/src/libstrongswan/credentials/sets/mem_cred.c
+++ b/src/libstrongswan/credentials/sets/mem_cred.c
@@ -108,6 +108,11 @@ CALLBACK(certs_filter, bool,
 					return TRUE;
 				}
 			}
+			else
+			{
+				public->destroy(public);
+				continue;
+			}
 			public->destroy(public);
 		}
 		else if (data->key != KEY_ANY)


### PR DESCRIPTION
If the key type is specified but the id is null, it is possible to return a certificate that does not match the parameter key type.