### PR TITLE
flex: Fix parallel shadow build

### DIFF
--- a/src/libstrongswan/settings/settings_lexer.l
+++ b/src/libstrongswan/settings/settings_lexer.l
@@ -16,7 +16,7 @@
 
 #include <utils/parser_helper.h>
 
-#include "settings_parser.h"
+#include <settings/settings_parser.h>
 
 bool settings_parser_open_next_file(parser_helper_t *ctx);
 

--- a/src/starter/parser/lexer.l
+++ b/src/starter/parser/lexer.l
@@ -17,7 +17,7 @@
 #include <utils/parser_helper.h>
 #include <parser/conf_parser.h>
 
-#include "parser.h"
+#include <parser/parser.h>
 
 bool conf_parser_open_next_file(parser_helper_t *ctx);
 


### PR DESCRIPTION
On some builds, the source file is built before the header is created/copied to the shadow directory.