### PR TITLE
Remove the minimum character limitation for pre-shared keys

### DIFF
--- a/src/frontends/gnome/auth-dialog/main.c
+++ b/src/frontends/gnome/auth-dialog/main.c
@@ -113,7 +113,6 @@ static gboolean get_secrets(const char *type, const char *uuid, const char *name
 	NMAVpnPasswordDialog *dialog;
 	char *prompt, *pw = NULL;
 	const char *new_pw = NULL;
-	guint32 minlen = 0;
 
 	if (!(flags & NM_SETTING_SECRET_FLAG_NOT_SAVED) &&
 		!(flags & NM_SETTING_SECRET_FLAG_NOT_REQUIRED))
@@ -144,9 +143,8 @@ static gboolean get_secrets(const char *type, const char *uuid, const char *name
 	}
 	else if (!strcmp(type, "psk"))
 	{
-		prompt = g_strdup_printf (_("Pre-shared key required to establish VPN connection '%s' (min. 20 characters)."),
+		prompt = g_strdup_printf (_("Pre-shared key required to establish VPN connection '%s'."),
 								  name);
-		minlen = 20;
 	}
 	else /* smartcard */
 	{
@@ -192,11 +190,7 @@ too_short_retry:
 	if (nma_vpn_password_dialog_run_and_block (dialog))
 	{
 		new_pw = nma_vpn_password_dialog_get_password(dialog);
-		if (new_pw && minlen && strlen(new_pw) < minlen)
-		{
-			goto too_short_retry;
-		}
-		else if (new_pw)
+		if (new_pw)
 		{
 			*out_pw = g_strdup (new_pw);
 		}

--- a/src/frontends/gnome/properties/nm-strongswan.c
+++ b/src/frontends/gnome/properties/nm-strongswan.c
@@ -127,22 +127,6 @@ check_validity (StrongswanPluginUiWidget *self, GError **error)
 					 "address");
 		return FALSE;
 	}
-	widget = GTK_WIDGET (gtk_builder_get_object (priv->builder, "method-combo"));
-	switch (gtk_combo_box_get_active (GTK_COMBO_BOX (widget)))
-	{
-		case 4:
-		{
-			widget = GTK_WIDGET (gtk_builder_get_object (priv->builder, "passwd-entry"));
-			str = (char *) gtk_entry_get_text (GTK_ENTRY (widget));
-			if (str && strlen (str) < 20) {
-				g_set_error (error,
-							 STRONGSWAN_PLUGIN_UI_ERROR,
-							 STRONGSWAN_PLUGIN_UI_ERROR_INVALID_PROPERTY,
-							 "password is too short");
-				return FALSE;
-			}
-		}
-	}
 	return TRUE;
 }
 


### PR DESCRIPTION
This removes the minimum character limitation for pre-shared keys.
Reason: (taken from Augustin Rivero https://bugs.launchpad.net/ubuntu/+source/network-manager-strongswan/+bug/1697536):
This a client configuration not a server configuration. In a server you could enforce the user not to use an insecure password. But is it insecure to configure the client wrongly? It's like not allowing a login prompt to enter a short password. Security must be implemented when setting the password in the server, not when logging in!

A client shouldn't impose restrictions in configuration, otherwise it's not a generic client, it's just a client that works in some cases.

Other people having this problem:
https://ubuntuforums.org/showthread.php?t=2388118
https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=896086