### PR TITLE
Move D-Bus conf file to $(datadir)/dbus-1/system.d

### DIFF
--- a/src/charon-nm/Makefile.am
+++ b/src/charon-nm/Makefile.am
@@ -23,7 +23,7 @@ charon_nm_LDADD = \
 	$(top_builddir)/src/libcharon/libcharon.la \
 	-lm $(PTHREADLIB) $(ATOMICLIB) $(DLLIB) ${nm_LIBS}
 
-dbusservicedir = $(sysconfdir)/dbus-1/system.d
+dbusservicedir = $(datadir)/dbus-1/system.d
 dbusservice_DATA = nm-strongswan-service.conf
 
 EXTRA_DIST = $(dbusservice_DATA)


### PR DESCRIPTION
Since D-Bus 1.9.18 configuration files installed by third-party should
go in share/dbus-1/system.d. The old location is for sysadmin overrides.