### PR TITLE
Fixes for building with wolfSSL

### DIFF
--- a/src/libstrongswan/plugins/wolfssl/wolfssl_aead.h
+++ b/src/libstrongswan/plugins/wolfssl/wolfssl_aead.h
@@ -27,8 +27,8 @@
  * @{ @ingroup wolfssl_p
  */
 
-#ifndef WOLFSSL_AEAD_H_
-#define WOLFSSL_AEAD_H_
+#ifndef PLUGIN_WOLFSSL_AEAD_H_
+#define PLUGIN_WOLFSSL_AEAD_H_
 
 #include <crypto/aead.h>
 
@@ -43,4 +43,4 @@
 aead_t *wolfssl_aead_create(encryption_algorithm_t algo, size_t key_size,
 							size_t salt_size);
 
-#endif /** WOLFSSL_AEAD_H_ @}*/
+#endif /** PLUGIN_WOLFSSL_AEAD_H_ @}*/

--- a/src/libstrongswan/plugins/wolfssl/wolfssl_common.h
+++ b/src/libstrongswan/plugins/wolfssl/wolfssl_common.h
@@ -20,8 +20,8 @@
  * THE SOFTWARE.
  */
 
-#ifndef WOLFSSL_COMMON_H_
-#define WOLFSSL_COMMON_H_
+#ifndef PLUGIN_WOLFSSL_COMMON_H_
+#define PLUGIN_WOLFSSL_COMMON_H_
 
 #include <library.h>
 
@@ -41,11 +41,32 @@
 /* PARSE_ERROR is an enum entry in wolfSSL - not used in this plugin */
 #define PARSE_ERROR	WOLFSSL_PARSE_EROR
 
+/* remap these enum's from compatibility layer to avoid name conflicts */
+#define ASN1_BOOLEAN         REMAP_ASN1_BOOLEAN
+#define ASN1_OID             REMAP_ASN1_OID
+#define ASN1_INTEGER         REMAP_ASN1_INTEGER
+#define ASN1_BIT_STRING      REMAP_ASN1_BIT_STRING
+#define ASN1_IA5STRING       REMAP_ASN1_IA5STRING
+#define ASN1_OCTET_STRING    REMAP_ASN1_OCTET_STRING
+#define ASN1_UTCTIME         REMAP_ASN1_UTCTIME
+#define ASN1_GENERALIZEDTIME REMAP_ASN1_GENERALIZEDTIME
+
 #ifndef WOLFSSL_USER_SETTINGS
 	#include <wolfssl/options.h>
 #endif
 #include <wolfssl/ssl.h>
 
+#undef ASN1_BOOLEAN
+#undef ASN1_OID
+#undef ASN1_INTEGER
+#undef ASN1_BIT_STRING
+#undef ASN1_IA5STRING
+#undef ASN1_OCTET_STRING
+#undef ASN1_UTCTIME
+#undef ASN1_GENERALIZEDTIME
+
+/* eliminate macro conflicts */
+#undef RNG
 #undef PARSE_ERROR
 
-#endif /* WOLFSSL_COMMON_H_ */
+#endif /* PLUGIN_WOLFSSL_COMMON_H_ */

--- a/src/libstrongswan/plugins/wolfssl/wolfssl_crypter.h
+++ b/src/libstrongswan/plugins/wolfssl/wolfssl_crypter.h
@@ -25,8 +25,8 @@
  * @{ @ingroup wolfssl_p
  */
 
-#ifndef WOLFSSL_CRYPTER_H_
-#define WOLFSSL_CRYPTER_H_
+#ifndef PLUGIN_WOLFSSL_CRYPTER_H_
+#define PLUGIN_WOLFSSL_CRYPTER_H_
 
 typedef struct wolfssl_crypter_t wolfssl_crypter_t;
 
@@ -53,4 +53,4 @@ struct wolfssl_crypter_t {
 wolfssl_crypter_t *wolfssl_crypter_create(encryption_algorithm_t algo,
 										  size_t key_size);
 
-#endif /** WOLFSSL_CRYPTER_H_ @}*/
+#endif /** PLUGIN_WOLFSSL_CRYPTER_H_ @}*/

--- a/src/libstrongswan/plugins/wolfssl/wolfssl_diffie_hellman.h
+++ b/src/libstrongswan/plugins/wolfssl/wolfssl_diffie_hellman.h
@@ -25,8 +25,8 @@
  * @{ @ingroup wolfssl_p
  */
 
-#ifndef WOLFSSL_DIFFIE_HELLMAN_H_
-#define WOLFSSL_DIFFIE_HELLMAN_H_
+#ifndef PLUGIN_WOLFSSL_DIFFIE_HELLMAN_H_
+#define PLUGIN_WOLFSSL_DIFFIE_HELLMAN_H_
 
 typedef struct wolfssl_diffie_hellman_t wolfssl_diffie_hellman_t;
 
@@ -53,5 +53,5 @@ struct wolfssl_diffie_hellman_t {
 wolfssl_diffie_hellman_t *wolfssl_diffie_hellman_create(
 											diffie_hellman_group_t group, ...);
 
-#endif /** WOLFSSL_DIFFIE_HELLMAN_H_ @}*/
+#endif /** PLUGIN_WOLFSSL_DIFFIE_HELLMAN_H_ @}*/
 

--- a/src/libstrongswan/plugins/wolfssl/wolfssl_ec_diffie_hellman.h
+++ b/src/libstrongswan/plugins/wolfssl/wolfssl_ec_diffie_hellman.h
@@ -25,8 +25,8 @@
  * @{ @ingroup wolfssl_p
  */
 
-#ifndef WOLFSSL_EC_DIFFIE_HELLMAN_H_
-#define WOLFSSL_EC_DIFFIE_HELLMAN_H_
+#ifndef PLUGIN_WOLFSSL_EC_DIFFIE_HELLMAN_H_
+#define PLUGIN_WOLFSSL_EC_DIFFIE_HELLMAN_H_
 
 typedef struct wolfssl_ec_diffie_hellman_t wolfssl_ec_diffie_hellman_t;
 
@@ -53,4 +53,4 @@ struct wolfssl_ec_diffie_hellman_t {
 wolfssl_ec_diffie_hellman_t *wolfssl_ec_diffie_hellman_create(
 												diffie_hellman_group_t group);
 
-#endif /** WOLFSSL_EC_DIFFIE_HELLMAN_H_ @}*/
+#endif /** PLUGIN_WOLFSSL_EC_DIFFIE_HELLMAN_H_ @}*/

--- a/src/libstrongswan/plugins/wolfssl/wolfssl_ec_private_key.h
+++ b/src/libstrongswan/plugins/wolfssl/wolfssl_ec_private_key.h
@@ -25,8 +25,8 @@
  * @{ @ingroup wolfssl_p
  */
 
-#ifndef WOLFSSL_EC_PRIVATE_KEY_H_
-#define WOLFSSL_EC_PRIVATE_KEY_H_
+#ifndef PLUGIN_WOLFSSL_EC_PRIVATE_KEY_H_
+#define PLUGIN_WOLFSSL_EC_PRIVATE_KEY_H_
 
 #include <credentials/builder.h>
 #include <credentials/keys/private_key.h>
@@ -68,4 +68,4 @@ wolfssl_ec_private_key_t *wolfssl_ec_private_key_gen(key_type_t type,
 wolfssl_ec_private_key_t *wolfssl_ec_private_key_load(key_type_t type,
 													  va_list args);
 
-#endif /** WOLFSSL_EC_PRIVATE_KEY_H_ @}*/
+#endif /** PLUGIN_WOLFSSL_EC_PRIVATE_KEY_H_ @}*/

--- a/src/libstrongswan/plugins/wolfssl/wolfssl_ec_public_key.h
+++ b/src/libstrongswan/plugins/wolfssl/wolfssl_ec_public_key.h
@@ -25,8 +25,8 @@
  * @{ @ingroup wolfssl_p
  */
 
-#ifndef WOLFSSL_EC_PUBLIC_KEY_H_
-#define WOLFSSL_EC_PUBLIC_KEY_H_
+#ifndef PLUGIN_WOLFSSL_EC_PUBLIC_KEY_H_
+#define PLUGIN_WOLFSSL_EC_PUBLIC_KEY_H_
 
 typedef struct wolfssl_ec_public_key_t wolfssl_ec_public_key_t;
 
@@ -56,4 +56,4 @@ struct wolfssl_ec_public_key_t {
 wolfssl_ec_public_key_t *wolfssl_ec_public_key_load(key_type_t type,
 													va_list args);
 
-#endif /** WOLFSSL_EC_PUBLIC_KEY_H_ @}*/
+#endif /** PLUGIN_WOLFSSL_EC_PUBLIC_KEY_H_ @}*/

--- a/src/libstrongswan/plugins/wolfssl/wolfssl_ed_private_key.h
+++ b/src/libstrongswan/plugins/wolfssl/wolfssl_ed_private_key.h
@@ -25,8 +25,8 @@
  * @{ @ingroup wolfssl_p
  */
 
-#ifndef WOLFSSL_ED_PRIVATE_KEY_H_
-#define WOLFSSL_ED_PRIVATE_KEY_H_
+#ifndef PLUGIN_WOLFSSL_ED_PRIVATE_KEY_H_
+#define PLUGIN_WOLFSSL_ED_PRIVATE_KEY_H_
 
 #include <credentials/builder.h>
 #include <credentials/keys/private_key.h>
@@ -51,4 +51,4 @@ private_key_t *wolfssl_ed_private_key_gen(key_type_t type, va_list args);
  */
 private_key_t *wolfssl_ed_private_key_load(key_type_t type, va_list args);
 
-#endif /** WOLFSSL_ED_PRIVATE_KEY_H_ @}*/
+#endif /** PLUGIN_WOLFSSL_ED_PRIVATE_KEY_H_ @}*/

--- a/src/libstrongswan/plugins/wolfssl/wolfssl_ed_public_key.h
+++ b/src/libstrongswan/plugins/wolfssl/wolfssl_ed_public_key.h
@@ -25,8 +25,8 @@
  * @{ @ingroup wolfssl_p
  */
 
-#ifndef WOLFSSL_ED_PUBLIC_KEY_H_
-#define WOLFSSL_ED_PUBLIC_KEY_H_
+#ifndef PLUGIN_WOLFSSL_ED_PUBLIC_KEY_H_
+#define PLUGIN_WOLFSSL_ED_PUBLIC_KEY_H_
 
 #include <credentials/builder.h>
 #include <credentials/keys/public_key.h>
@@ -42,4 +42,4 @@
  */
 public_key_t *wolfssl_ed_public_key_load(key_type_t type, va_list args);
 
-#endif /** WOLFSSL_ED_PUBLIC_KEY_H_ @}*/
+#endif /** PLUGIN_WOLFSSL_ED_PUBLIC_KEY_H_ @}*/

--- a/src/libstrongswan/plugins/wolfssl/wolfssl_hasher.h
+++ b/src/libstrongswan/plugins/wolfssl/wolfssl_hasher.h
@@ -25,8 +25,8 @@
  * @{ @ingroup wolfssl_p
  */
 
-#ifndef WOLFSSL_HASHER_H_
-#define WOLFSSL_HASHER_H_
+#ifndef PLUGIN_WOLFSSL_HASHER_H_
+#define PLUGIN_WOLFSSL_HASHER_H_
 
 typedef struct wolfssl_hasher_t wolfssl_hasher_t;
 
@@ -51,4 +51,4 @@ struct wolfssl_hasher_t {
  */
 wolfssl_hasher_t *wolfssl_hasher_create(hash_algorithm_t algo);
 
-#endif /** WOLFSSL_HASHER_H_ @}*/
+#endif /** PLUGIN_WOLFSSL_HASHER_H_ @}*/

--- a/src/libstrongswan/plugins/wolfssl/wolfssl_hmac.h
+++ b/src/libstrongswan/plugins/wolfssl/wolfssl_hmac.h
@@ -27,8 +27,8 @@
  * @{ @ingroup wolfssl_p
  */
 
-#ifndef WOLFSSL_HMAC_H_
-#define WOLFSSL_HMAC_H_
+#ifndef PLUGIN_WOLFSSL_HMAC_H_
+#define PLUGIN_WOLFSSL_HMAC_H_
 
 #include <crypto/prfs/prf.h>
 #include <crypto/signers/signer.h>
@@ -49,4 +49,4 @@ prf_t *wolfssl_hmac_prf_create(pseudo_random_function_t algo);
  */
 signer_t *wolfssl_hmac_signer_create(integrity_algorithm_t algo);
 
-#endif /** WOLFSSL_HMAC_H_ @}*/
+#endif /** PLUGIN_WOLFSSL_HMAC_H_ @}*/

--- a/src/libstrongswan/plugins/wolfssl/wolfssl_plugin.h
+++ b/src/libstrongswan/plugins/wolfssl/wolfssl_plugin.h
@@ -28,8 +28,8 @@
  * @{ @ingroup wolfssl_p
  */
 
-#ifndef WOLFSSL_PLUGIN_H_
-#define WOLFSSL_PLUGIN_H_
+#ifndef PLUGIN_WOLFSSL_PLUGIN_H_
+#define PLUGIN_WOLFSSL_PLUGIN_H_
 
 #include <plugins/plugin.h>
 
@@ -46,4 +46,4 @@ struct wolfssl_plugin_t {
 	plugin_t plugin;
 };
 
-#endif /** WOLFSSL_PLUGIN_H_ @}*/
+#endif /** PLUGIN_WOLFSSL_PLUGIN_H_ @}*/

--- a/src/libstrongswan/plugins/wolfssl/wolfssl_rng.h
+++ b/src/libstrongswan/plugins/wolfssl/wolfssl_rng.h
@@ -25,8 +25,8 @@
  * @{ @ingroup wolfssl_p
  */
 
-#ifndef WOLFSSL_RNG_H_
-#define WOLFSSL_RNG_H_
+#ifndef PLUGIN_WOLFSSL_RNG_H_
+#define PLUGIN_WOLFSSL_RNG_H_
 
 #include <library.h>
 
@@ -63,4 +63,4 @@ int wolfssl_rng_global_init();
  */
 void wolfssl_rng_global_final();
 
-#endif /** WOLFSSL_RNG_H_ @}*/
+#endif /** PLUGIN_WOLFSSL_RNG_H_ @}*/

--- a/src/libstrongswan/plugins/wolfssl/wolfssl_rsa_private_key.h
+++ b/src/libstrongswan/plugins/wolfssl/wolfssl_rsa_private_key.h
@@ -25,8 +25,8 @@
  * @{ @ingroup wolfssl_p
  */
 
-#ifndef WOLFSSL_RSA_PRIVATE_KEY_H_
-#define WOLFSSL_RSA_PRIVATE_KEY_H_
+#ifndef PLUGIN_WOLFSSL_RSA_PRIVATE_KEY_H_
+#define PLUGIN_WOLFSSL_RSA_PRIVATE_KEY_H_
 
 #include <credentials/builder.h>
 #include <credentials/keys/private_key.h>
@@ -68,4 +68,4 @@ wolfssl_rsa_private_key_t *wolfssl_rsa_private_key_gen(key_type_t type,
 wolfssl_rsa_private_key_t *wolfssl_rsa_private_key_load(key_type_t type,
 														va_list args);
 
-#endif /** WOLFSSL_RSA_PRIVATE_KEY_H_ @}*/
+#endif /** PLUGIN_WOLFSSL_RSA_PRIVATE_KEY_H_ @}*/

--- a/src/libstrongswan/plugins/wolfssl/wolfssl_rsa_public_key.h
+++ b/src/libstrongswan/plugins/wolfssl/wolfssl_rsa_public_key.h
@@ -25,8 +25,8 @@
  * @{ @ingroup wolfssl_p
  */
 
-#ifndef WOLFSSL_RSA_PUBLIC_KEY_H_
-#define WOLFSSL_RSA_PUBLIC_KEY_H_
+#ifndef PLUGIN_WOLFSSL_RSA_PUBLIC_KEY_H_
+#define PLUGIN_WOLFSSL_RSA_PUBLIC_KEY_H_
 
 typedef struct wolfssl_rsa_public_key_t wolfssl_rsa_public_key_t;
 
@@ -55,4 +55,4 @@ struct wolfssl_rsa_public_key_t {
 wolfssl_rsa_public_key_t *wolfssl_rsa_public_key_load(key_type_t type,
 													  va_list args);
 
-#endif /** WOLFSSL_RSA_PUBLIC_KEY_H_ @}*/
+#endif /** PLUGIN_WOLFSSL_RSA_PUBLIC_KEY_H_ @}*/

--- a/src/libstrongswan/plugins/wolfssl/wolfssl_sha1_prf.h
+++ b/src/libstrongswan/plugins/wolfssl/wolfssl_sha1_prf.h
@@ -25,8 +25,8 @@
  * @{ @ingroup wolfssl_p
  */
 
-#ifndef WOLFSSL_SHA1_PRF_H_
-#define WOLFSSL_SHA1_PRF_H_
+#ifndef PLUGIN_WOLFSSL_SHA1_PRF_H_
+#define PLUGIN_WOLFSSL_SHA1_PRF_H_
 
 typedef struct wolfssl_sha1_prf_t wolfssl_sha1_prf_t;
 
@@ -52,4 +52,4 @@ struct wolfssl_sha1_prf_t {
  */
 wolfssl_sha1_prf_t *wolfssl_sha1_prf_create(pseudo_random_function_t algo);
 
-#endif /** WOLFSSL_SHA1_PRF_H_ @}*/
+#endif /** PLUGIN_WOLFSSL_SHA1_PRF_H_ @}*/

--- a/src/libstrongswan/plugins/wolfssl/wolfssl_util.h
+++ b/src/libstrongswan/plugins/wolfssl/wolfssl_util.h
@@ -25,8 +25,8 @@
  * @{ @ingroup wolfssl_p
  */
 
-#ifndef WOLFSSL_UTIL_H_
-#define WOLFSSL_UTIL_H_
+#ifndef PLUGIN_WOLFSSL_UTIL_H_
+#define PLUGIN_WOLFSSL_UTIL_H_
 
 #include <wolfssl/wolfcrypt/integer.h>
 #include <wolfssl/wolfcrypt/hash.h>
@@ -95,4 +95,4 @@ bool wolfssl_hash2type(hash_algorithm_t hash, enum wc_HashType *type);
  */
 bool wolfssl_hash2mgf1(hash_algorithm_t hash, int *mgf1);
 
-#endif /** WOLFSSL_UTIL_H_ @}*/
+#endif /** PLUGIN_WOLFSSL_UTIL_H_ @}*/

--- a/src/libstrongswan/plugins/wolfssl/wolfssl_x_diffie_hellman.h
+++ b/src/libstrongswan/plugins/wolfssl/wolfssl_x_diffie_hellman.h
@@ -27,8 +27,8 @@
  * @{ @ingroup wolfssl_p
  */
 
-#ifndef WOLFSSL_X_DIFFIE_HELLMAN_H_
-#define WOLFSSL_X_DIFFIE_HELLMAN_H_
+#ifndef PLUGIN_WOLFSSL_X_DIFFIE_HELLMAN_H_
+#define PLUGIN_WOLFSSL_X_DIFFIE_HELLMAN_H_
 
 #include <library.h>
 
@@ -40,4 +40,4 @@
  */
 diffie_hellman_t *wolfssl_x_diffie_hellman_create(diffie_hellman_group_t group);
 
-#endif /** WOLFSSL_X_DIFFIE_HELLMAN_H_ @}*/
+#endif /** PLUGIN_WOLFSSL_X_DIFFIE_HELLMAN_H_ @}*/


### PR DESCRIPTION
Resolves conflicts with building against wolfSSL when `--enable-opensslextra` is set. Fixes `WOLFSSL_HMAC_H_`, `RNG` and ASN1 name conflicts.