### PR TITLE
install libvici.h with dev headers

### DIFF
--- a/src/libcharon/plugins/vici/Makefile.am
+++ b/src/libcharon/plugins/vici/Makefile.am
@@ -47,6 +47,12 @@ libvici_la_SOURCES = \
 libvici_la_LIBADD = $(top_builddir)/src/libstrongswan/libstrongswan.la
 
 
+if USE_DEV_HEADERS
+vici_includedir = ${dev_headers}/vici
+vici_include_HEADERS = libvici.h
+endif
+
+
 TESTS = vici_tests
 
 check_PROGRAMS = $(TESTS)


### PR DESCRIPTION
This installs libvici.h as `/usr/include/strongswan/vici/libvici.h` so that other programs can build against it.