### PR TITLE
vici: Use unique names for CHILD_SAs in the child-updown event too

### DIFF
--- a/src/libcharon/plugins/vici/vici_query.c
+++ b/src/libcharon/plugins/vici/vici_query.c
@@ -1716,6 +1716,7 @@ METHOD(listener_t, child_updown, bool,
 {
 	vici_builder_t *b;
 	time_t now;
+	char buf[BUF_LEN];
 
 	if (!this->dispatcher->has_event_listeners(this->dispatcher, "child-updown"))
 	{
@@ -1734,7 +1735,11 @@ METHOD(listener_t, child_updown, bool,
 	list_ike(this, b, ike_sa, now);
 	b->begin_section(b, "child-sas");
 
-	b->begin_section(b, child_sa->get_name(child_sa));
+	snprintf(buf, sizeof(buf), "%s-%u",
+	         child_sa->get_name(child_sa),
+	         child_sa->get_unique_id(child_sa));
+
+	b->begin_section(b, buf);
 	list_child(this, b, child_sa, now);
 	b->end_section(b);
 


### PR DESCRIPTION
The unique names were introduced for the list-sas command in commit
04c0219e55d9338b6492548c073189bfd3d5431b. Unfortunately
the child-updown command wasn't updated to match.

The original name is already being returned in the "name" attribute,
so it'll still be available.

Example:

    >>> import vici, json
    >>> s = vici.Session()

    # First, for comparison, the list-sas command:
    >>> print(json.dumps(list(s.list_sas()), sort_keys=True, indent=4, separators=(',', ': ')))
    [
        {
            "vti0": {
                "child-sas": {
                    "vti0-1": {
                        ...

    # A child-updown event before the change:
    >>> for x in s.listen(["child-updown"]): print(json.dumps(x, sort_keys=True, indent=4, separators=(',', ': ')))
    [
        "child-updown",
        {
            "vti0": {
                "child-sas": {
                    "vti0": {   # <-- wrong: inconsistent with list-sas
                        ...

    # A child-updown event after the change:
    >>> s = vici.Session()
    >>> for x in s.listen(["child-updown"]): print(json.dumps(x, sort_keys=True, indent=4, separators=(',', ': ')))
    [
        "child-updown",
        {
            "vti0": {
                "child-sas": {
                    "vti0-1": {  # <-- fixed