### PR TITLE
HACKING: add libgmp3-dev to dependencies list, because the default config requires it

### DIFF
--- a/HACKING
+++ b/HACKING
@@ -20,6 +20,7 @@ the code, you need the following tools:
     - lex/flex
     - yacc/bison
     - gperf
+    - libgmp3-dev
 
     Optionally:
     - lcov/genhtml


### PR DESCRIPTION
Steps to repro:

    Run an AWS EC2 (free tier is fine) with Amazon's Ubuntu 18.04 AMI.

    git clone ...
    sudo apt-get update
    sudo apt-get install automake autoconf libtool pkg-config gettext perl python flex bison
    ./autogen.sh
    ./configure

Error:

    configure: error: GNU Multi Precision library gmp not found