### PR TITLE
kernel_pfkey: Pass ESN flag to kernel if ESN is enabled

### DIFF
--- a/src/libcharon/plugins/kernel_pfkey/kernel_pfkey_ipsec.c
+++ b/src/libcharon/plugins/kernel_pfkey/kernel_pfkey_ipsec.c
@@ -1766,6 +1766,14 @@ METHOD(kernel_ipsec_t, add_sa, status_t,
 	}
 	PFKEY_EXT_ADD(msg, sa);
 
+#ifdef SADB_X_SAFLAGS_ESN
+	if (id->proto != IPPROTO_COMP && data->esn)
+	{
+		DBG2(DBG_KNL, "  using extended sequence numbers (ESN)");
+		sa->sadb_sa_flags |= SADB_X_SAFLAGS_ESN;
+	}
+#endif
+
 #ifdef SADB_X_EXT_SA_REPLAY
 	if (data->inbound)
 	{


### PR DESCRIPTION
Current behaviour is that ESN can be negotiated even when kernel doesn't
support ESN. Pfkey plugin have ESN flag provided but this information is
not propagated to kernel.

This patch adds passing ESN flag to kernel when ESN was negotiated and
appropriate flag is present in kernel headers.

Signed-off-by: Patryk Duda <pdk@semihalf.com>