### PR TITLE
configure: Abort if gperf not found though needed

### DIFF
--- a/HACKING
+++ b/HACKING
@@ -19,7 +19,7 @@ the code, you need the following tools:
     - python
     - lex/flex
     - yacc/bison
-    - gperf
+    - gperf (>= 3.x)
 
     Optionally:
     - lcov/genhtml

--- a/configure.ac
+++ b/configure.ac
@@ -374,13 +374,12 @@ AC_PROG_LEX
 AC_PROG_YACC
 AM_PATH_PYTHON(,,[:])
 AC_PATH_PROG([PERL], [perl], [], [$PATH:/bin:/usr/bin:/usr/local/bin])
-AC_PATH_PROG([GPERF], [gperf], [], [$PATH:/bin:/usr/bin:/usr/local/bin])
+AC_PATH_PROG([GPERF_TMP], [gperf], [], [$PATH:/bin:/usr/bin:/usr/local/bin])
 
-# because gperf is not needed by end-users we just report it but do not abort on failure
-AC_MSG_CHECKING([gperf version >= 3.0.0])
-if test -x "$GPERF"; then
-	if test "`$GPERF --version | $AWK -F' ' '/^GNU gperf/ { print $3 }' | $AWK -F. '{ print $1 }'`" -ge "3"; then
-		GPERF_OUTPUT="`echo foo | ${GPERF}`"
+if test -x "$GPERF_TMP"; then
+	AC_MSG_CHECKING([gperf version >= 3.0.0])
+	if test "`$GPERF_TMP --version | $AWK -F' ' '/^GNU gperf/ { print $3 }' | $AWK -F. '{ print $1 }'`" -ge "3"; then
+		GPERF_OUTPUT="`echo foo | ${GPERF_TMP}`"
 		AC_COMPILE_IFELSE(
 			[AC_LANG_PROGRAM(
 				[[#include <string.h>
@@ -395,12 +394,15 @@ if test -x "$GPERF"; then
 			)]
 		)
 		AC_SUBST(GPERF_LEN_TYPE)
+		AC_SUBST([GPERF], [$GPERF_TMP])
 		AC_MSG_RESULT([yes])
 	else
 		AC_MSG_RESULT([no])
 	fi
-else
-	AC_MSG_RESULT([not found])
+fi
+
+if ! test -x "$GPERF" -o -f "$srcdir/src/libstrongswan/crypto/proposal/proposal_keywords_static.c"; then
+	AC_MSG_ERROR([gperf version >= 3.0.0 is needed])
 fi
 
 # ========================


### PR DESCRIPTION
If `src/libstrongswan/crypto/proposal/proposal_keywords_static.c` doesn't exist (i.e. git cloned, not tar.gz) and gperf is not installed, the build fails with a strange error:

```sh
Making all in libstrongswan
make[3]: Entering directory '/home/wsh/qc/strongswan/src/libstrongswan'
\
  (cd ./asn1/ && /usr/bin/perl oid.pl)
\
  sed \
  -e "s:\@GPERF_LEN_TYPE\@::" \
  crypto/proposal/proposal_keywords_static.h.in > crypto/proposal/proposal_keywords_static.h
\
   -N proposal_get_token_static -m 10 -C -G -c -t -D < \
                      ./crypto/proposal/proposal_keywords_static.txt > crypto/proposal/proposal_keywords_static.c
/bin/bash: line 1: -N: command not found
```

This patch makes it easy to understand what is required:

```sh
$ ./configure
...
checking for perl... /usr/local/bin/perl
checking for gperf... no
configure: error: gperf version >= 3.0.0 is needed
```

## Tests

If `src/libstrongswan/crypto/proposal/proposal_keywords_static.c` exists:

```sh
$ ./configure
...
checking for gperf... no
checking for stdbool.h that conforms to C99... yes
...
```

If gperf installed:

```sh
$ ./configure
checking for gperf... /usr/bin/gperf
checking gperf version >= 3.0.0... yes
checking for stdbool.h that conforms to C99... yes
...
```

If gperf is actually `/bin/echo` and `proposal_keywords_static.c` exists:

```sh
checking for gperf... /usr/bin/gperf
checking gperf version >= 3.0.0... ../configure: line 18360: test: : integer expression expected
no
checking for stdbool.h that conforms to C99... yes
```

If gperf is actually `/bin/echo` and `proposal_keywords_static.c` doesn't exist:

```sh
checking for gperf... /usr/bin/gperf
checking gperf version >= 3.0.0... ../configure: line 18360: test: : integer expression expected
no
configure: error: gperf version >= 3.0.0 is needed
```
