### PR TITLE
swanctl: fix build failure against gcc-10

### DIFF
--- a/src/swanctl/swanctl.h
+++ b/src/swanctl/swanctl.h
@@ -30,7 +30,7 @@
 /**
  * Base directory for credentials and config
  */
-char *swanctl_dir;
+extern char *swanctl_dir;
 
 /**
  * Configuration file for connections, etc.


### PR DESCRIPTION
On gcc-10 (and gcc-9 -fno-common) build fails as:

```
libtool: link: gcc ... -o .libs/swanctl ...
ld: commands/load_authorities.o:strongswan/src/swanctl/./swanctl.h:33:
  multiple definition of `swanctl_dir'; commands/load_all.o:strongswan/src/swanctl/./swanctl.h:33: first defined here
```

gcc-10 will change the default from -fcommon to fno-common:
https://gcc.gnu.org/PR85678.

The error also happens if CFLAGS=-fno-common passed explicitly.

Reported-by: Toralf Förster
Bug: https://bugs.gentoo.org/706408