### PR TITLE
Implement passthrough type routes and use them on Linux

### DIFF
--- a/src/libcharon/kernel/kernel_interface.c
+++ b/src/libcharon/kernel/kernel_interface.c
@@ -604,14 +604,14 @@ METHOD(kernel_interface_t, del_ip, status_t,
 
 METHOD(kernel_interface_t, add_route, status_t,
 	private_kernel_interface_t *this, chunk_t dst_net,
-	uint8_t prefixlen, host_t *gateway, host_t *src_ip, char *if_name)
+	uint8_t prefixlen, host_t *gateway, host_t *src_ip, char *if_name, bool is_passthrough_policy)
 {
 	if (!this->net)
 	{
 		return NOT_SUPPORTED;
 	}
 	return this->net->add_route(this->net, dst_net, prefixlen, gateway,
-								src_ip, if_name);
+								src_ip, if_name, is_passthrough_policy);
 }
 
 METHOD(kernel_interface_t, del_route, status_t,

--- a/src/libcharon/kernel/kernel_interface.h
+++ b/src/libcharon/kernel/kernel_interface.h
@@ -380,7 +380,7 @@ struct kernel_interface_t {
 	 */
 	status_t (*add_route) (kernel_interface_t *this, chunk_t dst_net,
 						   uint8_t prefixlen, host_t *gateway, host_t *src_ip,
-						   char *if_name);
+						   char *if_name, bool is_passthrough_policy);
 
 	/**
 	 * Delete a route.

--- a/src/libcharon/kernel/kernel_net.h
+++ b/src/libcharon/kernel/kernel_net.h
@@ -160,17 +160,18 @@ struct kernel_net_t {
 	/**
 	 * Add a route.
 	 *
-	 * @param dst_net		destination net
-	 * @param prefixlen		destination net prefix length
-	 * @param gateway		gateway for this route
-	 * @param src_ip		source ip of the route
-	 * @param if_name		name of the interface the route is bound to
-	 * @return				SUCCESS if operation completed
-	 *						ALREADY_DONE if the route already exists
+	 * @param dst_net				destination net
+	 * @param prefixlen				destination net prefix length
+	 * @param gateway				gateway for this route
+	 * @param src_ip				source ip of the route
+	 * @param if_name				name of the interface the route is bound to
+	 * @param is_passthrough_policy	if the route to be added is for a passthrough policy or not
+	 * @return						SUCCESS if operation completed
+	 *								ALREADY_DONE if the route already exists
 	 */
 	status_t (*add_route) (kernel_net_t *this, chunk_t dst_net,
 						   uint8_t prefixlen, host_t *gateway, host_t *src_ip,
-						   char *if_name);
+						   char *if_name, bool is_passthrough_policy);
 
 	/**
 	 * Delete a route.

--- a/src/libcharon/plugins/kernel_iph/kernel_iph_net.c
+++ b/src/libcharon/plugins/kernel_iph/kernel_iph_net.c
@@ -715,7 +715,7 @@ static status_t manage_route(private_kernel_iph_net_t *this, bool add,
 
 METHOD(kernel_net_t, add_route, status_t,
 	private_kernel_iph_net_t *this, chunk_t dst, uint8_t prefixlen,
-	host_t *gateway, host_t *src, char *name)
+	host_t *gateway, host_t *src, char *name, bool is_passthrough_policy)
 {
 	return manage_route(this, TRUE, dst, prefixlen, gateway, name);
 }

--- a/src/libcharon/plugins/kernel_libipsec/kernel_libipsec_ipsec.c
+++ b/src/libcharon/plugins/kernel_libipsec/kernel_libipsec_ipsec.c
@@ -315,7 +315,7 @@ static void add_exclude_route(private_kernel_libipsec_ipsec_t *this,
 			if (charon->kernel->get_interface(charon->kernel, src, &if_name) &&
 				charon->kernel->add_route(charon->kernel, dst->get_address(dst),
 									dst->get_family(dst) == AF_INET ? 32 : 128,
-									gtw, src, if_name) == SUCCESS)
+									gtw, src, if_name, TRUE) == SUCCESS)
 			{
 				INIT(exclude,
 					.dst = dst->clone(dst),
@@ -481,7 +481,7 @@ static bool install_route(private_kernel_libipsec_ipsec_t *this,
 
 	switch (charon->kernel->add_route(charon->kernel, route->dst_net,
 									  route->prefixlen, route->gateway,
-									  route->src_ip, route->if_name))
+									  route->src_ip, route->if_name, FALSE))
 	{
 		case ALREADY_DONE:
 			/* route exists, do not uninstall */

--- a/src/libcharon/plugins/kernel_netlink/kernel_netlink_net.c
+++ b/src/libcharon/plugins/kernel_netlink/kernel_netlink_net.c
@@ -2699,7 +2699,7 @@ static status_t manage_srcroute(private_kernel_netlink_net_t *this,
 	   Otherwise we don't need to do this because deletes happen by destination net, ignoring all other parameters
 	   (Except if metrics are used but we don't support that so we can ignore it here)
 	*/
-	if (nlmsg_type == RTM_NEWROUTE && !is_passthrough_route) {
+	if (nlmsg_type == RTM_NEWROUTE && !is_passthrough_route && src_ip) {
 		chunk = src_ip->get_address(src_ip);
 		netlink_add_attribute(hdr, RTA_PREFSRC, chunk, sizeof(request));
 		if (gateway && gateway->get_family(gateway) == src_ip->get_family(src_ip))

--- a/src/libcharon/plugins/kernel_netlink/kernel_netlink_net.c
+++ b/src/libcharon/plugins/kernel_netlink/kernel_netlink_net.c
@@ -263,7 +263,7 @@ static bool addr_map_entry_match_up(addr_map_entry_t *a, addr_map_entry_t *b)
  */
 static bool addr_map_entry_match(addr_map_entry_t *a, addr_map_entry_t *b)
 {
-	return a->ip->ip_equals(a->ip, b->ip);
+	return (a && b && a->ip && b->ip) ? a->ip->ip_equals(a->ip, b->ip) : FALSE;
 }
 
 typedef struct route_entry_t route_entry_t;
@@ -294,10 +294,9 @@ struct route_entry_t {
 static route_entry_t *route_entry_clone(route_entry_t *this)
 {
 	route_entry_t *route;
-
 	INIT(route,
-		.if_name = strdup(this->if_name),
-		.src_ip = this->src_ip->clone(this->src_ip),
+		.if_name = (this->if_name) ? strdup(this->if_name) : NULL,
+		.src_ip = (this->src_ip) ? this->src_ip->clone(this->src_ip) : NULL, 
 		.gateway = this->gateway ? this->gateway->clone(this->gateway) : NULL,
 		.dst_net = chunk_clone(this->dst_net),
 		.prefixlen = this->prefixlen,
@@ -332,7 +331,7 @@ static u_int route_entry_hash(route_entry_t *this)
 static bool route_entry_equals(route_entry_t *a, route_entry_t *b)
 {
 	if (a->if_name && b->if_name && streq(a->if_name, b->if_name) &&
-		a->src_ip->ip_equals(a->src_ip, b->src_ip) &&
+		((a && b && a->src_ip->ip_equals(a->src_ip, b->src_ip)) || (!a && !b)) &&
 		chunk_equals(a->dst_net, b->dst_net) && a->prefixlen == b->prefixlen)
 	{
 		return (!a->gateway && !b->gateway) || (a->gateway && b->gateway &&
@@ -544,7 +543,7 @@ struct private_kernel_netlink_net_t {
 static status_t manage_srcroute(private_kernel_netlink_net_t *this,
 								int nlmsg_type, int flags, chunk_t dst_net,
 								uint8_t prefixlen, host_t *gateway,
-								host_t *src_ip, char *if_name);
+								host_t *src_ip, char *if_name, bool is_passthrough_route);
 
 /**
  * Clear the queued network changes.
@@ -598,7 +597,7 @@ static job_requeue_t reinstall_routes(private_kernel_netlink_net_t *this)
 		{
 			manage_srcroute(this, RTM_NEWROUTE, NLM_F_CREATE | NLM_F_EXCL,
 							route->dst_net, route->prefixlen, route->gateway,
-							route->src_ip, route->if_name);
+							route->src_ip, route->if_name, false);
 		}
 	}
 	enumerator->destroy(enumerator);
@@ -2632,7 +2631,7 @@ METHOD(kernel_net_t, del_ip, status_t,
 static status_t manage_srcroute(private_kernel_netlink_net_t *this,
 								int nlmsg_type, int flags, chunk_t dst_net,
 								uint8_t prefixlen, host_t *gateway,
-								host_t *src_ip, char *if_name)
+								host_t *src_ip, char *if_name, bool is_passthrough_route)
 {
 	netlink_buf_t request;
 	struct nlmsghdr *hdr;
@@ -2653,12 +2652,12 @@ static status_t manage_srcroute(private_kernel_netlink_net_t *this,
 		half_net = chunk_alloca(dst_net.len);
 		memset(half_net.ptr, 0, half_net.len);
 		half_prefixlen = 1;
-
+		/* No passthrough routes in the main table */
 		status = manage_srcroute(this, nlmsg_type, flags, half_net,
-								 half_prefixlen, gateway, src_ip, if_name);
+								 half_prefixlen, gateway, src_ip, if_name, false);
 		half_net.ptr[0] |= 0x80;
 		status |= manage_srcroute(this, nlmsg_type, flags, half_net,
-								  half_prefixlen, gateway, src_ip, if_name);
+								  half_prefixlen, gateway, src_ip, if_name, false);
 		return status;
 	}
 
@@ -2670,10 +2669,15 @@ static status_t manage_srcroute(private_kernel_netlink_net_t *this,
 	hdr->nlmsg_len = NLMSG_LENGTH(sizeof(struct rtmsg));
 
 	msg = NLMSG_DATA(hdr);
-	msg->rtm_family = src_ip->get_family(src_ip);
+	msg->rtm_family = dst_net.len == 4 ? AF_INET : AF_INET6;
+	// msg->rtm_family = src_ip->get_family(src_ip);
 	msg->rtm_dst_len = prefixlen;
 	msg->rtm_protocol = RTPROT_STATIC;
-	msg->rtm_type = RTN_UNICAST;
+	if (is_passthrough_route) {
+		msg->rtm_type = RTN_THROW;
+	} else {
+		msg->rtm_type = RTN_UNICAST;
+	}
 	msg->rtm_scope = RT_SCOPE_UNIVERSE;
 
 	if (this->routing_table < 256)
@@ -2691,42 +2695,47 @@ static status_t manage_srcroute(private_kernel_netlink_net_t *this,
 #endif /* HAVE_RTA_TABLE */
 	}
 	netlink_add_attribute(hdr, RTA_DST, dst_net, sizeof(request));
-	chunk = src_ip->get_address(src_ip);
-	netlink_add_attribute(hdr, RTA_PREFSRC, chunk, sizeof(request));
-	if (gateway && gateway->get_family(gateway) == src_ip->get_family(src_ip))
-	{
-		chunk = gateway->get_address(gateway);
-		netlink_add_attribute(hdr, RTA_GATEWAY, chunk, sizeof(request));
-	}
-	ifindex = get_interface_index(this, if_name);
-	chunk.ptr = (char*)&ifindex;
-	chunk.len = sizeof(ifindex);
-	netlink_add_attribute(hdr, RTA_OIF, chunk, sizeof(request));
-
-	if (this->mtu || this->mss)
-	{
-		chunk = chunk_alloca(RTA_LENGTH((sizeof(struct rtattr) +
-										 sizeof(uint32_t)) * 2));
-		chunk.len = 0;
-		rta = (struct rtattr*)chunk.ptr;
-		if (this->mtu)
+	/* Do the complicated way if we install a route because we need all the parameters
+	   Otherwise we don't need to do this because deletes happen by destination net, ignoring all other parameters
+	   (Except if metrics are used but we don't support that so we can ignore it here)
+	*/
+	if (nlmsg_type == RTM_NEWROUTE && !is_passthrough_route) {
+		chunk = src_ip->get_address(src_ip);
+		netlink_add_attribute(hdr, RTA_PREFSRC, chunk, sizeof(request));
+		if (gateway && gateway->get_family(gateway) == src_ip->get_family(src_ip))
 		{
-			rta->rta_type = RTAX_MTU;
-			rta->rta_len = RTA_LENGTH(sizeof(uint32_t));
-			memcpy(RTA_DATA(rta), &this->mtu, sizeof(uint32_t));
-			chunk.len = rta->rta_len;
+			chunk = gateway->get_address(gateway);
+			netlink_add_attribute(hdr, RTA_GATEWAY, chunk, sizeof(request));
 		}
-		if (this->mss)
-		{
-			rta = (struct rtattr*)(chunk.ptr + RTA_ALIGN(chunk.len));
-			rta->rta_type = RTAX_ADVMSS;
-			rta->rta_len = RTA_LENGTH(sizeof(uint32_t));
-			memcpy(RTA_DATA(rta), &this->mss, sizeof(uint32_t));
-			chunk.len = RTA_ALIGN(chunk.len) + rta->rta_len;
-		}
-		netlink_add_attribute(hdr, RTA_METRICS, chunk, sizeof(request));
-	}
+		ifindex = get_interface_index(this, if_name);
+		chunk.ptr = (char*)&ifindex;
+		chunk.len = sizeof(ifindex);
+		netlink_add_attribute(hdr, RTA_OIF, chunk, sizeof(request));
 
+		if (this->mtu || this->mss)
+		{
+			chunk = chunk_alloca(RTA_LENGTH((sizeof(struct rtattr) +
+											 sizeof(uint32_t)) * 2));
+			chunk.len = 0;
+			rta = (struct rtattr*)chunk.ptr;
+			if (this->mtu)
+			{
+				rta->rta_type = RTAX_MTU;
+				rta->rta_len = RTA_LENGTH(sizeof(uint32_t));
+				memcpy(RTA_DATA(rta), &this->mtu, sizeof(uint32_t));
+				chunk.len = rta->rta_len;
+			}
+			if (this->mss)
+			{
+				rta = (struct rtattr*)(chunk.ptr + RTA_ALIGN(chunk.len));
+				rta->rta_type = RTAX_ADVMSS;
+				rta->rta_len = RTA_LENGTH(sizeof(uint32_t));
+				memcpy(RTA_DATA(rta), &this->mss, sizeof(uint32_t));
+				chunk.len = RTA_ALIGN(chunk.len) + rta->rta_len;
+			}
+			netlink_add_attribute(hdr, RTA_METRICS, chunk, sizeof(request));
+		}
+	}
 	return this->socket->send_ack(this->socket, hdr);
 }
 
@@ -2747,7 +2756,7 @@ static bool route_with_vip(route_entry_lookup_t *a, route_entry_t *b)
 {
 	if (chunk_equals(a->route.dst_net, b->dst_net) &&
 		a->route.prefixlen == b->prefixlen &&
-		is_known_vip(a->this, b->src_ip))
+		a->route.src_ip && b->src_ip && is_known_vip(a->this, b->src_ip))
 	{
 		return TRUE;
 	}
@@ -2769,7 +2778,7 @@ static bool route_with_dst(route_entry_lookup_t *a, route_entry_t *b)
 
 METHOD(kernel_net_t, add_route, status_t,
 	private_kernel_netlink_net_t *this, chunk_t dst_net, uint8_t prefixlen,
-	host_t *gateway, host_t *src_ip, char *if_name)
+	host_t *gateway, host_t *src_ip, char *if_name, bool is_passthrough_route)
 {
 	status_t status;
 	route_entry_t *found;
@@ -2808,7 +2817,7 @@ METHOD(kernel_net_t, add_route, status_t,
 	else
 	{
 		status = manage_srcroute(this, RTM_NEWROUTE, NLM_F_CREATE|NLM_F_REPLACE,
-								 dst_net, prefixlen, gateway, src_ip, if_name);
+								 dst_net, prefixlen, gateway, src_ip, if_name, is_passthrough_route);
 	}
 	if (status == SUCCESS)
 	{
@@ -2860,12 +2869,12 @@ METHOD(kernel_net_t, del_route, status_t,
 	{
 		status = manage_srcroute(this, RTM_NEWROUTE, NLM_F_CREATE|NLM_F_REPLACE,
 							found->dst_net, found->prefixlen, found->gateway,
-							found->src_ip, found->if_name);
+							found->src_ip, found->if_name, false);
 	}
 	else
 	{
 		status = manage_srcroute(this, RTM_DELROUTE, 0, dst_net, prefixlen,
-								 gateway, src_ip, if_name);
+								 gateway, src_ip, if_name, false);
 	}
 	this->routes_lock->unlock(this->routes_lock);
 	return status;
@@ -3111,7 +3120,7 @@ METHOD(kernel_net_t, destroy, void,
 	while (enumerator->enumerate(enumerator, NULL, (void**)&route))
 	{
 		manage_srcroute(this, RTM_DELROUTE, 0, route->dst_net, route->prefixlen,
-						route->gateway, route->src_ip, route->if_name);
+						route->gateway, route->src_ip, route->if_name, false);
 		route_entry_destroy(route);
 	}
 	enumerator->destroy(enumerator);

--- a/src/libcharon/plugins/kernel_pfkey/kernel_pfkey_ipsec.c
+++ b/src/libcharon/plugins/kernel_pfkey/kernel_pfkey_ipsec.c
@@ -2332,7 +2332,7 @@ static void add_exclude_route(private_kernel_pfkey_ipsec_t *this,
 				charon->kernel->add_route(charon->kernel,
 									dst->get_address(dst),
 									dst->get_family(dst) == AF_INET ? 32 : 128,
-									gtw, src, if_name) == SUCCESS)
+									gtw, src, if_name, FALSE) == SUCCESS)
 			{
 				INIT(exclude,
 					.dst = dst->clone(dst),
@@ -2512,7 +2512,7 @@ static bool install_route(private_kernel_pfkey_ipsec_t *this,
 
 	switch (charon->kernel->add_route(charon->kernel, route->dst_net,
 									  route->prefixlen, route->gateway,
-									  route->src_ip, route->if_name))
+									  route->src_ip, route->if_name, FALSE))
 	{
 		case ALREADY_DONE:
 			/* route exists, do not uninstall */

--- a/src/libcharon/plugins/kernel_pfroute/kernel_pfroute_net.c
+++ b/src/libcharon/plugins/kernel_pfroute/kernel_pfroute_net.c
@@ -1494,7 +1494,7 @@ static status_t manage_route(private_kernel_pfroute_net_t *this, int op,
 
 METHOD(kernel_net_t, add_route, status_t,
 	private_kernel_pfroute_net_t *this, chunk_t dst_net, uint8_t prefixlen,
-	host_t *gateway, host_t *src_ip, char *if_name)
+	host_t *gateway, host_t *src_ip, char *if_name, bool is_passthrough_policy)
 {
 	status_t status;
 	route_entry_t *found, route = {

--- a/src/libcharon/plugins/kernel_wfp/kernel_wfp_ipsec.c
+++ b/src/libcharon/plugins/kernel_wfp/kernel_wfp_ipsec.c
@@ -1447,7 +1447,7 @@ static bool install_route(private_kernel_wfp_ipsec_t *this,
 		if (charon->kernel->get_interface(charon->kernel, src, &name))
 		{
 			if (charon->kernel->add_route(charon->kernel,
-						dst->get_address(dst), mask, gtw, src, name) == SUCCESS)
+						dst->get_address(dst), mask, gtw, src, name, FALSE) == SUCCESS)
 			{
 				INIT(route,
 					.dst = dst->clone(dst),


### PR DESCRIPTION
Enables us to ignore any future kernel features for routes unless
we actually need to consider them for the source IP routes.
Also enables us to actually really skip IPsec processing for those networks
(Because even the routes don't touch those packets). It's more what
users expect.