### PR TITLE
charon-nm: Allow fixed values for charon-nm.port and charon-nm.port_nat_t

### DIFF
--- a/src/charon-nm/charon-nm.c
+++ b/src/charon-nm/charon-nm.c
@@ -196,9 +196,11 @@ int main(int argc, char *argv[])
 							   "charon-nm.syslog.daemon.default", 1));
 	charon->load_loggers(charon);
 
-	/* use random ports to avoid conflicts with regular charon */
-	lib->settings->set_int(lib->settings, "charon-nm.port", 0);
-	lib->settings->set_int(lib->settings, "charon-nm.port_nat_t", 0);
+	/* use random ports by default to avoid conflicts with regular charon */
+	lib->settings->set_int(lib->settings, "charon-nm.port",
+		lib->settings->get_int(lib->settings, "charon-nm.port", 0));
+	lib->settings->set_int(lib->settings, "charon-nm.port_nat_t",
+		lib->settings->get_int(lib->settings, "charon-nm.port_nat_t", 0));
 
 	DBG1(DBG_DMN, "Starting charon NetworkManager backend (strongSwan "VERSION")");
 	if (lib->integrity)


### PR DESCRIPTION
This change allows to optionally set `charon-nm.port` and/or `charon-nm.port_nat_t` to a fixed value, while retaining the default of using a random port.

My use case for this is a roadwarrior VPN connection over IPv6 (with MOBIKE enabled), where the client sits behind a customer grade router with a packet filter firewall (Fritz!Box in my case, but should not really matter). 

In this scenario, initiating the VPN works because the firewall detects the outgoing packets to ports 500/4500 on the server and allows answer packets. Likewise, ESP works because the firewall detects an active connection initiated by the client side. But when the server tries to rekey the child SA, the firewall has already timed out the initial UDP connection, and the CREATE_CHILD_SA request fails.

The simple solution here is to configure the firewall to allow incoming packets to the client on the UDP port(s) used by Strongswan, but the random ports used by charon-nm make this impractical.