### PR TITLE
src/Makefile.am: fix build with netlink but without libcharon

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -145,5 +145,7 @@ if USE_TPM
 endif
 
 if USE_KERNEL_NETLINK
+if USE_LIBCHARON
   SUBDIRS += xfrmi
+endif
 endif


### PR DESCRIPTION
xfrmi has been moved to a separate directory since version 5.8.0 and https://github.com/strongswan/strongswan/commit/d74ddd78937506436ba1ec8ebfbbd8a2cdaf0cc0

However, build of xfrmi will fail without libcharon:
`make[4]: *** No rule to make target '../../src/libcharon/plugins/kernel_netlink/libstrongswan-kernel-netlink.la', needed by 'xfrmi'.  Stop.`

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>