### PR TITLE
pkcs11-plugin: Add support for tokens which don't support hashing with signature

### DIFF
--- a/conf/plugins/pkcs11.opt
+++ b/conf/plugins/pkcs11.opt
@@ -30,3 +30,6 @@ charon.plugins.pkcs11.use_pubkey = no
 
 charon.plugins.pkcs11.use_rng = no
 	Whether the PKCS#11 modules should be used as RNG.
+	
+charon.plugins.pkcs11.use_sign_hasher = no
+	Whether the PKCS#11 modules should use signature mechanisms with hashing.

--- a/src/libstrongswan/plugins/pkcs11/pkcs11.h
+++ b/src/libstrongswan/plugins/pkcs11/pkcs11.h
@@ -512,6 +512,8 @@ typedef unsigned long ck_mechanism_type_t;
 #define CKM_SHA256_RSA_PKCS_PSS		(0x43)
 #define CKM_SHA384_RSA_PKCS_PSS		(0x44)
 #define CKM_SHA512_RSA_PKCS_PSS		(0x45)
+#define CKM_SHA224_RSA_PKCS		(0x46)
+#define CKM_SHA224_RSA_PKCS_PSS		(0x47)
 #define CKM_RC2_KEY_GEN			(0x100)
 #define CKM_RC2_ECB			(0x101)
 #define	CKM_RC2_CBC			(0x102)

--- a/src/libstrongswan/plugins/pkcs11/pkcs11_private_key.h
+++ b/src/libstrongswan/plugins/pkcs11/pkcs11_private_key.h
@@ -62,6 +62,8 @@ pkcs11_private_key_t *pkcs11_private_key_connect(key_type_t type, va_list args);
  * @param type			key type
  * @param keylen		key length in bits
  * @param hash			hash algorithm to apply first (HASH_UNKNOWN if none)
+ * 						If hash is given NULL, returns mechanism (if supported)
+ * 						for hashing and signing/verifying at once.
  */
 CK_MECHANISM_PTR pkcs11_signature_scheme_to_mech(signature_scheme_t scheme,
 												 key_type_t type, size_t keylen,
@@ -71,5 +73,11 @@ CK_MECHANISM_PTR pkcs11_signature_scheme_to_mech(signature_scheme_t scheme,
  * Get the Cryptoki mechanism for a encryption scheme.
  */
 CK_MECHANISM_PTR pkcs11_encryption_scheme_to_mech(encryption_scheme_t scheme);
+
+/**
+ * Encodes digest for PKCS#1 v1.5 signature to be given for CKM_RSA_PKCS mechanism
+ */
+chunk_t pkcs11_ssa_pkcs1v15_encode(hash_algorithm_t hash_alg, chunk_t hash);
+
 
 #endif /** PKCS11_PRIVATE_KEY_H_ @}*/


### PR DESCRIPTION
Some PKCS#11 libraries do not support combined hashing and signature creation.

For now only RSA signature is performed (hashing is done using external hasher i.e. openssl or gnutls), as virtually all PKCS#11 libraries support this kind of operation.

Added option in `strongswan.conf`: `pkcs11.use_sign_hasher` for enabling old behaviour - using signature mechanism with hashing done using PKCS#11 library.

Also added mechanisms with SHA-224.