### PR TITLE
Can one use a MySQL backend for user authentication in a strongswan VPN server (new)?

### DIFF
--- a/conf/options/charon.opt
+++ b/conf/options/charon.opt
@@ -120,6 +120,10 @@ charon.flush_auth_cfg = no
 charon.follow_redirects = yes
 	Whether to follow IKEv2 redirects (RFC 5685).
 
+charon.force_eap_only_authentication = no
+	Violate RFC 5998 and use EAP-only authentication even if the peer did not
+	send an EAP_ONLY_AUTHENTICATION notify during IKE_AUTH.
+
 charon.fragment_size = 1280
 	Maximum size (complete IP datagram size in bytes) of a sent IKE fragment
 	when using proprietary IKEv1 or standardized IKEv2 fragmentation, defaults

--- a/src/libcharon/sa/ikev2/tasks/ike_auth.c
+++ b/src/libcharon/sa/ikev2/tasks/ike_auth.c
@@ -1009,9 +1009,19 @@ METHOD(task_t, build_r, status_t,
 			if (!this->ike_sa->supports_extension(this->ike_sa,
 												  EXT_EAP_ONLY_AUTHENTICATION))
 			{
-				DBG1(DBG_IKE, "configured EAP-only authentication, but peer "
-					 "does not support it");
-				goto peer_auth_failed;
+				if (lib->settings->get_bool(lib->settings,
+							"%s.force_eap_only_authentication", FALSE, lib->ns))
+				{
+					DBG1(DBG_IKE, "ignore missing %N notify and use EAP-only "
+						 "authentication", notify_type_names,
+						 EAP_ONLY_AUTHENTICATION);
+				}
+				else
+				{
+					DBG1(DBG_IKE, "configured EAP-only authentication, but "
+						 "peer does not support it");
+					goto peer_auth_failed;
+				}
 			}
 		}
 		else


### PR DESCRIPTION
hi

We have installed and configured a strongswan VPN server with username / password authentication. Is it possible to store the users' credentials in a MySQL backend and configure strongswan to use the backend for this purpose?

this is old question but , I don't know what settings to add in the database ?

login method : EAP this is my user credentials ex: username: test pass : test

INSERT INTO identities (type, data) VALUES (2, X'74657374'); INSERT INTO shared_secrets (type, data) VALUES (2, X'74657374'); INSERT INTO shared_secret_identity (shared_secret, identity) VALUES (1, 1);

and not worked!

charon log:

07[IKE] no EAP key found for hosts 'CN=mydomain.com' - 'test'

what other setting must add to database ? can any one say exactly ?
wiki not enough for me !


https://serverfault.com/questions/1015477/can-one-use-a-mysql-backend-for-user-authentication-in-a-strongswan-vpn-server