### PR TITLE
Makefile.am: store appdata to /usr/share/metainfo

### DIFF
--- a/src/frontends/gnome/Makefile.am
+++ b/src/frontends/gnome/Makefile.am
@@ -6,7 +6,7 @@ nmvpnservice_DATA = nm-strongswan-service.name
 
 @INTLTOOL_DESKTOP_RULE@
 
-appdatadir = $(datadir)/appdata
+appdatadir = $(datadir)/metainfo
 appdata_DATA = $(appdata_in_files:.xml.in=.xml)
 appdata_in_files = NetworkManager-strongswan.appdata.xml.in
 @INTLTOOL_XML_RULE@


### PR DESCRIPTION
The path '/usr/share/appdata' is deprecated and
should be changed to '/usr/share/metainfo'.

See section: 2.1.2. Filesystem locations
https://www.freedesktop.org/software/appstream/docs/chap-Metadata.html

Signed-off-by: Conrad Kostecki <conrad@kostecki.com>