### PR TITLE
Remove a certificate installed by a vici authority on unload

### DIFF
--- a/src/libcharon/plugins/vici/vici_authority.c
+++ b/src/libcharon/plugins/vici/vici_authority.c
@@ -500,6 +500,17 @@ CALLBACK(unload_authority, vici_message_t*,
 	{
 		if (streq(authority->name, authority_name))
 		{
+			if (authority->cert)
+			{
+				certificate_t *c =
+					this->cred->remove_cert(this->cred,
+								authority->cert);
+				if (c != authority->cert)
+				{
+					DESTROY_IF(c);
+				}
+
+			}
 			this->authorities->remove_at(this->authorities, enumerator);
 			authority_destroy(authority);
 			found = TRUE;

--- a/src/libcharon/plugins/vici/vici_cred.c
+++ b/src/libcharon/plugins/vici/vici_cred.c
@@ -589,6 +589,12 @@ METHOD(vici_cred_t, add_cert, certificate_t*,
 	return this->creds->add_cert_ref(this->creds, TRUE, cert);
 }
 
+METHOD(vici_cred_t, remove_cert, certificate_t*,
+	private_vici_cred_t *this, certificate_t *cert)
+{
+	return this->creds->remove_cert(this->creds, cert);
+}
+
 METHOD(vici_cred_t, destroy, void,
 	private_vici_cred_t *this)
 {
@@ -618,6 +624,7 @@ vici_cred_t *vici_cred_create(vici_dispatcher_t *dispatcher)
 				.cache_cert = (void*)_cache_cert,
 			},
 			.add_cert = _add_cert,
+			.remove_cert = _remove_cert,
 			.destroy = _destroy,
 		},
 		.dispatcher = dispatcher,

--- a/src/libcharon/plugins/vici/vici_cred.h
+++ b/src/libcharon/plugins/vici/vici_cred.h
@@ -49,6 +49,13 @@ struct vici_cred_t {
 	certificate_t* (*add_cert)(vici_cred_t *this, certificate_t *cert);
 
 	/**
+	 * Remove a certificate from the certificate store
+	 *
+	 * @param cert	certificate to be removed from the store
+	 * @return		The removed certificate
+	 */
+	certificate_t* (*remove_cert)(vici_cred_t *this, certificate_t *cert);
+	/**
 	 * Destroy a vici_cred_t.
 	 */
 	void (*destroy)(vici_cred_t *this);

--- a/src/libstrongswan/credentials/sets/mem_cred.c
+++ b/src/libstrongswan/credentials/sets/mem_cred.c
@@ -220,6 +220,23 @@ METHOD(mem_cred_t, get_cert_ref, certificate_t*,
 	return cert;
 }
 
+METHOD(mem_cred_t, remove_cert, certificate_t*,
+	private_mem_cred_t *this, certificate_t *cert)
+{
+	certificate_t *cached = NULL;
+
+	this->lock->write_lock(this->lock);
+	if (this->untrusted->find_first(this->untrusted, certificate_equals,
+					(void**)&cached, cert))
+	{
+		this->untrusted->remove(this->untrusted, cached, NULL);
+		this->trusted->remove(this->trusted, cached, NULL);
+	}
+	this->lock->unlock(this->lock);
+
+	return cached;
+}
+
 METHOD(mem_cred_t, add_crl, bool,
 	private_mem_cred_t *this, crl_t *crl)
 {
@@ -931,6 +948,7 @@ mem_cred_t *mem_cred_create()
 			.add_cert = _add_cert,
 			.add_cert_ref = _add_cert_ref,
 			.get_cert_ref = _get_cert_ref,
+			.remove_cert = _remove_cert,
 			.add_crl = _add_crl,
 			.add_key = _add_key,
 			.remove_key = _remove_key,

--- a/src/libstrongswan/credentials/sets/mem_cred.h
+++ b/src/libstrongswan/credentials/sets/mem_cred.h
@@ -70,7 +70,13 @@ struct mem_cred_t {
 	 * @return				the same certificate, potentially different instance
 	 */
 	certificate_t* (*get_cert_ref)(mem_cred_t *this, certificate_t *cert);
-
+	/**
+	 * Remove a certificate from the credential set.
+	 *
+	 * @param cert			certificate to remove
+	 * @return the certificate if found else NULL
+	 */
+	certificate_t* (*remove_cert)(mem_cred_t *this, certificate_t *cert);
 	/**
 	 * Add an X.509 CRL to the credential set.
 	 *


### PR DESCRIPTION
vici.load-authority installed certificates were not removed when
the authority was unloaded. The underlying mem_cred has no support
to remove certs. This change adds this support to mem_cred, vici_cred
and removes and destroys the certificate if required when the authority
is unloaded