### PR TITLE
charon-nm: allow configurable remote traffic selectors

### DIFF
--- a/src/charon-nm/nm/nm_service.c
+++ b/src/charon-nm/nm/nm_service.c
@@ -839,10 +839,24 @@ static gboolean connect_(NMVpnServicePlugin *plugin, NMConnection *connection,
 	}
 	ts = traffic_selector_create_dynamic(0, 0, 65535);
 	child_cfg->add_traffic_selector(child_cfg, TRUE, ts);
-	ts = traffic_selector_create_from_cidr("0.0.0.0/0", 0, 0, 65535);
-	child_cfg->add_traffic_selector(child_cfg, FALSE, ts);
-	ts = traffic_selector_create_from_cidr("::/0", 0, 0, 65535);
-	child_cfg->add_traffic_selector(child_cfg, FALSE, ts);
+	str = nm_setting_vpn_get_data_item(vpn, "remote-ts");
+	if (str && strlen(str))
+	{
+		enumerator = enumerator_create_token(str, ";", "");
+		while (enumerator->enumerate(enumerator, &str))
+		{
+			ts = traffic_selector_create_from_cidr((char*)str, 0, 0, 65535);
+			child_cfg->add_traffic_selector(child_cfg, FALSE, ts);
+		}
+		enumerator->destroy(enumerator);
+	}
+	else
+	{
+		ts = traffic_selector_create_from_cidr("0.0.0.0/0", 0, 0, 65535);
+		child_cfg->add_traffic_selector(child_cfg, FALSE, ts);
+		ts = traffic_selector_create_from_cidr("::/0", 0, 0, 65535);
+		child_cfg->add_traffic_selector(child_cfg, FALSE, ts);	
+	}
 	peer_cfg->add_child_cfg(peer_cfg, child_cfg);
 
 	/**


### PR DESCRIPTION
this change allows to customize the previously hard-coded remote traffic selectors. it corresponds to ipsec.conf's `rightsubnet` and charon-cmd's `--remote-ts` parameters, but keeps the comfort of being able to toggle the connection through gnome's gui. 

this does not actually write the newly added "remote-ts" configuration node into the NetworkManager configuration file, but will use an existing value. exposing the config setting in the gui could be done in an amended or followup PR if this is a desired change.

use case: remote firewall appliance wrongly accepts the `0.0.0.0/0` but does not actually route external traffic, leaving the user with a partially working internet connection.