### PR TITLE
Terminate empty IKE-SA on unload

### DIFF
--- a/src/libcharon/plugins/vici/vici_config.c
+++ b/src/libcharon/plugins/vici/vici_config.c
@@ -2166,7 +2166,7 @@ static void clear_start_action(private_vici_config_t *this, char *peer_name,
 	enumerator_t *enumerator, *children;
 	child_sa_t *child_sa;
 	ike_sa_t *ike_sa;
-	uint32_t id = 0, others;
+	uint32_t id = 0, others, childs;
 	array_t *ids = NULL, *ikeids = NULL;
 	char *name;
 
@@ -2183,10 +2183,11 @@ static void clear_start_action(private_vici_config_t *this, char *peer_name,
 				{
 					continue;
 				}
-				others = id = 0;
+				childs = others = id = 0;
 				children = ike_sa->create_child_sa_enumerator(ike_sa);
 				while (children->enumerate(children, &child_sa))
 				{
+					childs++;
 					if (child_sa->get_state(child_sa) != CHILD_DELETING &&
 						child_sa->get_state(child_sa) != CHILD_DELETED)
 					{
@@ -2202,7 +2203,7 @@ static void clear_start_action(private_vici_config_t *this, char *peer_name,
 				}
 				children->destroy(children);
 
-				if (id && !others)
+				if (childs == 0 || (id && !others))
 				{
 					/* found matching children only, delete full IKE_SA */
 					id = ike_sa->get_unique_id(ike_sa);


### PR DESCRIPTION
It is possible that IKE-SA in CONNECTING state won't be removed even after calling 'unload-conn'.

In following example we have connection configured as initiator, but without responder, so IKE-SA will stuck in the CONNECTING state:
Before this patch:
```
[root@pb1 python]# python
Python 2.7.5 (default, Apr  2 2020, 13:16:51) 
[GCC 4.8.5 20150623 (Red Hat 4.8.5-39)] on linux2
Type "help", "copyright", "credits" or "license" for more information.
>>> import vici
>>> s = vici.Session()
>>> def print_conns():
...   for c in s.list_conns():
...     print c
... 
>>> def print_sas():
...   for c in s.list_sas():
...     print c
... 
>>> print_conns()
OrderedDict([(u'ipip0', OrderedDict([(u'local_addrs', ['10.255.0.10']), (u'remote_addrs', ['10.255.0.20']), (u'version', 'IKEv1'), (u'reauth_time', '25920'), (u'rekey_time', '0'), (u'unique', 'UNIQUE_NO'), (u'local-1', OrderedDict([(u'class', 'pre-shared key'), (u'id', '10.255.0.10'), (u'groups', []), (u'cert_policy', []), (u'certs', []), (u'cacerts', [])])), (u'remote-1', OrderedDict([(u'class', 'pre-shared key'), (u'id', '10.255.0.20'), (u'groups', []), (u'cert_policy', []), (u'certs', []), (u'cacerts', [])])), (u'children', OrderedDict([(u'child0', OrderedDict([(u'mode', 'TUNNEL'), (u'rekey_time', '324'), (u'rekey_bytes', '0'), (u'rekey_packets', '0'), (u'dpd_action', 'clear'), (u'close_action', 'clear'), (u'local-ts', ['0.0.0.0/0']), (u'remote-ts', ['0.0.0.0/0'])]))]))]))])
>>> print_sas()
OrderedDict([(u'ipip0', OrderedDict([(u'uniqueid', '1'), (u'version', '1'), (u'state', 'CONNECTING'), (u'local-host', '10.255.0.10'), (u'local-port', '500'), (u'local-id', '%any'), (u'remote-host', '10.255.0.20'), (u'remote-port', '500'), (u'remote-id', '%any'), (u'initiator', 'yes'), (u'initiator-spi', '1820005609252098575'), (u'responder-spi', '0'), (u'tasks-queued', ['QUICK_MODE', 'QUICK_MODE', 'QUICK_MODE', 'QUICK_MODE']), (u'tasks-active', ['ISAKMP_VENDOR', 'ISAKMP_CERT_PRE', 'MAIN_MODE', 'ISAKMP_CERT_POST', 'ISAKMP_NATD']), (u'child-sas', OrderedDict())]))])
>>> s.unload_conn({'name':'ipip0'})
>>> print_conns()
>>> print_sas()
OrderedDict([(u'ipip0', OrderedDict([(u'uniqueid', '1'), (u'version', '1'), (u'state', 'CONNECTING'), (u'local-host', '10.255.0.10'), (u'local-port', '500'), (u'local-id', '%any'), (u'remote-host', '10.255.0.20'), (u'remote-port', '500'), (u'remote-id', '%any'), (u'initiator', 'yes'), (u'initiator-spi', '1820005609252098575'), (u'responder-spi', '0'), (u'tasks-queued', ['QUICK_MODE', 'QUICK_MODE', 'QUICK_MODE', 'QUICK_MODE', 'QUICK_MODE']), (u'tasks-active', ['ISAKMP_VENDOR', 'ISAKMP_CERT_PRE', 'MAIN_MODE', 'ISAKMP_CERT_POST', 'ISAKMP_NATD']), (u'child-sas', OrderedDict())]))])
```

After:
```
...
>>> print_conns()
OrderedDict([(u'ipip0', OrderedDict([(u'local_addrs', ['10.255.0.10']), (u'remote_addrs', ['10.255.0.20']), (u'version', 'IKEv1'), (u'reauth_time', '25920'), (u'rekey_time', '0'), (u'unique', 'UNIQUE_NO'), (u'local-1', OrderedDict([(u'class', 'pre-shared key'), (u'id', '10.255.0.10'), (u'groups', []), (u'cert_policy', []), (u'certs', []), (u'cacerts', [])])), (u'remote-1', OrderedDict([(u'class', 'pre-shared key'), (u'id', '10.255.0.20'), (u'groups', []), (u'cert_policy', []), (u'certs', []), (u'cacerts', [])])), (u'children', OrderedDict([(u'child0', OrderedDict([(u'mode', 'TUNNEL'), (u'rekey_time', '324'), (u'rekey_bytes', '0'), (u'rekey_packets', '0'), (u'dpd_action', 'clear'), (u'close_action', 'clear'), (u'local-ts', ['0.0.0.0/0']), (u'remote-ts', ['0.0.0.0/0'])]))]))]))])
>>> print_sas()
OrderedDict([(u'ipip0', OrderedDict([(u'uniqueid', '1'), (u'version', '1'), (u'state', 'CONNECTING'), (u'local-host', '10.255.0.10'), (u'local-port', '500'), (u'local-id', '%any'), (u'remote-host', '10.255.0.20'), (u'remote-port', '500'), (u'remote-id', '%any'), (u'initiator', 'yes'), (u'initiator-spi', '16177725842992919556'), (u'responder-spi', '0'), (u'tasks-queued', ['QUICK_MODE', 'QUICK_MODE', 'QUICK_MODE', 'QUICK_MODE', 'QUICK_MODE', 'QUICK_MODE']), (u'tasks-active', ['ISAKMP_VENDOR', 'ISAKMP_CERT_PRE', 'MAIN_MODE', 'ISAKMP_CERT_POST', 'ISAKMP_NATD']), (u'child-sas', OrderedDict())]))])
>>> s.unload_conn({'name':'ipip0'})
>>> print_conns()
>>> print_sas()
>>> 
```

After some time this IKE-SA will be destroyed because of retransmissions, but I think it is more correct to drop such connections in unload-conn.

And one more question: does unload-conn guarantee that all conections/IKEs/childs is removed after return?