### PR TITLE
Send CISCO FLexVPN vendor ID

### DIFF
--- a/conf/options/charon.opt
+++ b/conf/options/charon.opt
@@ -392,6 +392,15 @@ charon.routing_table_prio
 charon.rsa_pss = no
 	Whether to use RSA with PSS padding instead of PKCS#1 padding by default.
 
+charon.send_cisco_flexvpn_vendor_id = no
+	Send the CISCO FlexVPN vendor ID. It is required in order to make CISCO
+	brand devicesallow negotiating a local_ts (from strongSwan's point of view)
+	that is not the assigned "virtual" IP address, if a "virtual" IP address is
+	requested by strongSwan. Sending the CISCO FlexVPN vendor ID makes the CISCO
+	peer allow this peer to negotiate a TS of 0.0.0.0/0 == 0.0.0.0/0 instead
+	(unknow if it works for IPv6 too). This has been tested with a "tunnel mode
+	ipsec ipv4" CISCO template but should also work for GRE encapsulation.
+
 charon.send_delay = 0
 	Delay in ms for sending packets, to simulate larger RTT.
 

--- a/src/libcharon/sa/ikev2/tasks/ike_vendor.c
+++ b/src/libcharon/sa/ikev2/tasks/ike_vendor.c
@@ -97,7 +97,7 @@ static vid_data_t vids[] = {
 	  "\x88\x2f\xe5\x6d\x6f\xd2\x0d\xbc\x22\x51\x61\x3b\x2e\xbe\x5b\xeb"},
 	{ "Cisco Delete Reason", 0, NULL, 0,
 	  "CISCO-DELETE-REASON" },
-	{ "Cisco FlexVPN Supported", 0, NULL, 0,
+	{ "Cisco FlexVPN Supported", 0, "send_cisco_flexvpn_vendor_id", 0,
 	  "FLEXVPN-SUPPORTED" },
 	{ "Cisco Copyright (c) 2009", 0, NULL, 0,
 	  "CISCO(COPYRIGHT)&Copyright (c) 2009 Cisco Systems, Inc." },


### PR DESCRIPTION
Send CISCO FLexVPN vendor ID if send_cisco_flexvpn_vendor_id is set to "yes".
Option description:
Send the CISCO FlexVPN vendor ID. It is required in order to make CISCO brand devices allow negotiating a local_ts (from strongSwan's point of view) that is not the assigned "virtual" IP address, if a "virtual" IP address is requested by strongSwan. Sending the CISCO FlexVPN vendor ID makes the CISCO peer allow this peer to negotiate a TS of 0.0.0.0/0 == 0.0.0.0/0 instead (unknow if it works for IPv6 too). This has been tested with a "tunnel mode ipsec ipv4" CISCO template but should also work for GRE encapsulation.