### PR TITLE
Remove obsolete setting regarding the Standard Output

### DIFF
--- a/init/systemd-starter/strongswan-starter.service.in
+++ b/init/systemd-starter/strongswan-starter.service.in
@@ -4,7 +4,6 @@ After=syslog.target network-online.target
 
 [Service]
 ExecStart=@SBINDIR@/@IPSEC_SCRIPT@ start --nofork
-StandardOutput=syslog
 Restart=on-abnormal
 
 [Install]


### PR DESCRIPTION
The Standard output type "syslog" is obsolete, causing a warning since systemd
version 246 [1].

Please consider using "journal" or "journal+console"

[1] https://github.com/systemd/systemd/blob/master/NEWS#L202

Signed-off-by: Mingli Yu <mingli.yu@windriver.com>