### PR TITLE
code improvement for charon-tkm.c file to avoid duplicate code block

### DIFF
--- a/src/charon-cmd/charon-cmd.c
+++ b/src/charon-cmd/charon-cmd.c
@@ -134,14 +134,10 @@ static int run()
 				break;
 			}
 			case SIGINT:
-			{
-				DBG1(DBG_DMN, "signal of type SIGINT received. Shutting down");
-				charon->bus->alert(charon->bus, ALERT_SHUTDOWN_SIGNAL, sig);
-				return 0;
-			}
 			case SIGTERM:
 			{
-				DBG1(DBG_DMN, "signal of type SIGTERM received. Shutting down");
+				DBG1(DBG_DMN, "%s received. Shutting down", 
+						sig == SIGINT ? "SIGINT" : "SIGTERM");
 				charon->bus->alert(charon->bus, ALERT_SHUTDOWN_SIGNAL, sig);
 				return 0;
 			}

--- a/src/charon-nm/charon-nm.c
+++ b/src/charon-nm/charon-nm.c
@@ -94,14 +94,10 @@ static void run()
 		switch (sig)
 		{
 			case SIGINT:
-			{
-				DBG1(DBG_DMN, "signal of type SIGINT received. Shutting down");
-				charon->bus->alert(charon->bus, ALERT_SHUTDOWN_SIGNAL, sig);
-				return;
-			}
 			case SIGTERM:
 			{
-				DBG1(DBG_DMN, "signal of type SIGTERM received. Shutting down");
+				DBG1(DBG_DMN, "%s received. Shutting down", 
+						sig == SIGINT ? "SIGINT" : "SIGTERM");
 				charon->bus->alert(charon->bus, ALERT_SHUTDOWN_SIGNAL, sig);
 				return;
 			}

--- a/src/charon-tkm/src/charon-tkm.c
+++ b/src/charon-tkm/src/charon-tkm.c
@@ -115,20 +115,11 @@ static void run()
 			DBG1(DBG_DMN, "waiting for signal failed: %s", strerror(errno));
 			return;
 		}
-		switch (sig)
-		{
-			case SIGINT:
-			{
-				DBG1(DBG_DMN, "signal of type SIGINT received. Shutting down");
-				charon->bus->alert(charon->bus, ALERT_SHUTDOWN_SIGNAL, sig);
-				return;
-			}
-			case SIGTERM:
-			{
-				DBG1(DBG_DMN, "signal of type SIGTERM received. Shutting down");
-				charon->bus->alert(charon->bus, ALERT_SHUTDOWN_SIGNAL, sig);
-				return;
-			}
+		if (sigismember(&set,sig) >= 1)
+		{	/* if condition incase the sigprocmask call fails for some reason */
+			DBG1(DBG_DMN, "signal of type %s received. Shutting down", (sig == SIGINT) ? "SIGINT" : "SIGTERM");
+			charon->bus->alert(charon->bus, ALERT_SHUTDOWN_SIGNAL, sig);
+			return;
 		}
 	}
 }

--- a/src/charon-tkm/src/charon-tkm.c
+++ b/src/charon-tkm/src/charon-tkm.c
@@ -115,11 +115,16 @@ static void run()
 			DBG1(DBG_DMN, "waiting for signal failed: %s", strerror(errno));
 			return;
 		}
-		if (sigismember(&set,sig) >= 1)
-		{	/* if condition incase the sigprocmask call fails for some reason */
-			DBG1(DBG_DMN, "signal of type %s received. Shutting down", (sig == SIGINT) ? "SIGINT" : "SIGTERM");
-			charon->bus->alert(charon->bus, ALERT_SHUTDOWN_SIGNAL, sig);
-			return;
+		switch (sig)
+		{
+			case SIGINT:
+			case SIGTERM:
+			{
+				DBG1(DBG_DMN, "%s received, shutting down",
+					 sig == SIGINT ? "SIGINT" : "SIGTERM");
+				charon->bus->alert(charon->bus, ALERT_SHUTDOWN_SIGNAL, sig);
+				return;
+			}
 		}
 	}
 }

--- a/src/charon/charon.c
+++ b/src/charon/charon.c
@@ -126,14 +126,10 @@ static void run()
 				break;
 			}
 			case SIGINT:
-			{
-				DBG1(DBG_DMN, "signal of type SIGINT received. Shutting down");
-				charon->bus->alert(charon->bus, ALERT_SHUTDOWN_SIGNAL, sig);
-				return;
-			}
 			case SIGTERM:
 			{
-				DBG1(DBG_DMN, "signal of type SIGTERM received. Shutting down");
+				DBG1(DBG_DMN, "%s received. Shutting down", 
+						sig == SIGINT ? "SIGINT" : "SIGTERM");
 				charon->bus->alert(charon->bus, ALERT_SHUTDOWN_SIGNAL, sig);
 				return;
 			}

--- a/src/frontends/osx/charon-xpc/charon-xpc.c
+++ b/src/frontends/osx/charon-xpc/charon-xpc.c
@@ -92,11 +92,9 @@ static int run()
 		switch (sig)
 		{
 			case SIGINT:
-				DBG1(DBG_DMN, "signal of type SIGINT received. Shutting down");
-				charon->bus->alert(charon->bus, ALERT_SHUTDOWN_SIGNAL, sig);
-				return 0;
 			case SIGTERM:
-				DBG1(DBG_DMN, "signal of type SIGTERM received. Shutting down");
+				DBG1(DBG_DMN, "%s received. Shutting down", 
+						sig == SIGINT ? "SIGINT" : "SIGTERM");
 				charon->bus->alert(charon->bus, ALERT_SHUTDOWN_SIGNAL, sig);
 				return 0;
 		}


### PR DESCRIPTION
#### Reference Issues/PRs
None

#### What does this improvement fix? 
A better way to handle both SIGINT and SIGTERM signals in charon-tkm.c file, without code block duplication. This will also prevent unnecessary entry into the switch block incase the sigprocmask call fails for some reason.
