### PR TITLE
libtls: Add 'tls.send_certreq_authorities' configuration knob

### DIFF
--- a/conf/options/charon.opt
+++ b/conf/options/charon.opt
@@ -476,6 +476,10 @@ charon.tls.mac
 charon.tls.suites
 	List of TLS cipher suites.
 
+charon.tls.send_certreq_authorities
+	In server's Certificate Request message, controls whether
+	certificate_authorities list should be populated.
+
 charon.user
 	Name of the user the daemon changes to after startup.
 


### PR DESCRIPTION
Formerly, when tls server builds the Certificate Request message, all
loaded X509_CA certificates are written into the certificate_authorities
list.

Alas, certain EAP-TLS clients fail to process this message if the
certificate_authorities list is too long, returning fatal TLS alert
'illegal parameter'.

Allow configuring whether the tls server fills the
certificate_authorities list with its known CAs or not; Providing an
empty list is a valid configuration according to TLS spec:

   certificate_authorities
      A list of the distinguished names [X501] of acceptable
      certificate_authorities, represented in DER-encoded format.  These
      distinguished names may specify a desired distinguished name for a
      root CA or for a subordinate CA; thus, this message can be used to
      describe known roots as well as a desired authorization space.  If
      the certificate_authorities list is empty, then the client MAY
      send any certificate of the appropriate ClientCertificateType,
      unless there is some external arrangement to the contrary.

The default is TRUE which preserves former behavior.