### PR TITLE
ipsec: Adding full hw-offload configuration support

### DIFF
--- a/src/include/linux/xfrm.h
+++ b/src/include/linux/xfrm.h
@@ -503,6 +503,7 @@ struct xfrm_user_offload {
 };
 #define XFRM_OFFLOAD_IPV6	1
 #define XFRM_OFFLOAD_INBOUND	2
+#define XFRM_OFFLOAD_FULL	4
 
 #ifndef __KERNEL__
 /* backwards compatibility for userspace */

--- a/src/libcharon/plugins/kernel_netlink/kernel_netlink_ipsec.c
+++ b/src/libcharon/plugins/kernel_netlink/kernel_netlink_ipsec.c
@@ -1448,13 +1448,15 @@ static bool netlink_detect_offload(const char *ifname)
 #endif
 
 /**
- * There are 3 HW offload configuration values:
+ * There are 4 HW offload configuration values:
  * 1. HW_OFFLOAD_NO   : Do not configure HW offload.
  * 2. HW_OFFLOAD_YES  : Configure HW offload.
  *                      Fail SA addition if offload is not supported.
  * 3. HW_OFFLOAD_AUTO : Configure HW offload if supported by the kernel
  *                      and device.
  *                      Do not fail SA addition otherwise.
+ * 4. HW_OFFLOAD_FULL : Configure HW FULL offload if supported by the kernel
+ *                      Fail SA addition if offload is not supported.
  */
 static bool config_hw_offload(kernel_ipsec_sa_id_t *id,
 							  kernel_ipsec_add_sa_t *data, struct nlmsghdr *hdr,
@@ -1471,7 +1473,8 @@ static bool config_hw_offload(kernel_ipsec_sa_id_t *id,
 		return TRUE;
 	}
 
-	hw_offload_yes = (data->hw_offload == HW_OFFLOAD_YES);
+	hw_offload_yes = ( (data->hw_offload == HW_OFFLOAD_YES) ||
+			   (data->hw_offload == HW_OFFLOAD_FULL) );
 
 	if (!charon->kernel->get_interface(charon->kernel, local, &ifname))
 	{
@@ -1499,6 +1502,12 @@ static bool config_hw_offload(kernel_ipsec_sa_id_t *id,
 		offload->flags |= XFRM_OFFLOAD_IPV6;
 	}
 	offload->flags |= data->inbound ? XFRM_OFFLOAD_INBOUND : 0;
+
+	/* activate full HW offload */
+	if ( data->hw_offload == HW_OFFLOAD_FULL )
+	{
+		offload->flags |= XFRM_OFFLOAD_FULL;
+	}
 
 	ret = TRUE;
 

--- a/src/libcharon/plugins/vici/vici_config.c
+++ b/src/libcharon/plugins/vici/vici_config.c
@@ -1031,6 +1031,7 @@ CALLBACK(parse_hw_offload, bool,
 		{ "no",		HW_OFFLOAD_NO	},
 		{ "yes",	HW_OFFLOAD_YES	},
 		{ "auto",	HW_OFFLOAD_AUTO	},
+		{ "full",	HW_OFFLOAD_FULL	},
 	};
 	int d;
 

--- a/src/libstrongswan/ipsec/ipsec_types.c
+++ b/src/libstrongswan/ipsec/ipsec_types.c
@@ -37,10 +37,11 @@ ENUM(ipcomp_transform_names, IPCOMP_NONE, IPCOMP_LZJH,
 	"IPCOMP_LZJH"
 );
 
-ENUM(hw_offload_names, HW_OFFLOAD_NO, HW_OFFLOAD_AUTO,
+ENUM(hw_offload_names, HW_OFFLOAD_NO, HW_OFFLOAD_FULL,
 	"no",
 	"yes",
 	"auto",
+	"full",
 );
 
 ENUM(dscp_copy_names, DSCP_COPY_OUT_ONLY, DSCP_COPY_NO,

--- a/src/libstrongswan/ipsec/ipsec_types.h
+++ b/src/libstrongswan/ipsec/ipsec_types.h
@@ -126,6 +126,7 @@ enum hw_offload_t {
 	HW_OFFLOAD_NO = 0,
 	HW_OFFLOAD_YES = 1,
 	HW_OFFLOAD_AUTO = 2,
+	HW_OFFLOAD_FULL = 3,
 };
 
 /**


### PR DESCRIPTION
Full offload does both crypto and encapsulation in HW, reducing SW overhead.
In this mode HW fully offloads the ESP data-path including: crypto, transport mode encapsulation, replay protection, ESP sequence number generation, ESN, error reporting.

This commit introduces a new configuration mode: **hw_offload = full**

Until now the configuration available to user for HW offload were:
- hw_offload = no
- hw_offload = yes
- hw_offload = auto
 
With this commit users will be able to configure full-offload using:
- hw_offload = full

Changes:
new flag HW_OFFLOAD_FULL added
modified config_hw_offload() to support the new flag
new value in swanctl.conf connections:children:hw_offload=full
