### PR TITLE
plugins pkcs11, kernel_iph: Windows build fixes

### DIFF
--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -174,7 +174,7 @@ win*)
 			--enable-constraints --enable-revocation --enable-pem --enable-pkcs1
 			--enable-pkcs8 --enable-x509 --enable-pubkey --enable-acert
 			--enable-eap-tnc --enable-eap-ttls --enable-eap-identity
-			--enable-updown --enable-ext-auth --enable-libipsec
+			--enable-updown --enable-ext-auth --enable-libipsec --enable-pkcs11
 			--enable-tnccs-20 --enable-imc-attestation --enable-imv-attestation
 			--enable-imc-os --enable-imv-os --enable-tnc-imv --enable-tnc-imc
 			--enable-pki --enable-swanctl --enable-socket-win

--- a/src/libcharon/plugins/kernel_iph/kernel_iph_net.c
+++ b/src/libcharon/plugins/kernel_iph/kernel_iph_net.c
@@ -16,6 +16,8 @@
 /* Windows 7, for some iphlpapi.h functionality */
 #define _WIN32_WINNT 0x0601
 #include <winsock2.h>
+/* required for iphlpapi.h (which in turn includes mprapi.h)
+ * - needs CERT_NAME_BLOB definition */
 #include <wincrypt.h>
 #include <ws2ipdef.h>
 #include <windows.h>

--- a/src/libcharon/plugins/kernel_iph/kernel_iph_net.c
+++ b/src/libcharon/plugins/kernel_iph/kernel_iph_net.c
@@ -16,6 +16,7 @@
 /* Windows 7, for some iphlpapi.h functionality */
 #define _WIN32_WINNT 0x0601
 #include <winsock2.h>
+#include <wincrypt.h>
 #include <ws2ipdef.h>
 #include <windows.h>
 #include <ntddndis.h>

--- a/src/libstrongswan/plugins/pkcs11/pkcs11_library.c
+++ b/src/libstrongswan/plugins/pkcs11/pkcs11_library.c
@@ -18,7 +18,16 @@
 
 #include "pkcs11_library.h"
 
-#include <dlfcn.h>
+#ifndef WIN32
+#  include <dlfcn.h>
+#else
+#  include <windows.h>
+#  define dlopen(name, _flags) (void *)LoadLibrary(name)
+#  define dclose(hlib) FreeLibrary((HMODULE)hlib)
+#  define dlsym(hlib, sym) (void*)GetProcAddress((HMODULE)hlib, sym)
+/* windows.h defines it as CreateMutexA, which breaks compilation */
+#  undef CreateMutex
+#endif
 
 #include <library.h>
 #include <asn1/asn1.h>

--- a/src/libstrongswan/plugins/pkcs11/pkcs11_library.c
+++ b/src/libstrongswan/plugins/pkcs11/pkcs11_library.c
@@ -18,15 +18,12 @@
 
 #include "pkcs11_library.h"
 
-#ifndef WIN32
-#  include <dlfcn.h>
-#else
-#  include <windows.h>
-#  define dlopen(name, _flags) (void *)LoadLibrary(name)
-#  define dclose(hlib) FreeLibrary((HMODULE)hlib)
-#  define dlsym(hlib, sym) (void*)GetProcAddress((HMODULE)hlib, sym)
+#ifdef WIN32
+#  include <utils/compat/windows.h>
 /* windows.h defines it as CreateMutexA, which breaks compilation */
 #  undef CreateMutex
+#else
+#  include <dlfcn.h>
 #endif
 
 #include <library.h>


### PR DESCRIPTION
- pkcs11: allow compile plugin for Windows - add DLL loading compat macros
- kernel_iph: fixes build when `-DNOCRYPT` compiler option  is given, as
  suggested by openssl plugin compilation for Windows because of
  conflicting definitions of `X509_EXTENSIONS`