### PR TITLE
FreeBSD 12.2

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,5 +1,5 @@
 freebsd_instance:
-  image: freebsd-12-1-release-amd64
+  image_family: freebsd-12-2
 
 env:
   TESTS_REDUCED_KEYLENGTHS: yes


### PR DESCRIPTION
Seems it's fixing the installation. 12.2 is the new CURRENT and the packages are frequently updated under the hood so that might have been the issue.