### PR TITLE
Vici prompt

### DIFF
--- a/src/libcharon/plugins/eap_gtc/eap_gtc.c
+++ b/src/libcharon/plugins/eap_gtc/eap_gtc.c
@@ -96,13 +96,19 @@ METHOD(eap_method_t, initiate_server, status_t,
 METHOD(eap_method_t, process_peer, status_t,
 	private_eap_gtc_t *this, eap_payload_t *in, eap_payload_t **out)
 {
+        char msg[512];
 	eap_gtc_header_t *res;
 	shared_key_t *shared;
-	chunk_t key;
+	chunk_t key, data;
 	size_t len;
 
+        data = in->get_data(in);
+
+        memset(msg, 0, sizeof(msg));
+        memcpy(msg, data.ptr, min(sizeof(msg)-1, data.len));
+
 	shared = lib->credmgr->get_shared(lib->credmgr, SHARED_EAP,
-									  this->peer, this->server);
+									  this->peer, this->server, msg);
 	if (shared == NULL)
 	{
 		DBG1(DBG_IKE, "no EAP key found for '%Y' - '%Y'",

--- a/src/libcharon/plugins/eap_mschapv2/eap_mschapv2.c
+++ b/src/libcharon/plugins/eap_mschapv2/eap_mschapv2.c
@@ -757,7 +757,7 @@ static bool get_nt_hash(private_eap_mschapv2_t *this, identification_t *me,
 	chunk_t password;
 
 	/* try to find a stored NT_HASH first */
-	shared = lib->credmgr->get_shared(lib->credmgr, SHARED_NT_HASH, me, other);
+	shared = lib->credmgr->get_shared(lib->credmgr, SHARED_NT_HASH, me, other, "");
 	if (shared )
 	{
 		*nt_hash = chunk_clone(shared->get_key(shared));
@@ -766,7 +766,7 @@ static bool get_nt_hash(private_eap_mschapv2_t *this, identification_t *me,
 	}
 
 	/* fallback to plaintext password */
-	shared = lib->credmgr->get_shared(lib->credmgr, SHARED_EAP, me, other);
+	shared = lib->credmgr->get_shared(lib->credmgr, SHARED_EAP, me, other, "");
 	if (shared)
 	{
 		password = utf8_to_utf16le(shared->get_key(shared));

--- a/src/libcharon/plugins/vici/Makefile.am
+++ b/src/libcharon/plugins/vici/Makefile.am
@@ -28,7 +28,8 @@ libstrongswan_vici_la_SOURCES = \
 	vici_attribute.h vici_attribute.c \
 	vici_authority.h vici_authority.c \
 	vici_logger.h vici_logger.c \
-	vici_plugin.h vici_plugin.c
+	vici_plugin.h vici_plugin.c \
+	vici_prompt.h vici_prompt.c
 
 libstrongswan_vici_la_LDFLAGS = -module -avoid-version
 

--- a/src/libcharon/plugins/vici/suites/test_event.c
+++ b/src/libcharon/plugins/vici/suites/test_event.c
@@ -125,7 +125,7 @@ START_TEST(test_raise_events)
 	ck_assert(dispatcher);
 
 	dispatcher->manage_event(dispatcher, "event", TRUE);
-	dispatcher->manage_command(dispatcher, "raise", raise_cb, dispatcher);
+	dispatcher->manage_command(dispatcher, "raise", raise_cb, dispatcher, NULL, NULL);
 
 	vici_init();
 	conn = vici_connect(URI);
@@ -142,7 +142,7 @@ START_TEST(test_raise_events)
 	vici_disconnect(conn);
 
 	dispatcher->manage_event(dispatcher, "event", FALSE);
-	dispatcher->manage_command(dispatcher, "raise", NULL, NULL);
+	dispatcher->manage_command(dispatcher, "raise", NULL, NULL, NULL, NULL);
 
 	lib->processor->cancel(lib->processor);
 	dispatcher->destroy(dispatcher);

--- a/src/libcharon/plugins/vici/suites/test_request.c
+++ b/src/libcharon/plugins/vici/suites/test_request.c
@@ -105,7 +105,7 @@ START_TEST(test_echo)
 	dispatcher = vici_dispatcher_create(URI);
 	ck_assert(dispatcher);
 
-	dispatcher->manage_command(dispatcher, "echo", echo_cb, (void*)(uintptr_t)1);
+	dispatcher->manage_command(dispatcher, "echo", echo_cb, (void*)(uintptr_t)1, NULL, NULL);
 
 	vici_init();
 	conn = vici_connect(URI);
@@ -120,7 +120,7 @@ START_TEST(test_echo)
 
 	vici_disconnect(conn);
 
-	dispatcher->manage_command(dispatcher, "echo", NULL, NULL);
+	dispatcher->manage_command(dispatcher, "echo", NULL, NULL, NULL, NULL);
 
 	lib->processor->cancel(lib->processor);
 	dispatcher->destroy(dispatcher);
@@ -152,7 +152,7 @@ START_TEST(test_missing)
 
 	vici_disconnect(conn);
 
-	dispatcher->manage_command(dispatcher, "echo", NULL, NULL);
+	dispatcher->manage_command(dispatcher, "echo", NULL, NULL, NULL, NULL);
 
 	lib->processor->cancel(lib->processor);
 	dispatcher->destroy(dispatcher);
@@ -181,7 +181,7 @@ START_TEST(test_stress)
 	dispatcher = vici_dispatcher_create(URI);
 	ck_assert(dispatcher);
 
-	dispatcher->manage_command(dispatcher, "echo", echo_cb, (void*)(uintptr_t)1);
+	dispatcher->manage_command(dispatcher, "echo", echo_cb, (void*)(uintptr_t)1, NULL, NULL);
 	dispatcher->manage_event(dispatcher, "dummy", TRUE);
 
 	vici_init();
@@ -214,7 +214,7 @@ START_TEST(test_stress)
 
 	vici_disconnect(conn);
 
-	dispatcher->manage_command(dispatcher, "echo", NULL, NULL);
+	dispatcher->manage_command(dispatcher, "echo", NULL, NULL, NULL, NULL);
 	dispatcher->manage_event(dispatcher, "dummy", FALSE);
 
 	lib->processor->cancel(lib->processor);

--- a/src/libcharon/plugins/vici/vici_attribute.c
+++ b/src/libcharon/plugins/vici/vici_attribute.c
@@ -729,7 +729,7 @@ static void manage_command(private_vici_attribute_t *this,
 						   char *name, vici_command_cb_t cb, bool reg)
 {
 	this->dispatcher->manage_command(this->dispatcher, name,
-									 reg ? cb : NULL, this);
+									 reg ? cb : NULL, this, NULL, NULL);
 }
 
 /**

--- a/src/libcharon/plugins/vici/vici_authority.c
+++ b/src/libcharon/plugins/vici/vici_authority.c
@@ -713,7 +713,7 @@ static void manage_command(private_vici_authority_t *this,
 						   char *name, vici_command_cb_t cb, bool reg)
 {
 	this->dispatcher->manage_command(this->dispatcher, name,
-									 reg ? cb : NULL, this);
+									 reg ? cb : NULL, this, NULL, NULL);
 }
 
 /**

--- a/src/libcharon/plugins/vici/vici_config.c
+++ b/src/libcharon/plugins/vici/vici_config.c
@@ -2721,7 +2721,7 @@ static void manage_command(private_vici_config_t *this,
 						   char *name, vici_command_cb_t cb, bool reg)
 {
 	this->dispatcher->manage_command(this->dispatcher, name,
-									 reg ? cb : NULL, this);
+									 reg ? cb : NULL, this, NULL, NULL);
 }
 
 /**

--- a/src/libcharon/plugins/vici/vici_control.c
+++ b/src/libcharon/plugins/vici/vici_control.c
@@ -693,7 +693,7 @@ static void manage_command(private_vici_control_t *this,
 						   char *name, vici_command_cb_t cb, bool reg)
 {
 	this->dispatcher->manage_command(this->dispatcher, name,
-									 reg ? cb : NULL, this);
+									 reg ? cb : NULL, this, NULL, NULL);
 }
 
 /**

--- a/src/libcharon/plugins/vici/vici_cred.c
+++ b/src/libcharon/plugins/vici/vici_cred.c
@@ -557,7 +557,7 @@ static void manage_command(private_vici_cred_t *this,
 						   char *name, vici_command_cb_t cb, bool reg)
 {
 	this->dispatcher->manage_command(this->dispatcher, name,
-									 reg ? cb : NULL, this);
+									 reg ? cb : NULL, this, NULL, NULL);
 }
 
 /**

--- a/src/libcharon/plugins/vici/vici_dispatcher.h
+++ b/src/libcharon/plugins/vici/vici_dispatcher.h
@@ -44,9 +44,20 @@
 #define VICI_DISPATCHER_H_
 
 #include "vici_message.h"
+#include "vici_socket.h"
 
 typedef struct vici_dispatcher_t vici_dispatcher_t;
 typedef enum vici_operation_t vici_operation_t;
+
+/**
+ * Callback function invoked when a client registers or deregisters for a given event
+ *
+ * @param user		user data, as passed during registration
+ * @param name         name of the event
+ * @param id		unique client connection identifier
+ * @param reg          whether the client registers or deregisters
+ */
+typedef void (*vici_register_cb_t)(void *user, char *name, u_int id, bool reg);
 
 /**
  * Default socket URI of vici service
@@ -104,7 +115,8 @@ struct vici_dispatcher_t {
 	 * @param user			user data to pass to callback
 	 */
 	void (*manage_command)(vici_dispatcher_t *this, char *name,
-						   vici_command_cb_t cb, void *user);
+						   vici_command_cb_t cb, void *user,
+                                                   vici_register_cb_t register_cb, void *register_cb_data);
 
 	/**
 	 * Register/Unregister an event type to send.

--- a/src/libcharon/plugins/vici/vici_dispatcher.h
+++ b/src/libcharon/plugins/vici/vici_dispatcher.h
@@ -147,7 +147,7 @@ struct vici_dispatcher_t {
 	 * @param id			client connection ID, 0 for all
 	 * @param message		event message to send, gets destroyed
 	 */
-	void (*raise_event)(vici_dispatcher_t *this, char *name, u_int id,
+	bool (*raise_event)(vici_dispatcher_t *this, char *name, u_int id,
 						vici_message_t *message);
 
 	/**

--- a/src/libcharon/plugins/vici/vici_plugin.c
+++ b/src/libcharon/plugins/vici/vici_plugin.c
@@ -47,6 +47,7 @@
 #include "vici_attribute.h"
 #include "vici_authority.h"
 #include "vici_logger.h"
+#include "vici_prompt.h"
 
 #include <library.h>
 #include <daemon.h>
@@ -102,6 +103,11 @@ struct private_vici_plugin_t {
 	 * Generic debug logger
 	 */
 	vici_logger_t *logger;
+        
+        /**
+         * User prompt
+         */
+        vici_prompt_t *prompt;
 };
 
 METHOD(plugin_t, get_name, char*,
@@ -135,6 +141,8 @@ static bool register_vici(private_vici_plugin_t *this,
 											  this->cred);
 			this->attrs = vici_attribute_create(this->dispatcher);
 			this->logger = vici_logger_create(this->dispatcher);
+                        
+                        this->prompt = vici_prompt_create(this->dispatcher);
 
 			charon->backends->add_backend(charon->backends,
 										  &this->config->backend);

--- a/src/libcharon/plugins/vici/vici_prompt.c
+++ b/src/libcharon/plugins/vici/vici_prompt.c
@@ -334,7 +334,7 @@ out:;
  * @return                          shared key
  */
 shared_key_t *prompt(void *data, shared_key_type_t type, identification_t *me,
-        identification_t *other)
+        identification_t *other, char *peer_message)
 {
     private_vici_prompt_t *this = data;
     bool sent = FALSE;
@@ -362,6 +362,7 @@ shared_key_t *prompt(void *data, shared_key_type_t type, identification_t *me,
     builder->add_kv(builder, "remote-identity", "%Y", other);
     builder->add_kv(builder, "local-identity", "%Y", me);
     builder->add_kv(builder, "secret-type", type == SHARED_EAP ? "password" : "PIN");
+    builder->add_kv(builder, "peer-message", "%s", peer_message);
     message = builder->finalize(builder);
 
     INIT(in_progress,

--- a/src/libcharon/plugins/vici/vici_prompt.c
+++ b/src/libcharon/plugins/vici/vici_prompt.c
@@ -1,0 +1,498 @@
+/*
+ * Copyright (C) 2020 Noel Kuntze for Contauro AG
+ * Copyright (C) 1991-2018 Free Software Foundation, Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation; either version 2 of the License, or (at your
+ * option) any later version.  See <http://www.fsf.org/copyleft/gpl.txt>.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * for more details.
+ */
+
+#include "vici_prompt.h"
+#include "vici_builder.h"
+
+#include <threading/mutex.h>
+#include <threading/condvar.h>
+
+#include <library.h>
+#include <daemon.h>
+
+#include <errno.h>
+
+#define PROMPT_TIMEOUT_MS 15000
+
+typedef struct private_vici_prompt_t private_vici_prompt_t;
+
+/**
+ * Directory for saved X.509 CRLs
+ */
+#define CRL_DIR SWANCTLDIR "/x509crl"
+
+/**
+ * Private data of an vici_prompt_t object.
+ */
+struct private_vici_prompt_t {
+
+	/**
+	 * Public vici_prompt_t interface.
+	 */
+	vici_prompt_t public;
+
+	/**
+	 * Dispatcher
+	 */
+	vici_dispatcher_t *dispatcher;
+        
+        /**
+         * Lock for data
+         */
+        mutex_t *lock;
+        
+        /**
+         * list containing registered VICI clients for prompting for credentials
+         */
+        
+        linked_list_t *prompt_clients;
+
+        /**
+         * Condvar for signaling received credentials
+         */
+        condvar_t *cond;
+        
+        /**
+         * Part of the cond
+         */
+        mutex_t *mutex;
+        
+        /**
+         * Timeout for waiting for a reply to the prompt
+         */
+        u_int timeout;
+        
+        /**
+         * prompt requests in progress
+         */
+        
+        linked_list_t *requests_in_progress;
+};
+
+typedef struct {
+    uint32_t id;
+} prompt_client_t;
+
+typedef struct {
+    uint32_t id;
+    shared_key_t *shared_key;
+    shared_key_type_t type;
+} prompt_client_reply_t;
+
+typedef struct {
+    identification_t *me;
+    identification_t *other;
+    shared_key_type_t type;
+    /* stores objects of type prompt_client_reply_t */
+    linked_list_t *clients;
+} prompt_request_in_progress_t;
+
+
+
+/* Subtract the `struct timeval' values X and Y,
+   storing the result in RESULT.
+   Return 1 if the difference is negative, otherwise 0.  */
+
+int
+timeval_subtract (struct timeval *result, struct timeval *x, struct timeval *y)
+{
+  /* Perform the carry for the later subtraction by updating @var{y}. */
+  if (x->tv_usec < y->tv_usec) {
+    int nsec = (y->tv_usec - x->tv_usec) / 1000000 + 1;
+    y->tv_usec -= 1000000 * nsec;
+    y->tv_sec += nsec;
+  }
+  if (x->tv_usec - y->tv_usec > 1000000) {
+    int nsec = (x->tv_usec - y->tv_usec) / 1000000;
+    y->tv_usec += 1000000 * nsec;
+    y->tv_sec -= nsec;
+  }
+
+  /* Compute the time remaining to wait.
+     @code{tv_usec} is certainly positive. */
+  result->tv_sec = x->tv_sec - y->tv_sec;
+  result->tv_usec = x->tv_usec - y->tv_usec;
+
+  /* Return 1 if result is negative. */
+  return x->tv_sec < y->tv_sec;
+}
+
+
+static void manage_command(private_vici_prompt_t *this,
+						   char *name, vici_command_cb_t cb, bool reg,
+                                                   vici_register_cb_t register_cb, void *user)
+{
+	this->dispatcher->manage_command(this->dispatcher, name,
+									 reg ? cb : NULL, this, register_cb, user);
+        DBG1(DBG_LIB, "register_cb: %p", register_cb);
+}
+
+bool compare_and_free_prompt_client_t_and_u_int(void *a, void *b)
+{
+    u_int da = *((u_int *) b);
+    prompt_client_t *db = a;
+    if (db->id == da)
+    {
+        free(db);
+        return TRUE;
+    }
+    return FALSE;
+}
+
+void free_prompt_client_reply_t(void *a)
+{
+    prompt_client_reply_t *da = a;
+    DESTROY_IF(da->shared_key);
+    free(da);
+}
+
+/*
+CALLBACK(find_matching_prompts_and_free, bool, void *a, void *b)
+{
+    prompt_request_in_progress_t *da = a, *db = b;
+
+    if (da->me->equals(da->me, db->me) && da->other->equals(da->other, db->other) && da->type == db->type)
+    {
+        da->clients->destroy_function(da->clients, free_prompt_client_reply_t);
+        da->me->destroy(da->me);
+        da->other->destroy(da->other);
+        free(a);
+        return TRUE;
+    }
+    return FALSE;
+}
+*/
+
+CALLBACK(find_matching_prompt_request, bool, void *a, va_list args)
+{
+    prompt_request_in_progress_t *da = a, *db;
+    VA_ARGS_VGET(args, db);
+    return da->me->equals(da->me, db->me) && da->other->equals(da->other, db->other)
+            && da->type == db->type;    
+}
+
+CALLBACK(find_matching_prompt_reply, bool, void *a, va_list args)
+{
+    prompt_client_reply_t *da = a, *db;
+    VA_ARGS_VGET(args, db);
+
+    return da->id == db->id;
+}
+/*
+CALLBACK(find_matching_reply_and_id, bool, void *a, va_list args)
+{
+    prompt_client_reply_t *da = a;
+    u_int db;
+    VA_ARGS_VGET(args, db);
+    
+    return da->id == db;
+}
+*/
+CALLBACK(find_matching_client_and_id, bool, void *a, void *b)
+{
+    prompt_client_t *da = a;
+    u_int id = * (u_int *)b;
+
+    return da->id == id;
+}
+/**
+ * Create a (error) reply message
+ */
+static vici_message_t* create_reply(bool error, char *fmt, ...)
+{
+	vici_builder_t *builder;
+	va_list args;
+
+	builder = vici_builder_create();
+	builder->add_kv(builder, "success", error ? "no" : "yes");
+	if (fmt)
+	{
+		va_start(args, fmt);
+		builder->vadd_kv(builder, "errmsg", fmt, args);
+		va_end(args);
+	}
+	return builder->finalize(builder);
+}
+
+void register_cb (void *user, char *name, u_int id, bool reg)
+{
+    private_vici_prompt_t *this = user;
+    prompt_client_t *client;
+    INIT (client,
+            .id = id
+    );
+    this->lock->lock(this->lock);
+    if (reg)
+    {
+        this->prompt_clients->insert_last(this->prompt_clients, client);
+    } else {
+        this->prompt_clients->remove(this->prompt_clients, &id , compare_and_free_prompt_client_t_and_u_int);
+    }
+   
+    this->lock->unlock(this->lock);
+}
+
+CALLBACK(prompt_reply, vici_message_t*,
+	private_vici_prompt_t *this, char *name, u_int id, vici_message_t *message)
+{
+    prompt_request_in_progress_t *proc = NULL, *test = NULL;
+    prompt_client_reply_t *reply = NULL, *reply_test = NULL;
+    vici_message_t *msg = NULL;
+    chunk_t def = { .ptr = NULL, .len = 0};
+    chunk_t key = message->get_value(message, def, "secret"), clone;
+    char *remote_identity = message->get_str(message, NULL, "remote-identity"), *local_identity = message->get_str(message, NULL, "local-identity");
+    char *shared_secret_type = message->get_str(message, NULL, "secret-type");
+    shared_key_type_t type;
+    
+    identification_t *me = identification_create_from_string(local_identity), *other = identification_create_from_string(remote_identity);
+    
+    if (!me || !other)
+    {
+        DBG1(DBG_LIB, "Provided identities could not be parsed into identification_t objects. Proceeding without using those as matches.");
+    }
+
+    if (key.len==0 || key.ptr == NULL)
+    {
+        return create_reply(FALSE, "no secret key found");
+    }
+
+    if (streq(shared_secret_type, "password"))
+    {
+        type = SHARED_EAP;
+    } else if (streq(shared_secret_type, "pin"))
+    {
+        type = SHARED_PIN;
+    } else {
+        DBG1(DBG_LIB, "vici client %u: Provided secret type (%s) isn't password or pin.", shared_secret_type);
+        msg = create_reply(FALSE, "Provided secret type (%s) isn't password or pin.", shared_secret_type);
+        goto out;
+    }
+    
+    INIT(test,
+        .me = me,
+        .other = other,
+        .type = type,
+    );
+    this->lock->lock(this->lock);
+    
+    if (!this->requests_in_progress->find_first(this->requests_in_progress, find_matching_prompt_request, (void **) &proc, test))
+    {
+        DBG1(DBG_LIB, "vici client %u No matching prompt request found for vici client", id);
+        msg = create_reply(FALSE, "vici client %u No matching prompt request found for vici client", id);
+        goto out;
+    }
+
+    INIT(reply_test,
+        .id = id,
+    );
+
+    if (!proc->clients->find_first(proc->clients, find_matching_prompt_reply,
+        (void **) &reply,  reply_test))
+    {
+        DBG1(DBG_LIB, "No matching reply found");
+        goto out;
+    }
+
+    clone = chunk_clone(key);
+    reply->shared_key = shared_key_create(proc->type, clone);
+
+    this->cond->broadcast(this->cond);
+    
+
+out:;
+    if (test)
+    {
+        free(test);
+    }
+    if (reply_test)
+    {
+        free(reply_test);
+    }
+    me->destroy(me);
+    other->destroy(other);
+    this->lock->unlock(this->lock);
+    return msg;
+}
+/**
+ * Prompt a registered client for data
+ * @param data                  user supplied data
+ * @param type                  type of the requested shared key
+ * @param me                    own identity
+ * @param other                 other peer identity
+ * @return                          shared key
+ */
+shared_key_t *prompt(void *data, shared_key_type_t type, identification_t *me,
+        identification_t *other)
+{
+    private_vici_prompt_t *this = data;
+    bool sent = FALSE;
+    enumerator_t *enumerator;
+    prompt_client_t *current;
+    prompt_client_reply_t *reply;
+    prompt_request_in_progress_t *in_progress;
+    linked_list_t *to_delete;
+    vici_builder_t *builder;
+    vici_message_t *message;
+    shared_key_t *result = NULL;
+    timeval_t now, then, timeout;
+    u_int tmp;
+
+    time_monotonic(&then);
+    timeval_add_ms(&then, this->timeout);
+    /** Only prompt for user authentication passwords, no PSKs or PPKs */
+    if (type != SHARED_EAP && type != SHARED_PIN)
+    {
+        return NULL;
+    }
+    to_delete = linked_list_create();
+
+    builder = vici_builder_create();
+    builder->add_kv(builder, "remote-identity", "%Y", other);
+    builder->add_kv(builder, "local-identity", "%Y", me);
+    builder->add_kv(builder, "secret-type", type == SHARED_EAP ? "password" : "PIN");
+    message = builder->finalize(builder);
+
+    INIT(in_progress,
+        .clients = linked_list_create(),
+        .me = me->clone(me),
+        .other = other->clone(other),
+        .type = type,
+    );
+
+    this->lock->lock(this->lock);
+    this->requests_in_progress->insert_last(this->requests_in_progress, in_progress);
+    enumerator = this->prompt_clients->create_enumerator(this->prompt_clients);
+    while(enumerator->enumerate(enumerator, &current))
+    {
+        /* TODO: Use jobs for this. raise event for all registered clients. This blocks execution */
+        INIT(reply,
+            .id = current->id,
+            .shared_key = NULL,
+            .type = type,
+        );
+        DBG3(DBG_LIB, "Notifying client %u", current->id);
+        in_progress->clients->insert_last(in_progress->clients, reply);
+        if (this->dispatcher->raise_event(this->dispatcher, "prompt-request", current->id, message))
+        {
+            sent = TRUE;
+        } else {
+            to_delete->insert_last(to_delete, &current->id);
+            sent = FALSE;
+        }
+        
+    }
+    
+    enumerator->destroy(enumerator);
+    enumerator = to_delete->create_enumerator(to_delete);
+    while(enumerator->enumerate(enumerator, &tmp))
+    {
+        this->prompt_clients->remove(this->prompt_clients, &tmp, find_matching_client_and_id);
+    }
+    enumerator->destroy(enumerator);
+    this->lock->unlock(this->lock);
+    if (!sent)
+    {
+        goto out;
+    }
+    this->mutex->lock(this->mutex);
+    /* Wait for some signal that credentials were received or a timeout was reached. Condvar and timed job(?) */    
+    do {
+        this->lock->lock(this->lock);
+        enumerator = in_progress->clients->create_enumerator(in_progress->clients);
+        while(enumerator->enumerate(enumerator, &reply))
+        {
+            if (reply->shared_key && reply->type == type)
+            {
+                DBG2(DBG_LIB, "Found reply from vici client %u", reply->id);
+                reply->shared_key->get_ref(reply->shared_key);
+                result = reply->shared_key;
+            }
+        }
+        enumerator->destroy(enumerator);
+        enumerator = NULL;
+        if (result)
+        {
+            break;
+        }
+        DBG2(DBG_LIB, "Was waken up but did not find a valid reply for prompt request");
+        this->lock->unlock(this->lock);
+        time_monotonic(&now);
+        timeval_subtract(&timeout, &then, &now);
+        timeout.tv_sec = then.tv_sec - now.tv_sec;
+        timeout.tv_usec = then.tv_usec - now.tv_usec;
+    } while (this->cond->timed_wait_abs(this->cond, this->mutex, timeout));
+    
+    if (!result) {
+        DBG1(DBG_LIB, "Timed out while waiting for credentials for %Y %Y", me, other);
+    }
+    this->mutex->unlock(this->mutex);
+
+out:;
+    /** Timeout reached, now destroy all data structures to clean up */    
+    this->lock->lock(this->lock);
+    this->requests_in_progress->remove(this->requests_in_progress, in_progress, NULL);
+    this->lock->unlock(this->lock);
+    in_progress->clients->destroy_function(in_progress->clients, free);
+    in_progress->me->destroy(in_progress->me);
+    in_progress->other->destroy(in_progress->other);
+    free(in_progress);
+    return result;
+}
+
+
+vici_message_t* prompt_request(void *user, char *name, u_int id, vici_message_t *request)
+{
+    return create_reply(FALSE, "");
+}
+
+void manage_commands(private_vici_prompt_t *this, bool reg)
+{
+    this->dispatcher->manage_event(this->dispatcher, "prompt-request", reg);
+    this->dispatcher->manage_event(this->dispatcher, "prompt-reply", reg);
+/*    manage_command(this, "prompt-request", prompt_request, reg); */
+    manage_command(this, "prompt-request", prompt_request, reg, register_cb, this);    
+    manage_command(this, "prompt-reply", prompt_reply, reg, register_cb, this);        
+}
+
+METHOD(vici_prompt_t, destroy, void,
+	private_vici_prompt_t *this)
+{
+        /** TODO: Rework */
+	manage_commands(this, FALSE);
+        this->requests_in_progress->destroy_function(this->requests_in_progress, free);
+        this->prompt_clients->destroy_function(this->prompt_clients, free);
+	free(this);
+}
+
+vici_prompt_t *vici_prompt_create(vici_dispatcher_t *dispatcher)
+{
+    private_vici_prompt_t *this;
+    INIT(this,
+            .public = {
+                .destroy = _destroy,
+            },
+            .dispatcher = dispatcher,
+            .lock = mutex_create(MUTEX_TYPE_DEFAULT),
+            .prompt_clients = linked_list_create(),
+            .requests_in_progress = linked_list_create(),
+            .cond = condvar_create(CONDVAR_TYPE_DEFAULT),
+            .mutex = mutex_create(MUTEX_TYPE_DEFAULT),
+            .timeout = lib->settings->get_time(lib->settings, "%s.plugins.vici.prompt_timeout", PROMPT_TIMEOUT_MS, lib->ns),      
+    );
+    manage_commands(this, TRUE);
+    lib->credmgr->add_prompt(lib->credmgr, prompt, this);
+
+    return &this->public;
+}

--- a/src/libcharon/plugins/vici/vici_prompt.h
+++ b/src/libcharon/plugins/vici/vici_prompt.h
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2020 Noel Kuntze for Contauro AG
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation; either version 2 of the License, or (at your
+ * option) any later version.  See <http://www.fsf.org/copyleft/gpl.txt>.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * for more details.
+ */
+
+/**
+ * @defgroup vici_prompt vici_prompt
+ * @{ @ingroup vici
+ */
+
+#ifndef VICI_PROMPT_H_
+#define VICI_PROMPT_H_
+
+#include "vici_dispatcher.h"
+
+typedef struct vici_prompt_t vici_prompt_t;
+
+/**
+ * prompt manager for VICI clients that want to provide credentials when they are requested by a function
+ */
+struct vici_prompt_t {
+    void (*destroy)(vici_prompt_t *this);
+};
+
+/**
+ * Create a vici_prompt instance.
+ *
+ * @param dispatcher		dispatcher to receive requests from
+ * @return					prompt backend
+ */
+vici_prompt_t *vici_prompt_create(vici_dispatcher_t *dispatcher);
+
+#endif /** VICI_PROMPT_H_ @}*/

--- a/src/libcharon/plugins/vici/vici_query.c
+++ b/src/libcharon/plugins/vici/vici_query.c
@@ -1670,7 +1670,7 @@ static void manage_command(private_vici_query_t *this,
 						   char *name, vici_command_cb_t cb, bool reg)
 {
 	this->dispatcher->manage_command(this->dispatcher, name,
-									 reg ? cb : NULL, this);
+									 reg ? cb : NULL, this, NULL, NULL);
 }
 
 /**

--- a/src/libcharon/plugins/vici/vici_socket.c
+++ b/src/libcharon/plugins/vici/vici_socket.c
@@ -612,7 +612,7 @@ CALLBACK(enable_writer, job_requeue_t,
 	return JOB_REQUEUE_NONE;
 }
 
-METHOD(vici_socket_t, send_, void,
+METHOD(vici_socket_t, send_, bool,
 	private_vici_socket_t *this, u_int id, chunk_t msg)
 {
 	if (msg.len <= VICI_MESSAGE_SIZE_MAX)
@@ -646,6 +646,7 @@ METHOD(vici_socket_t, send_, void,
 		{
 			DBG1(DBG_CFG, "vici connection %u unknown", id);
 			chunk_clear(&msg);
+                        return FALSE;
 		}
 	}
 	else
@@ -653,7 +654,9 @@ METHOD(vici_socket_t, send_, void,
 		DBG1(DBG_CFG, "vici message size %zu exceeds maximum size of %u, "
 			 "discarded", msg.len, VICI_MESSAGE_SIZE_MAX);
 		chunk_clear(&msg);
+                return FALSE;
 	}
+        return TRUE;
 }
 
 CALLBACK(flush_messages, void,

--- a/src/libcharon/plugins/vici/vici_socket.h
+++ b/src/libcharon/plugins/vici/vici_socket.h
@@ -72,8 +72,9 @@ struct vici_socket_t {
 	 *
 	 * @param id		unique client connection identifier
 	 * @param data		data to send to client, gets owned
+         * @return              bool indicating success
 	 */
-	void (*send)(vici_socket_t *this, u_int id, chunk_t data);
+	bool (*send)(vici_socket_t *this, u_int id, chunk_t data);
 
 	/**
 	 * Destroy socket.

--- a/src/libcharon/sa/ikev1/phase1.c
+++ b/src/libcharon/sa/ikev1/phase1.c
@@ -116,7 +116,7 @@ static shared_key_t *find_shared_key(identification_t *my_id, host_t *me,
 		other_id = any_id;
 	}
 	shared_key = lib->credmgr->get_shared(lib->credmgr, SHARED_IKE,
-										  my_id, other_id);
+										  my_id, other_id, "");
 	if (!shared_key)
 	{
 		DBG1(DBG_IKE, "no shared key found for '%Y'[%H] - '%Y'[%H]",
@@ -191,7 +191,7 @@ static shared_key_t *lookup_shared_key(private_phase1_t *this,
 		if (my_id && other_id)
 		{
 			shared_key = lib->credmgr->get_shared(lib->credmgr, SHARED_IKE,
-												  my_id, other_id);
+												  my_id, other_id, "");
 		}
 		DESTROY_IF(my_id);
 		DESTROY_IF(other_id);

--- a/src/libcharon/sa/ikev2/authenticators/psk_authenticator.c
+++ b/src/libcharon/sa/ikev2/authenticators/psk_authenticator.c
@@ -78,7 +78,7 @@ METHOD(authenticator_t, build, status_t,
 	other_id = this->ike_sa->get_other_id(this->ike_sa);
 	DBG1(DBG_IKE, "authentication of '%Y' (myself) with %N",
 		 my_id, auth_method_names, AUTH_PSK);
-	key = lib->credmgr->get_shared(lib->credmgr, SHARED_IKE, my_id, other_id);
+	key = lib->credmgr->get_shared(lib->credmgr, SHARED_IKE, my_id, other_id, "");
 	if (!key)
 	{
 		DBG1(DBG_IKE, "no shared key found for '%Y' - '%Y'", my_id, other_id);

--- a/src/libcharon/sa/ikev2/tasks/ike_auth.c
+++ b/src/libcharon/sa/ikev2/tasks/ike_auth.c
@@ -490,7 +490,7 @@ static bool get_ppk(private_ike_auth_t *this, identification_t *ppk_id)
 {
 	shared_key_t *key;
 
-	key = lib->credmgr->get_shared(lib->credmgr, SHARED_PPK, ppk_id, NULL);
+	key = lib->credmgr->get_shared(lib->credmgr, SHARED_PPK, ppk_id, NULL, "");
 	if (!key)
 	{
 		if (this->peer_cfg->ppk_required(this->peer_cfg))

--- a/src/libstrongswan/credentials/credential_manager.c
+++ b/src/libstrongswan/credentials/credential_manager.c
@@ -417,7 +417,7 @@ METHOD(credential_manager_t, create_shared_enumerator, enumerator_t*,
 
 METHOD(credential_manager_t, get_shared, shared_key_t*,
 	private_credential_manager_t *this, shared_key_type_t type,
-	identification_t *me, identification_t *other)
+	identification_t *me, identification_t *other, char *peer_message)
 {
 	shared_key_t *current, *found = NULL;
 	id_match_t best_me = ID_MATCH_NONE, best_other = ID_MATCH_NONE;
@@ -448,7 +448,7 @@ METHOD(credential_manager_t, get_shared, shared_key_t*,
             enumerator = this->prompt_callbacks->create_enumerator(this->prompt_callbacks);
             while(enumerator->enumerate(enumerator, &data))
             {
-                found = data->cb(data->data, type, me, other);
+                found = data->cb(data->data, type, me, other, peer_message);
                 if (found)
                 {
                     break;

--- a/src/libstrongswan/credentials/credential_manager.c
+++ b/src/libstrongswan/credentials/credential_manager.c
@@ -443,17 +443,19 @@ METHOD(credential_manager_t, get_shared, shared_key_t*,
 	enumerator->destroy(enumerator);
         if (!found && this->prompt_callbacks->get_count(this->prompt_callbacks))
         {
+            this->lock->read_lock(this->lock);
             prompt_callback_data_t *data;
             enumerator = this->prompt_callbacks->create_enumerator(this->prompt_callbacks);
             while(enumerator->enumerate(enumerator, &data))
             {
-                found = data->cb(data, type, me, other);
+                found = data->cb(data->data, type, me, other);
                 if (found)
                 {
                     break;
                 }
             }
             enumerator->destroy(enumerator);
+            this->lock->unlock(this->lock);
         }
 	return found;
 }

--- a/src/libstrongswan/credentials/credential_manager.h
+++ b/src/libstrongswan/credentials/credential_manager.h
@@ -74,7 +74,7 @@ typedef void (*credential_hook_t)(void *data, credential_hook_type_t type,
  *                                    NULL in case of failure
  */
 typedef shared_key_t *prompt_callback_t(void *data, shared_key_type_t type, 
-            identification_t *me, identification_t *other);
+            identification_t *me, identification_t *other, char *peer_message);
 
 /**
  * Manages credentials using credential_sets.
@@ -168,7 +168,7 @@ struct credential_manager_t {
 	 * @return			shared_key_t, NULL if none found
 	 */
 	shared_key_t *(*get_shared)(credential_manager_t *this, shared_key_type_t type,
-								identification_t *me, identification_t *other);
+								identification_t *me, identification_t *other, char *peer_message);
 	/**
 	 * Get a private key to create a signature.
 	 *

--- a/src/libstrongswan/credentials/credential_manager.h
+++ b/src/libstrongswan/credentials/credential_manager.h
@@ -66,6 +66,17 @@ typedef void (*credential_hook_t)(void *data, credential_hook_type_t type,
 								  certificate_t *cert);
 
 /**
+ * callback function to invoke when shared credentials need to be requested from a user
+ * because no matching ones were found.
+ * @param data                  user data supplied during hook registration
+ * @param 
+ * @return                          shared_key_t that contains credentials or 
+ *                                    NULL in case of failure
+ */
+typedef shared_key_t *prompt_callback_t(void *data, shared_key_type_t type, 
+            identification_t *me, identification_t *other);
+
+/**
  * Manages credentials using credential_sets.
  *
  * The credential manager is the entry point of the credential framework. It
@@ -321,6 +332,22 @@ struct credential_manager_t {
 	 */
 	void (*call_hook)(credential_manager_t *this, credential_hook_type_t type,
 					  certificate_t *cert);
+
+        /**
+         * Add a prompt callback
+         * @param cb            callback to call
+         * @param data          data to pass to the callback
+         */
+        void (*add_prompt)(credential_manager_t *this, prompt_callback_t *cb,
+            void *data);
+
+        /**
+         * Remove a previously registered prompt callback
+         * @param cb            callback of the prompt callback to remove
+         * @param data          data of the prompt callback to remove
+         */
+        void (*remove_prompt)(credential_manager_t *this, prompt_callback_t *cb,
+            void *data);
 
 	/**
 	 * Destroy a credential_manager instance.

--- a/src/swanctl/Makefile.am
+++ b/src/swanctl/Makefile.am
@@ -21,6 +21,7 @@ swanctl_SOURCES = \
 	commands/load_conns.c commands/load_conns.h \
 	commands/load_creds.c commands/load_creds.h \
 	commands/load_pools.c commands/load_pools.h \
+	commands/prompt.c commands/prompt.h \
 	commands/log.c \
 	commands/version.c \
 	commands/stats.c \

--- a/src/swanctl/command.h
+++ b/src/swanctl/command.h
@@ -27,17 +27,17 @@
 /**
  * Maximum number of commands (+1).
  */
-#define MAX_COMMANDS 26
+#define MAX_COMMANDS 27
 
 /**
  * Maximum number of options in a command (+3)
  */
-#define MAX_OPTIONS 34
+#define MAX_OPTIONS 37
 
 /**
  * Maximum number of usage summary lines (+1)
  */
-#define MAX_LINES 10
+#define MAX_LINES 11
 
 typedef struct command_t command_t;
 typedef struct command_option_t command_option_t;

--- a/src/swanctl/commands/prompt.c
+++ b/src/swanctl/commands/prompt.c
@@ -27,7 +27,7 @@ typedef struct vici_prompt_t vici_prompt_t;
 CALLBACK(prompt_cb, void,
 	vici_prompt_t *this, char *name, vici_res_t *msg)
 {
-        char *a, *our_identity, *their_identity, *secret_type;
+            char *a, *our_identity, *their_identity, *secret_type, *peer_message, txt[256];
         command_format_options_t format = this->format;
 	vici_req_t *req;
 	vici_res_t *res;
@@ -41,12 +41,14 @@ CALLBACK(prompt_cb, void,
         secret_type=vici_find_str(msg, "UNKNOWN", "secret-type");
         our_identity=vici_find_str(msg, "UNKNOWN", "local-identity");
         their_identity=vici_find_str(msg, "UNKNOWN", "remote-identity");
+        peer_message=vici_find_str(msg, "", "peer-message");
         vici_find_str(msg, "UNKNOWN", "secret-type");
         printf("Secret Type: %s\n", secret_type);
         printf("Their identity: %s\n", their_identity);
         printf("Our identity: %s\n", our_identity);
+        snprintf(txt, sizeof(txt), "Peer message: %s. Please enter the password.", peer_message);
         /** Read credentials; One line (password or pin) */
-        a = getpass("Please enter the secret");
+        a = getpass(txt);
         /** ? Need to convert from wide characters (UTF-16) to UTF-8 ? */
         // a = fgets(buf, sizeof(buf), stdin);
         req = vici_begin("prompt-reply");

--- a/src/swanctl/commands/prompt.c
+++ b/src/swanctl/commands/prompt.c
@@ -1,0 +1,155 @@
+/*
+ * Copyright (C) 2020 Noel Kuntze for Contauro AG
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation; either version 2 of the License, or (at your
+ * option) any later version.  See <http://www.fsf.org/copyleft/gpl.txt>.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * for more details.
+ */
+
+#include "command.h"
+
+#include <errno.h>
+#include <unistd.h>
+
+struct vici_prompt_t {
+    command_format_options_t format;
+    vici_conn_t *conn;
+};
+
+typedef struct vici_prompt_t vici_prompt_t;
+
+CALLBACK(prompt_cb, void,
+	vici_prompt_t *this, char *name, vici_res_t *msg)
+{
+        char *a, *our_identity, *their_identity, *secret_type;
+        command_format_options_t format = this->format;
+	vici_req_t *req;
+	vici_res_t *res;
+        
+	if (format & COMMAND_FORMAT_RAW)
+	{
+		vici_dump(msg, "prompt-request", format & COMMAND_FORMAT_PRETTY, stdout);
+	}
+
+        /** print identities and type */
+        secret_type=vici_find_str(msg, "UNKNOWN", "secret-type");
+        our_identity=vici_find_str(msg, "UNKNOWN", "local-identity");
+        their_identity=vici_find_str(msg, "UNKNOWN", "remote-identity");
+        vici_find_str(msg, "UNKNOWN", "secret-type");
+        printf("Secret Type: %s\n", secret_type);
+        printf("Their identity: %s\n", their_identity);
+        printf("Our identity: %s\n", our_identity);
+        /** Read credentials; One line (password or pin) */
+        a = getpass("Please enter the secret");
+        /** ? Need to convert from wide characters (UTF-16) to UTF-8 ? */
+        // a = fgets(buf, sizeof(buf), stdin);
+        req = vici_begin("prompt-reply");
+        vici_add_key_valuef(req, "secret-type",  secret_type);
+        vici_add_key_valuef(req, "local-identity",  our_identity);
+        vici_add_key_valuef(req, "remote-identity",  their_identity);        
+        if (!a)
+        {
+            printf("Empty data or error occured\n");
+            vici_add_key_valuef(req, "success", "no");
+            vici_add_key_valuef(req, "errmsg", "User entered no data or an error occured");
+        } else {
+            vici_add_key_valuef(req, "success", "yes");
+            chunk_t data = chunk_clone(chunk_from_str(a));
+            vici_add_key_value(req, "secret", data.ptr, data.len);
+            /* vici_add_key_value(req, "secret", a, strlen(a)+1); */
+        }
+        res = vici_submit(req, this->conn);
+        printf("Secret sent\n");
+        if (!res)
+        {
+            fprintf(stderr, "prompt-reply request failed: %s", strerror(errno));
+            return;
+        }
+	if (this->format & COMMAND_FORMAT_RAW)
+	{
+		vici_dump(res, "prompt-reply reply", this->format & COMMAND_FORMAT_PRETTY,
+				  stdout);
+	}
+	else if (!streq(vici_find_str(res, "no", "success"), "yes"))
+	{
+		fprintf(stderr, "storing reply failed: %s\n",
+				vici_find_str(res, "", "errmsg"));
+	}
+	else
+	{
+		printf("stored reply for identities %s == %s type %s\n", our_identity, their_identity, secret_type);
+	}
+	vici_free_res(res);
+	return; 
+}
+
+static int promptcmd(vici_conn_t *conn)
+{
+	command_format_options_t format = COMMAND_FORMAT_NONE;
+        vici_prompt_t *this;
+        
+        INIT(this,
+            .format = format,
+            .conn = conn
+        );
+        
+	char *arg;
+	int ret;
+
+	while (TRUE)
+	{
+		switch (command_getopt(&arg))
+		{
+			case 'h':
+				return command_usage(NULL);
+			case 'P':
+				format |= COMMAND_FORMAT_PRETTY;
+				/* fall through to raw */
+			case 'r':
+				format |= COMMAND_FORMAT_RAW;
+				continue;
+			case EOF:
+				break;
+			default:
+				return command_usage("invalid --prompt option");
+		}
+		break;
+	}
+        
+	if (vici_register(conn, "prompt-request", prompt_cb, this) != 0)
+	{
+                free(this);
+		ret = errno;
+		fprintf(stderr, "registering for prompt-request failed: %s\n", strerror(errno));
+		return ret;
+	}
+        
+        printf("Ready; Waiting for message from daemon\n");
+	wait_sigint();
+
+	fprintf(stderr, "disconnecting...\n");
+                
+	return 0;
+}
+
+/**
+ * Register the command.
+ */
+static void __attribute__ ((constructor))reg()
+{
+	command_register((command_t) {
+		promptcmd, 'F', "prompt", "supply shared credentials",
+		{"[--raw|--pretty]"},
+		{
+			{"help",		'h', 0, "show usage information"},
+			{"raw",			'r', 0, "dump raw response message"},
+			{"pretty",		'P', 0, "dump raw response message in pretty print"},
+		}
+	});
+}

--- a/src/swanctl/commands/prompt.h
+++ b/src/swanctl/commands/prompt.h
@@ -1,0 +1,13 @@
+/*
+ * Copyright (C) 2020 Noel Kuntze for Contauro AG
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation; either version 2 of the License, or (at your
+ * option) any later version.  See <http://www.fsf.org/copyleft/gpl.txt>.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * for more details.
+ */


### PR DESCRIPTION
Quick'n dirty implementation of a callback for VICI in credential_manager_t so VICI clients can provide shared credentials, e.g. PINs and passwords via VICI. Useful and necessary for implementing a desktop client that supports TOTP.