### PR TITLE
vici: Add DBG4 for IKE that prints loaded PSKs with their Identities …

### DIFF
--- a/src/libcharon/plugins/vici/vici_cred.c
+++ b/src/libcharon/plugins/vici/vici_cred.c
@@ -334,6 +334,7 @@ CALLBACK(load_token, vici_message_t*,
 	if (pin)
 	{	/* provide the pin in a temporary credential set to access the key */
 		shared = shared_key_create(SHARED_PIN, chunk_clone(chunk_from_str(pin)));
+		DBG4(DBG_CFG, "loaded shared PIN for '%s': %s", hex, pin);
 		owner = identification_create_from_encoding(ID_KEY_ID, handle);
 		set = mem_cred_create();
 		set->add_shared(set, shared->get_ref(shared), owner, NULL);
@@ -482,7 +483,7 @@ CALLBACK(load_shared, vici_message_t*,
 		DBG1(DBG_CFG, "loaded %N shared key for: %s",
 			 shared_key_type_names, type, buf);
 	}
-
+	DBG4(DBG_CFG, "key: %#B", &data);
 	this->creds->add_shared_unique(this->creds, unique,
 						shared_key_create(type, chunk_clone(data)), owners);
 


### PR DESCRIPTION
…and the secret, and PINs

The stroke backend prints PSKs and PINs when CFG is set to 4, but vici doesn't.
This commit adds code that does that for vici.