### PR TITLE
testing: Use kvm64 instead of core2duo

### DIFF
--- a/testing/config/kvm/moon.xml
+++ b/testing/config/kvm/moon.xml
@@ -11,7 +11,7 @@
     <boot dev='hd'/>
   </os>
   <cpu>
-    <model fallback='allow'>core2duo</model>
+    <model fallback='allow'>kvm64</model>
     <feature policy='optional' name='aes'/>
     <feature policy='optional' name='pclmuldq'/>
   </cpu>

--- a/testing/config/kvm/sun.xml
+++ b/testing/config/kvm/sun.xml
@@ -11,7 +11,7 @@
     <boot dev='hd'/>
   </os>
   <cpu>
-    <model fallback='allow'>core2duo</model>
+    <model fallback='allow'>kvm64</model>
     <feature policy='optional' name='aes'/>
     <feature policy='optional' name='pclmuldq'/>
   </cpu>


### PR DESCRIPTION
With that change you can use nested virtualization to run the test suite in a virtualized Ubuntu 20.04 (which then runs the debian based VMs that the test suite starts).

Without the changes, at the very least the "monitor" CPU feature isn't satisfied in the VM, which causes the core2duo specified VMs to not start. With kvm64 that issue does not occur.