### PR TITLE
ccm: destroy iv_gen on crypter creation failure

### DIFF
--- a/src/libstrongswan/plugins/ccm/ccm_aead.c
+++ b/src/libstrongswan/plugins/ccm/ccm_aead.c
@@ -415,8 +415,10 @@ ccm_aead_t *ccm_aead_create(encryption_algorithm_t algo,
 		.icv_size = icv_size,
 	);
 
-	if (!this->crypter)
+	if (!this->crypter || !this->iv_gen)
 	{
+		DESTROY_IF(this->crypter);
+		DESTROY_IF(this->iv_gen);
 		free(this);
 		return NULL;
 	}


### PR DESCRIPTION
The initialization creates a `crypter` and `iv_gen`, but checks only `crypter` creation failure and does not destroy `iv_gen` then.