### PR TITLE
testing: mkdir -p $SHAREDDIR

### DIFF
--- a/testing/scripts/build-strongswan
+++ b/testing/scripts/build-strongswan
@@ -124,6 +124,7 @@ execute "mount -t proc none $LOOPDIR/proc"
 do_on_exit umount $LOOPDIR/proc
 
 mkdir -p $LOOPDIR/root/shared
+mkdir -p "$SHAREDDIR"
 log_action "Mounting $SHAREDDIR as /root/shared"
 execute "mount -o bind $SHAREDDIR $LOOPDIR/root/shared"
 do_on_exit umount $LOOPDIR/root/shared


### PR DESCRIPTION
Otherwise testing fails because the dir does not exist when trying to mount it.