### PR TITLE
library: Initialize lib->leak_detective to NULL if the build is witho…

### DIFF
--- a/src/libstrongswan/library.c
+++ b/src/libstrongswan/library.c
@@ -345,6 +345,8 @@ bool library_init(char *settings, const char *namespace)
 		lib->leak_detective->set_report_cb(lib->leak_detective,
 										   report_leaks, sum_leaks, this);
 	}
+#else
+	lib->leak_detective = NULL;
 #endif /* LEAK_DETECTIVE */
 
 	pfh = printf_hook_create();


### PR DESCRIPTION
…ut leak detective.

Fixes at the very least a crash in the test cases when run with valgrind.