### PR TITLE
testing: Replace qemu-kvm with qemu-system-x86_64 (because qemu-kvm d…

### DIFF
--- a/testing/config/kvm/alice.xml
+++ b/testing/config/kvm/alice.xml
@@ -20,7 +20,7 @@
   <on_reboot>restart</on_reboot>
   <on_crash>restart</on_crash>
   <devices>
-    <emulator>/usr/bin/kvm</emulator>
+    <emulator>/usr/bin/qemu-system-x86_64</emulator>
     <disk type='file' device='disk'>
       <driver name='qemu' type='qcow2' cache='writethrough'/>
       <source file='/var/lib/libvirt/images/alice.qcow2'/>

--- a/testing/config/kvm/bob.xml
+++ b/testing/config/kvm/bob.xml
@@ -20,7 +20,7 @@
   <on_reboot>restart</on_reboot>
   <on_crash>restart</on_crash>
   <devices>
-    <emulator>/usr/bin/kvm</emulator>
+    <emulator>/usr/bin/qemu-system-x86_64</emulator>
     <disk type='file' device='disk'>
       <driver name='qemu' type='qcow2' cache='writethrough'/>
       <source file='/var/lib/libvirt/images/bob.qcow2'/>

--- a/testing/config/kvm/carol.xml
+++ b/testing/config/kvm/carol.xml
@@ -20,7 +20,7 @@
   <on_reboot>restart</on_reboot>
   <on_crash>restart</on_crash>
   <devices>
-    <emulator>/usr/bin/kvm</emulator>
+    <emulator>/usr/bin/qemu-system-x86_64</emulator>
     <disk type='file' device='disk'>
       <driver name='qemu' type='qcow2' cache='writethrough'/>
       <source file='/var/lib/libvirt/images/carol.qcow2'/>

--- a/testing/config/kvm/dave.xml
+++ b/testing/config/kvm/dave.xml
@@ -20,7 +20,7 @@
   <on_reboot>restart</on_reboot>
   <on_crash>restart</on_crash>
   <devices>
-    <emulator>/usr/bin/kvm</emulator>
+    <emulator>/usr/bin/qemu-system-x86_64</emulator>
     <disk type='file' device='disk'>
       <driver name='qemu' type='qcow2' cache='writethrough'/>
       <source file='/var/lib/libvirt/images/dave.qcow2'/>

--- a/testing/config/kvm/moon.xml
+++ b/testing/config/kvm/moon.xml
@@ -25,7 +25,7 @@
   <on_reboot>restart</on_reboot>
   <on_crash>restart</on_crash>
   <devices>
-    <emulator>/usr/bin/kvm</emulator>
+    <emulator>/usr/bin/qemu-system-x86_64</emulator>
     <disk type='file' device='disk'>
       <driver name='qemu' type='qcow2' cache='writethrough'/>
       <source file='/var/lib/libvirt/images/moon.qcow2'/>

--- a/testing/config/kvm/sun.xml
+++ b/testing/config/kvm/sun.xml
@@ -25,7 +25,7 @@
   <on_reboot>restart</on_reboot>
   <on_crash>restart</on_crash>
   <devices>
-    <emulator>/usr/bin/kvm</emulator>
+    <emulator>/usr/bin/qemu-system-x86_64</emulator>
     <disk type='file' device='disk'>
       <driver name='qemu' type='qcow2' cache='writethrough'/>
       <source file='/var/lib/libvirt/images/sun.qcow2'/>

--- a/testing/config/kvm/venus.xml
+++ b/testing/config/kvm/venus.xml
@@ -20,7 +20,7 @@
   <on_reboot>restart</on_reboot>
   <on_crash>restart</on_crash>
   <devices>
-    <emulator>/usr/bin/kvm</emulator>
+    <emulator>/usr/bin/qemu-system-x86_64</emulator>
     <disk type='file' device='disk'>
       <driver name='qemu' type='qcow2' cache='writethrough'/>
       <source file='/var/lib/libvirt/images/venus.qcow2'/>

--- a/testing/config/kvm/winnetou.xml
+++ b/testing/config/kvm/winnetou.xml
@@ -20,7 +20,7 @@
   <on_reboot>restart</on_reboot>
   <on_crash>restart</on_crash>
   <devices>
-    <emulator>/usr/bin/kvm</emulator>
+    <emulator>/usr/bin/qemu-system-x86_64</emulator>
     <disk type='file' device='disk'>
       <driver name='qemu' type='qcow2' cache='writethrough'/>
       <source file='/var/lib/libvirt/images/winnetou.qcow2'/>

--- a/testing/start-testing
+++ b/testing/start-testing
@@ -17,7 +17,7 @@ echo "Starting test environment"
 [ `id -u` -eq 0 ] || die "You must be root to run $0"
 running_any $STRONGSWANHOSTS && die "Please stop test environment before running $0"
 
-check_commands kvm virsh
+check_commands virsh qemu-system-x86_64
 
 [ -f $KNLSRC ] || die "Kernel $KNLSRC not found"
 log_action "Deploying kernel $KERNEL"


### PR DESCRIPTION
…oes not exist on non-debian based distros)

Also, the "kvm" script in PATH is only a compatibility thing, says the man page:
`man kvm`:
```
The kvm wrapper script is used to provide compatibility with old qemu-kvm package which has been merged into qemu as of version 1.3.
```