### PR TITLE
Fix undefined call to shake256 when WOLFSSL_NO_SHAKE256 is defined

### DIFF
--- a/src/libstrongswan/plugins/wolfssl/wolfssl_xof.c
+++ b/src/libstrongswan/plugins/wolfssl/wolfssl_xof.c
@@ -14,7 +14,7 @@
 
 #include <wolfssl/options.h>
 
-#ifdef WOLFSSL_SHAKE256
+#if defined WOLFSSL_SHAKE256 && !defined WOLFSSL_NO_SHAKE256
 
 #include <wolfssl/wolfcrypt/sha3.h>
 
@@ -149,4 +149,4 @@ xof_t *wolfssl_xof_create(ext_out_function_t algorithm)
 	return &this->public;
 }
 
-#endif /* WOLFSSL_SHAKE256 */
+#endif /* WOLFSSL_SHAKE256 && !WOLFSSL_NO_SHAKE256 */


### PR DESCRIPTION
When testing the FIPS instructions from https://www.wolfssl.com/strongswan-wolfssl-fips-2/ , there were build failures during make in strongswan.

```
wolfssl_xof.c:41:2: error: unknown type name ‘wc_Shake’
   41 |  wc_Shake shake;
      |  ^~~~~~~~
wolfssl_xof.c: In function ‘get_bytes’:
wolfssl_xof.c:69:6: warning: implicit declaration of function ‘wc_Shake256_Update’; did you mean ‘wc_Sha3_256_Update’? [-Wimplicit-function-declaration]
   69 |  if (wc_Shake256_Update(&this->shake, this->seed.ptr, this->seed.len) == 0)
      |      ^~~~~~~~~~~~~~~~~~
      |      wc_Sha3_256_Update
wolfssl_xof.c:72:7: warning: implicit declaration of function ‘wc_Shake256_Final’; did you mean ‘wc_Sha3_256_Final’? [-Wimplicit-function-declaration]
   72 |   if (wc_Shake256_Final(&this->shake, data.ptr, data.len) == 0)
      |       ^~~~~~~~~~~~~~~~~
      |       wc_Sha3_256_Final
wolfssl_xof.c: In function ‘destroy’:
wolfssl_xof.c:114:2: warning: implicit declaration of function ‘wc_Shake256_Free’; did you mean ‘wc_Sha3_256_Free’? [-Wimplicit-function-declaration]
  114 |  wc_Shake256_Free(&this->shake);
      |  ^~~~~~~~~~~~~~~~
      |  wc_Sha3_256_Free
wolfssl_xof.c: In function ‘wolfssl_xof_create’:
wolfssl_xof.c:143:6: warning: implicit declaration of function ‘wc_InitShake256’; did you mean ‘wc_InitSha3_256’? [-Wimplicit-function-declaration]
  143 |  if (wc_InitShake256(&this->shake, NULL, 0) != 0)
      |      ^~~~~~~~~~~~~~~
      |      wc_InitSha3_256
make[5]: *** [Makefile:648: wolfssl_xof.lo] Error 1
```

wolfSSL FIPS defines `WOLFSSL_NO_SHAKE256` because that algorithm is not certified.