### PR TITLE
Expose the dh_group on add_sa

### DIFF
--- a/src/libcharon/kernel/kernel_ipsec.h
+++ b/src/libcharon/kernel/kernel_ipsec.h
@@ -83,6 +83,8 @@ struct kernel_ipsec_add_sa_t {
 	uint16_t int_alg;
 	/** Integrity protection key */
 	chunk_t int_key;
+	/** Diffie Hellman group */
+	uint16_t dh_group;
 	/** Anti-replay window size */
 	uint32_t replay_window;
 	/** Traffic Flow Confidentiality padding */

--- a/src/libcharon/sa/child_sa.c
+++ b/src/libcharon/sa/child_sa.c
@@ -779,7 +779,7 @@ static status_t install_internal(private_child_sa_t *this, chunk_t encr,
 	chunk_t integ, uint32_t spi, uint16_t cpi, bool initiator, bool inbound,
 	bool tfcv3)
 {
-	uint16_t enc_alg = ENCR_UNDEFINED, int_alg = AUTH_UNDEFINED, size;
+	uint16_t enc_alg = ENCR_UNDEFINED, int_alg = AUTH_UNDEFINED, dh_group = MODP_NULL, size;
 	uint16_t esn = NO_EXT_SEQ_NUMBERS;
 	linked_list_t *my_ts, *other_ts, *src_ts, *dst_ts;
 	time_t now;
@@ -840,6 +840,8 @@ static status_t install_internal(private_child_sa_t *this, chunk_t encr,
 								  &enc_alg, &size);
 	this->proposal->get_algorithm(this->proposal, INTEGRITY_ALGORITHM,
 								  &int_alg, &size);
+	this->proposal->get_algorithm(this->proposal, DIFFIE_HELLMAN_GROUP,
+								  &dh_group, &size);
 	this->proposal->get_algorithm(this->proposal, EXTENDED_SEQUENCE_NUMBERS,
 								  &esn, NULL);
 
@@ -908,6 +910,7 @@ static status_t install_internal(private_child_sa_t *this, chunk_t encr,
 		.enc_key = encr,
 		.int_alg = int_alg,
 		.int_key = integ,
+		.dh_group = dh_group,
 		.replay_window = this->config->get_replay_window(this->config),
 		.tfc = tfc,
 		.ipcomp = this->ipcomp,


### PR DESCRIPTION
This would enable add_sa implementations to validate and expose externally the used DH group.