### PR TITLE
gitignore: Add /nbproject

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,4 @@ coverage/
 /*.files
 /*.includes
 test-driver
+nbproject/


### PR DESCRIPTION
/nbproject is the Apache Netbeans IDE project file directory. Lots of prople probably use Netbeans with the (simple) C plugin to work on strongSwan with it. It makes sense to add it into the .gitignore file here.