### PR TITLE
[RFC] random: provide RNG_WEAK

### DIFF
--- a/src/libstrongswan/plugins/random/random_plugin.c
+++ b/src/libstrongswan/plugins/random/random_plugin.c
@@ -108,6 +108,7 @@ METHOD(plugin_t, get_features, int,
 {
 	static plugin_feature_t f[] = {
 		PLUGIN_REGISTER(RNG, random_rng_create),
+			PLUGIN_PROVIDE(RNG, RNG_WEAK),
 			PLUGIN_PROVIDE(RNG, RNG_STRONG),
 			PLUGIN_PROVIDE(RNG, RNG_TRUE),
 	};


### PR DESCRIPTION
Looks like this was an oversight that the random plugin is not also
registering itself as a RNG source for RNG_WEAK.

There is code in random_rng.c which handels the RNG_WEAK case and
uses then /dev/urandom.