### PR TITLE
Support for trapping and restarting at the same time

### DIFF
--- a/src/libcharon/config/child_cfg.c
+++ b/src/libcharon/config/child_cfg.c
@@ -22,10 +22,11 @@
 
 #include <daemon.h>
 
-ENUM(action_names, ACTION_NONE, ACTION_RESTART,
+ENUM(action_names, ACTION_NONE, ACTION_TRAPRESTART,
 	"clear",
 	"hold",
 	"restart",
+	"traprestart"
 );
 
 /** Default replay window size, if not set using charon.replay_window */

--- a/src/libcharon/config/child_cfg.h
+++ b/src/libcharon/config/child_cfg.h
@@ -45,6 +45,8 @@ enum action_t {
 	ACTION_ROUTE,
 	/** Start or restart config immediately */
 	ACTION_RESTART,
+	/** perform ACTION_ROUTE and then ACTION_RESTART */
+	ACTION_TRAPRESTART
 };
 
 /**

--- a/src/libcharon/plugins/vici/vici_config.c
+++ b/src/libcharon/plugins/vici/vici_config.c
@@ -1004,6 +1004,7 @@ CALLBACK(parse_action, bool,
 	action_t *out, chunk_t v)
 {
 	enum_map_t map[] = {
+		{ "starttrap",	ACTION_TRAPRESTART },
 		{ "start",		ACTION_RESTART	},
 		{ "restart",	ACTION_RESTART	},
 		{ "route",		ACTION_ROUTE	},

--- a/src/libcharon/processing/jobs/start_action_job.c
+++ b/src/libcharon/processing/jobs/start_action_job.c
@@ -56,6 +56,25 @@ METHOD(job_t, execute, job_requeue_t,
 
 			switch (child_cfg->get_start_action(child_cfg))
 			{
+				case ACTION_TRAPRESTART:
+					DBG1(DBG_JOB, "start action: starttrap '%s'", name);
+					mode = child_cfg->get_mode(child_cfg);
+					if (mode == MODE_PASS || mode == MODE_DROP)
+					{
+						charon->shunts->install(charon->shunts,
+												peer_cfg->get_name(peer_cfg),
+												child_cfg);
+					}
+					else
+					{
+						charon->traps->install(charon->traps, peer_cfg,
+											   child_cfg);
+					}
+					charon->controller->initiate(charon->controller,
+												 peer_cfg->get_ref(peer_cfg),
+												 child_cfg->get_ref(child_cfg),
+												 NULL, NULL, 0, FALSE);
+					break;
 				case ACTION_RESTART:
 					DBG1(DBG_JOB, "start action: initiate '%s'", name);
 					charon->controller->initiate(charon->controller,

--- a/src/libcharon/sa/ike_sa.c
+++ b/src/libcharon/sa/ike_sa.c
@@ -2076,6 +2076,7 @@ static status_t reestablish_children(private_ike_sa_t *this, ike_sa_t *new,
 		}
 		switch (action)
 		{
+			case ACTION_TRAPRESTART:
 			case ACTION_RESTART:
 				child_cfg = child_sa->get_config(child_sa);
 				DBG1(DBG_IKE, "restarting CHILD_SA %s",
@@ -2166,6 +2167,8 @@ METHOD(ike_sa_t, reestablish, status_t,
 				case ACTION_RESTART:
 					restart = TRUE;
 					break;
+				case ACTION_TRAPRESTART:
+					restart = TRUE;
 				case ACTION_ROUTE:
 					charon->traps->install(charon->traps, this->peer_cfg,
 										   child_sa->get_config(child_sa));

--- a/src/libcharon/sa/ikev1/tasks/quick_delete.c
+++ b/src/libcharon/sa/ikev1/tasks/quick_delete.c
@@ -154,6 +154,10 @@ static status_t delete_child(private_quick_delete_t *this,
 
 			switch (child_sa->get_close_action(child_sa))
 			{
+				case ACTION_TRAPRESTART:
+					charon->traps->install(charon->traps,
+									this->ike_sa->get_peer_cfg(this->ike_sa),
+									child_cfg);
 				case ACTION_RESTART:
 					child_cfg->get_ref(child_cfg);
 					status = this->ike_sa->initiate(this->ike_sa, child_cfg,

--- a/src/libcharon/sa/ikev2/tasks/child_delete.c
+++ b/src/libcharon/sa/ikev2/tasks/child_delete.c
@@ -371,6 +371,14 @@ static status_t destroy_and_reestablish(private_child_delete_t *this)
 		{	/* enforce child_cfg policy if deleted passively */
 			switch (action)
 			{
+				case ACTION_TRAPRESTART:
+					child_cfg->get_ref(child_cfg);
+					status = this->ike_sa->initiate(this->ike_sa, child_cfg,
+													reqid, NULL, NULL);
+					charon->traps->install(charon->traps,
+									this->ike_sa->get_peer_cfg(this->ike_sa),
+									child_cfg);
+					break;
 				case ACTION_RESTART:
 					child_cfg->get_ref(child_cfg);
 					status = this->ike_sa->initiate(this->ike_sa, child_cfg,

--- a/src/swanctl/swanctl.opt
+++ b/src/swanctl/swanctl.opt
@@ -880,13 +880,14 @@ connections.<conn>.children.<child>.policies_fwd_out = no
 	traffic for this CHILD_SA.
 
 connections.<conn>.children.<child>.dpd_action = clear
-	Action to perform on DPD timeout (_clear_, _trap_ or _restart_).
+	Action to perform on DPD timeout (_clear_, _trap_ or _restart_, _traprestart_).
 
 	Action to perform for this CHILD_SA on DPD timeout. The default _clear_
 	closes the CHILD_SA and does not take further action. _trap_ installs
 	a trap policy, which will catch matching traffic and tries to re-negotiate
 	the tunnel on-demand. _restart_ immediately tries to re-negotiate the
-	CHILD_SA under a fresh IKE_SA.
+	CHILD_SA under a fresh IKE_SA. _traprestart_ performs the actions of
+	the _trap_ and _restart_ keywords.
 
 connections.<conn>.children.<child>.ipcomp = no
 	Enable IPComp compression before encryption.
@@ -1067,7 +1068,7 @@ connections.<conn>.children.<child>.copy_dscp = out
 	not supported by all kernel interfaces.
 
 connections.<conn>.children.<child>.start_action = none
-	Action to perform after loading the configuration (_none_, _trap_, _start_).
+	Action to perform after loading the configuration (_none_, _trap_, _start_, _trapstart_).
 
 	Action to perform after loading the configuration. The default of _none_
 	loads the connection only, which then can be manually initiated or used as
@@ -1075,19 +1076,23 @@ connections.<conn>.children.<child>.start_action = none
 
 	The value _trap_ installs a trap policy, which triggers the tunnel as soon
 	as matching traffic has been detected. The value _start_ initiates
-	the connection actively.
+	the connection actively. The value _trapstart_ performs the actions of the
+	_trap_ and _start_ keywords.
 
 	When unloading or replacing a CHILD_SA configuration having a
 	**start_action** different from _none_, the inverse action is performed.
 	Configurations with _start_ get closed, while such with _trap_ get
-	uninstalled.
+	uninstalled. Configurations with _trapstart_ get closed and their traps
+	get uninstalled.
 
 connections.<conn>.children.<child>.close_action = none
-	Action to perform after a CHILD_SA gets closed (_none_, _trap_, _start_).
+	Action to perform after a CHILD_SA gets closed (_none_, _trap_, _start_,
+	_trapstart_).
 
 	Action to perform after a CHILD_SA gets closed by the peer. The default of
 	_none_ does not take any action, _trap_ installs a trap policy for the
-	CHILD_SA. _start_ tries to re-create the CHILD_SA.
+	CHILD_SA. _start_ tries to re-create the CHILD_SA. _trapstart_ performs
+	the actions of _trap_ and _start_
 
 	**close_action** does not provide any guarantee that the CHILD_SA is kept
 	alive. It acts on explicit close messages only, but not on negotiation


### PR DESCRIPTION
Needed to tell strongSwan to trap and start a connection when the daemon starts.
Otherwise one needs to code that manually using a script and that sucks.