### PR TITLE
Usage of agreed PRF function in pubkey auth

### DIFF
--- a/src/libcharon/sa/ikev2/authenticators/pubkey_authenticator.c
+++ b/src/libcharon/sa/ikev2/authenticators/pubkey_authenticator.c
@@ -439,9 +439,31 @@ static status_t sign_classic(private_pubkey_authenticator_t *this,
 	switch (private->get_type(private))
 	{
 		case KEY_RSA:
-			scheme = SIGN_RSA_EMSA_PKCS1_SHA1;
+		{
+			chunk_t skd = chunk_empty;
+			keymat_v2_t *keymat = (keymat_v2_t*)this->ike_sa->get_keymat(this->ike_sa);
+			pseudo_random_function_t prf_alg = keymat->get_skd(keymat, &skd);
 			auth_method = AUTH_RSA;
+			switch (prf_alg)
+			{
+				case PRF_HMAC_MD5:
+					scheme = SIGN_RSA_EMSA_PKCS1_MD5;
+					break;
+				case PRF_HMAC_SHA2_256:
+					scheme = SIGN_RSA_EMSA_PKCS1_SHA2_256;
+					break;
+				case PRF_HMAC_SHA2_384:
+					scheme = SIGN_RSA_EMSA_PKCS1_SHA2_384;
+					break;
+				case PRF_HMAC_SHA2_512:
+					scheme = SIGN_RSA_EMSA_PKCS1_SHA2_512;
+					break;
+				default:
+					scheme = SIGN_RSA_EMSA_PKCS1_SHA1;
+					break;
+			}
 			break;
+		}
 		case KEY_ECDSA:
 			/* deduct the signature scheme from the keysize */
 			switch (private->get_keysize(private))
@@ -598,9 +620,31 @@ METHOD(authenticator_t, process, status_t,
 	switch (auth_method)
 	{
 		case AUTH_RSA:
+		{
 			key_type = KEY_RSA;
-			params->scheme = SIGN_RSA_EMSA_PKCS1_SHA1;
+			chunk_t skd = chunk_empty;
+			keymat_v2_t *keymat = (keymat_v2_t*)this->ike_sa->get_keymat(this->ike_sa);
+			pseudo_random_function_t prf_alg = keymat->get_skd(keymat, &skd);
+			switch (prf_alg)
+			{
+				case PRF_HMAC_MD5:
+					params->scheme = SIGN_RSA_EMSA_PKCS1_MD5;
+					break;
+				case PRF_HMAC_SHA2_256:
+					params->scheme = SIGN_RSA_EMSA_PKCS1_SHA2_256;
+					break;
+				case PRF_HMAC_SHA2_384:
+					params->scheme = SIGN_RSA_EMSA_PKCS1_SHA2_384;
+					break;
+				case PRF_HMAC_SHA2_512:
+					params->scheme = SIGN_RSA_EMSA_PKCS1_SHA2_512;
+					break;
+				default:
+					params->scheme = SIGN_RSA_EMSA_PKCS1_SHA1;
+					break;
+			}
 			break;
+		}
 		case AUTH_ECDSA_256:
 			params->scheme = SIGN_ECDSA_256;
 			break;


### PR DESCRIPTION
This patch adjust pubkey authentication to use agreed PRF function for RSA KEY types.