### PR TITLE
Extend IKE_SA of other OCTET ID

### DIFF
--- a/src/libcharon/sa/ike_sa.h
+++ b/src/libcharon/sa/ike_sa.h
@@ -507,6 +507,14 @@ struct ike_sa_t {
 	identification_t* (*get_other_id) (ike_sa_t *this);
 
 	/**
+	 * Get the other peer's identification for keymat octet
+	 * calculations
+	 *
+	 * @return				identification
+	 */
+	identification_t* (*get_other_octet_id) (ike_sa_t *this);
+
+	/**
 	 * Get the others peer identity, but prefer an EAP-Identity.
 	 *
 	 * @return				EAP or IKEv2 identity
@@ -519,6 +527,20 @@ struct ike_sa_t {
 	 * @param other			identification
 	 */
 	void (*set_other_id) (ike_sa_t *this, identification_t *other);
+
+	/**
+	 * Set the other peer's identification for keymat octet
+	 * calculations
+	 *
+	 * Authenticators by default use the same identification
+	 * for certificate selection and getting octet data for signature etc.
+	 * If other octet id is set, this identification is used fo getting
+	 * octet data for signature/verfication, while keeping the identification
+	 * used for certificate selection untouched
+	 *
+	 * @param other_octet_id		identification
+	 */
+	void (*set_other_octet_id) (ike_sa_t *this, identification_t* other_octet_id);
 
 	/**
 	 * Get the config used to setup this IKE_SA.

--- a/src/libcharon/sa/ikev2/authenticators/eap_authenticator.c
+++ b/src/libcharon/sa/ikev2/authenticators/eap_authenticator.c
@@ -457,6 +457,7 @@ static bool verify_auth(private_eap_authenticator_t *this, message_t *message,
 	notify_payload_t *notify;
 	chunk_t auth_data, recv_auth_data;
 	identification_t *other_id;
+	identification_t *other_octet_id;
 	auth_cfg_t *auth;
 	keymat_v2_t *keymat;
 	eap_type_t type;
@@ -483,9 +484,10 @@ static bool verify_auth(private_eap_authenticator_t *this, message_t *message,
 	}
 
 	other_id = this->ike_sa->get_other_id(this->ike_sa);
+	other_octet_id = this->ike_sa->get_other_octet_id(this->ike_sa);
 	keymat = (keymat_v2_t*)this->ike_sa->get_keymat(this->ike_sa);
 	if (!keymat->get_psk_sig(keymat, TRUE, init, nonce, this->msk, this->ppk,
-							 other_id, this->reserved, &auth_data))
+							 other_octet_id, this->reserved, &auth_data))
 	{
 		return FALSE;
 	}

--- a/src/libcharon/sa/ikev2/authenticators/psk_authenticator.c
+++ b/src/libcharon/sa/ikev2/authenticators/psk_authenticator.c
@@ -122,6 +122,7 @@ METHOD(authenticator_t, process, status_t,
 {
 	chunk_t auth_data, recv_auth_data;
 	identification_t *my_id, *other_id;
+	identification_t *other_octet_id;
 	auth_payload_t *auth_payload;
 	notify_payload_t *notify;
 	auth_cfg_t *auth;
@@ -152,6 +153,7 @@ METHOD(authenticator_t, process, status_t,
 	keymat = (keymat_v2_t*)this->ike_sa->get_keymat(this->ike_sa);
 	my_id = this->ike_sa->get_my_id(this->ike_sa);
 	other_id = this->ike_sa->get_other_id(this->ike_sa);
+	other_octet_id = this->ike_sa->get_other_octet_id(this->ike_sa);
 	enumerator = lib->credmgr->create_shared_enumerator(lib->credmgr,
 												SHARED_IKE, my_id, other_id);
 	while (!authenticated && enumerator->enumerate(enumerator, &key, NULL, NULL))
@@ -159,7 +161,7 @@ METHOD(authenticator_t, process, status_t,
 		keys_found++;
 
 		if (!keymat->get_psk_sig(keymat, TRUE, this->ike_sa_init, this->nonce,
-								 key->get_key(key), this->ppk, other_id,
+								 key->get_key(key), this->ppk, other_octet_id,
 								 this->reserved, &auth_data))
 		{
 			continue;

--- a/src/libcharon/sa/ikev2/authenticators/pubkey_authenticator.c
+++ b/src/libcharon/sa/ikev2/authenticators/pubkey_authenticator.c
@@ -408,8 +408,9 @@ static bool get_auth_octets_scheme(private_pubkey_authenticator_t *this,
 	array_insert(schemes, ARRAY_TAIL, *scheme);
 
 	keymat = (keymat_v2_t*)this->ike_sa->get_keymat(this->ike_sa);
-	if (keymat->get_auth_octets(keymat, verify, this->ike_sa_init, this->nonce,
-								ppk, id, this->reserved, octets,
+	if (keymat->get_auth_octets(keymat, verify, this->ike_sa_init, this->nonce, ppk,
+								verify ? this->ike_sa->get_other_octet_id(this->ike_sa) : id,
+								this->reserved, octets,
 								schemes) &&
 		array_remove(schemes, 0, scheme))
 	{


### PR DESCRIPTION
This enhancement allows various pubkey and eap authenticators to use different identification for keymat octets calculations then the one that is from received certificate