### PR TITLE
WIP: resolve: add search domain and resolveconf path settings

### DIFF
--- a/src/libcharon/plugins/resolve/resolve_handler.c
+++ b/src/libcharon/plugins/resolve/resolve_handler.c
@@ -60,6 +60,8 @@ struct private_resolve_handler_t {
 	 */
 	char *iface_prefix;
 
+	char *search_domain;
+
 	/**
 	 * Mutex to access file exclusively
 	 */
@@ -210,6 +212,8 @@ static bool invoke_resolvconf(private_resolve_handler_t *this, host_t *addr,
 		if (shell)
 		{
 			DBG1(DBG_IKE, "installing DNS server %H via resolvconf", addr);
+			if (this->search_domain)
+				fprintf(shell, "search %s\n", this->search_domain);
 			fprintf(shell, "nameserver %H\n", addr);
 			fclose(shell);
 		}
@@ -498,6 +502,9 @@ resolve_handler_t *resolve_handler_create()
 		this->iface_prefix = lib->settings->get_str(lib->settings,
 								"%s.plugins.resolve.resolvconf.iface_prefix",
 								RESOLVCONF_PREFIX, lib->ns);
+		this->search_domain = lib->settings->get_str(lib->settings,
+								"%s.plugins.resolve.resolvconf.search_domain",
+								NULL, lib->ns);
 	}
 
 	return &this->public;

--- a/src/libcharon/plugins/resolve/resolve_handler.c
+++ b/src/libcharon/plugins/resolve/resolve_handler.c
@@ -48,6 +48,8 @@ struct private_resolve_handler_t {
 	 */
 	char *file;
 
+	char *exec;
+
 	/**
 	 * Use resolvconf instead of writing directly to resolv.conf
 	 */
@@ -195,7 +197,7 @@ static bool invoke_resolvconf(private_resolve_handler_t *this, host_t *addr,
 	/* we use the nameserver's IP address as part of the interface name to
 	 * make them unique */
 	process = process_start_shell(NULL, install ? &in : NULL, &out, NULL,
-							"2>&1 %s %s %s%H", RESOLVCONF_EXEC,
+							"2>&1 %s %s %s%H", this->exec,
 							install ? "-a" : "-d", this->iface_prefix, addr);
 
 	if (!process)
@@ -486,7 +488,11 @@ resolve_handler_t *resolve_handler_create()
 									   RESOLV_CONF, lib->ns),
 	);
 
-	if (stat(RESOLVCONF_EXEC, &st) == 0)
+	this->exec = lib->settings->get_str(lib->settings,
+										"%s.plugins.resolve.resolvconf.exec",
+										RESOLVCONF_EXEC, lib->ns);
+
+	if (stat(this->exec, &st) == 0)
 	{
 		this->use_resolvconf = TRUE;
 		this->iface_prefix = lib->settings->get_str(lib->settings,


### PR DESCRIPTION
I'm just looking for feedback on this before I put any work into documentation/testing.

First, allowing the location of `resolvconf` to be specified.  This is to help with non-FHS systems (NixOS in my case).  An alternative here would be to depend on `$PATH`, but we'd then need to change how `use_resolvconf` is determined.  Currently nixpkgs patches strongswan to depend directly on `openresolv`, but this doesn't account for other implementations of `resolvconf`, such as `systemd-resolved`.

Secondly, allow a search domain to be specified in the configuration fragment passed to `resolvconf`.  Using this I can configure `resolvconf` to treat this as a private interface, which will in turn configure `dnsmasq` to use nameservers from charon only for the specified domain.

- Is there a way I could configure search domains per-connection?  I couldn't find an example of a similar setting.
- It looks like https://datatracker.ietf.org/doc/html/rfc8598 would cover this, but I don't see any signs of implementation.  Also, a client may still want to override it.
