### PR TITLE
sys-logger: Optionally support mapping strongSwan loglevels to syslog levels

### DIFF
--- a/conf/options/charon-logging.opt
+++ b/conf/options/charon-logging.opt
@@ -70,3 +70,14 @@ charon.syslog.<facility>.ike_name = no
 
 charon.syslog.<facility>.log_level = no
 	Add the log level of each message after the subsystem (e.g. [IKE2]).
+
+charon.syslog.<facility>.map_level = -1
+	Map strongSwan specific loglevels to syslog loglevels.
+
+	The default setting of -1 passes all messages to syslog using a log
+	level of LOG_INFO. A non-negative value maps the strongSwan specific
+	loglevels (0..4) to the syslog level starting at the specified number.
+	For example, a value of 5 (LOG_NOTICE) maps strongSwan loglevel 0 to
+	LOG_NOTICE, level 1 to LOG_INFO, and levels 2, 3 and 4 to LOG_DEBUG.
+	This allows (additional) filtering of log messages on the syslog
+	server.

--- a/src/libcharon/bus/listeners/sys_logger.h
+++ b/src/libcharon/bus/listeners/sys_logger.h
@@ -49,8 +49,10 @@ struct sys_logger_t {
 	 *
 	 * @param ike_name	TRUE to prefix the name of the IKE_SA
 	 * @param log_level	TRUE to include the log level in the message
+	 * @param map_level	map log level to syslog level, -1 to disable
 	 */
-	void (*set_options) (sys_logger_t *this, bool ike_name, bool log_level);
+	void (*set_options) (sys_logger_t *this, bool ike_name, bool log_level,
+						 int map_level);
 
 	/**
 	 * Destroys a sys_logger_t object.

--- a/src/libcharon/daemon.c
+++ b/src/libcharon/daemon.c
@@ -451,6 +451,7 @@ static void load_sys_logger(private_daemon_t *this, char *facility,
 	debug_t group;
 	level_t def;
 	bool ike_name, log_level;
+	int map_level;
 
 	if (get_syslog_facility(facility) == -1)
 	{
@@ -467,8 +468,10 @@ static void load_sys_logger(private_daemon_t *this, char *facility,
 									   FALSE, lib->ns, facility);
 	log_level = lib->settings->get_bool(lib->settings, "%s.syslog.%s.log_level",
 									   FALSE, lib->ns, facility);
+	map_level = lib->settings->get_int(lib->settings, "%s.syslog.%s.map_level",
+									   -1, lib->ns, facility);
 
-	sys_logger->set_options(sys_logger, ike_name, log_level);
+	sys_logger->set_options(sys_logger, ike_name, log_level, map_level);
 
 	def = lib->settings->get_int(lib->settings, "%s.syslog.%s.default", 1,
 								 lib->ns, facility);


### PR DESCRIPTION
strongSwan logs all syslog messages using LOG_INFO for historical reasons,
regardless of the strongSwan loglevel used producing the log message.

In some setups with advanced logging infrastructure, it may be feasible
to be more verbose when logging in strongSwan, but then filter messages
on the syslog server. While this may be possible by custom syslog filtering
rules matching the log level included with the log_level setting, this is
not super convenient.

So add a new map_level setting, which can map strongSwan loglevels to
syslog loglevels. By default this is disabled, keeping the existing
behavior. If enabled, it maps strongSwan loglevels to syslog loglevels
at a given syslog loglevel offset.