### PR TITLE
proposal: Add ESN transforms to default ESP AEAD proposal

### DIFF
--- a/src/libstrongswan/crypto/proposal/proposal.c
+++ b/src/libstrongswan/crypto/proposal/proposal.c
@@ -1304,6 +1304,7 @@ proposal_t *proposal_create_default_aead(protocol_id_t protocol)
 			add_algorithm(this, ENCRYPTION_ALGORITHM, ENCR_AES_GCM_ICV16, 128);
 			add_algorithm(this, ENCRYPTION_ALGORITHM, ENCR_AES_GCM_ICV16, 192);
 			add_algorithm(this, ENCRYPTION_ALGORITHM, ENCR_AES_GCM_ICV16, 256);
+			add_algorithm(this, EXTENDED_SEQUENCE_NUMBERS, NO_EXT_SEQ_NUMBERS, 0);
 			return &this->public;
 		case PROTO_AH:
 		default:


### PR DESCRIPTION
The commit mentioned below adds an AES-GCM default proposal for ESP. That
proposal does not include any ESN or non-ESN transform to indicate if extended
sequence numbers are supported.

A standards-compliant peer will include one or more ESN support transforms,
and will be unable to select this proposal due to a proposal mismatch.

Fix the default CGM proposal by adding both ESN and NOESN transforms. Given
that ESN is supported in Linux for more than ten years now, it probably
makes sense to indicate ESN support for use with AES-GCM.

Fixes: c7bef954eec6 ("proposal: Add AES-GCM to the ESP default AEAD proposal")