### PR TITLE
Remove not-implemented XFRM_OFFLOAD_IPV6 flag

### DIFF
--- a/src/libcharon/plugins/kernel_netlink/kernel_netlink_ipsec.c
+++ b/src/libcharon/plugins/kernel_netlink/kernel_netlink_ipsec.c
@@ -1497,10 +1497,6 @@ static bool config_hw_offload(kernel_ipsec_sa_id_t *id,
 		goto out;
 	}
 	offload->ifindex = if_nametoindex(ifname);
-	if (local->get_family(local) == AF_INET6)
-	{
-		offload->flags |= XFRM_OFFLOAD_IPV6;
-	}
 	offload->flags |= data->inbound ? XFRM_OFFLOAD_INBOUND : 0;
 
 	ret = TRUE;
@@ -2413,14 +2409,6 @@ METHOD(kernel_ipsec_t, update_sa, status_t,
 												  &ifname))
 				{
 					offload->ifindex = if_nametoindex(ifname);
-					if (local->get_family(local) == AF_INET6)
-					{
-						offload->flags |= XFRM_OFFLOAD_IPV6;
-					}
-					else
-					{
-						offload->flags &= ~XFRM_OFFLOAD_IPV6;
-					}
 					free(ifname);
 				}
 			}


### PR DESCRIPTION
The XFRM_OFFLOAD_IPV6 flag was never implemented in the kernel and no
plans to do so. Remove it from the strongswan code either.

Link: https://lore.kernel.org/netdev/8e526e4814f0c4da5a965567d3b8dce3a9ac2470.1644329331.git.leonro@nvidia.com/