### PR TITLE
ikev1: Remove outbound policy of rekeyed CHILD_SA

### DIFF
--- a/src/libcharon/sa/ikev1/tasks/quick_mode.c
+++ b/src/libcharon/sa/ikev1/tasks/quick_mode.c
@@ -411,6 +411,8 @@ static bool install(private_quick_mode_t *this)
 		/* rekeyed CHILD_SAs stay installed until they expire or are deleted
 		 * by the other peer */
 		old->set_state(old, CHILD_REKEYED);
+		/* remove from outbound since only one outbound policy is valid */
+		old->remove_outbound(old);
 		/* as initiator we delete the CHILD_SA if configured to do so */
 		if (this->initiator && this->delete)
 		{


### PR DESCRIPTION
Remove outbound policy of rekeyed CHILD_SA since only one policy is
valid. Otherwise, during update-SA job (when NAT mapping changed),
CHILD_SA are updated and installed one by one, leaving a window where
old SAs are being used. There are also circumstances where the new SA is
not processed last.