### PR TITLE
configure.ac: libsystemd-daemon and libsystemd-journal do not exist

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1041,10 +1041,10 @@ if test x$systemd = xtrue; then
 	PKG_CHECK_MODULES(systemd, [libsystemd >= 209],
 		[AC_SUBST(systemd_CFLAGS)
 		 AC_SUBST(systemd_LIBS)],
-		[PKG_CHECK_MODULES(systemd_daemon, [libsystemd-daemon])
+		[PKG_CHECK_MODULES(systemd_daemon, [libsystemd])
 		 AC_SUBST(systemd_daemon_CFLAGS)
 		 AC_SUBST(systemd_daemon_LIBS)
-		 PKG_CHECK_MODULES(systemd_journal, [libsystemd-journal])
+		 PKG_CHECK_MODULES(systemd_journal, [libsystemd])
 		 AC_SUBST(systemd_journal_CFLAGS)
 		 AC_SUBST(systemd_journal_LIBS)]
 	)


### PR DESCRIPTION
All functionality seems to have been merged into libsystemd since some
version of systemd. Arch Linux already patches these two lines like
this commit does. This commit would enable Arch Linux to just drop the
patch.