### PR TITLE
src/libstrongswan/plugins/wolfssl: rename encrypt

### DIFF
--- a/src/libstrongswan/plugins/wolfssl/wolfssl_aead.c
+++ b/src/libstrongswan/plugins/wolfssl/wolfssl_aead.c
@@ -87,7 +87,7 @@ struct private_aead_t {
 	encryption_algorithm_t alg;
 };
 
-METHOD(aead_t, encrypt, bool,
+METHOD(aead_t, strongswan_encrypt, bool,
 	private_aead_t *this, chunk_t plain, chunk_t assoc, chunk_t iv,
 	chunk_t *encrypted)
 {
@@ -323,7 +323,7 @@ aead_t *wolfssl_aead_create(encryption_algorithm_t algo,
 
 	INIT(this,
 		.public = {
-			.encrypt = _encrypt,
+			.encrypt = _strongswan_encrypt,
 			.decrypt = _decrypt,
 			.get_block_size = _get_block_size,
 			.get_icv_size = _get_icv_size,

--- a/src/libstrongswan/plugins/wolfssl/wolfssl_crypter.c
+++ b/src/libstrongswan/plugins/wolfssl/wolfssl_crypter.c
@@ -230,7 +230,7 @@ METHOD(crypter_t, decrypt, bool,
 	return success;
 }
 
-METHOD(crypter_t, encrypt, bool,
+METHOD(crypter_t, strongswan_encrypt, bool,
 	private_wolfssl_crypter_t *this, chunk_t data, chunk_t iv, chunk_t *dst)
 {
 	u_char *out;
@@ -578,7 +578,7 @@ wolfssl_crypter_t *wolfssl_crypter_create(encryption_algorithm_t algo,
 	INIT(this,
 		.public = {
 			.crypter = {
-				.encrypt = _encrypt,
+				.encrypt = _strongswan_encrypt,
 				.decrypt = _decrypt,
 				.get_block_size = _get_block_size,
 				.get_iv_size = _get_iv_size,

--- a/src/libstrongswan/plugins/wolfssl/wolfssl_ec_public_key.c
+++ b/src/libstrongswan/plugins/wolfssl/wolfssl_ec_public_key.c
@@ -193,7 +193,7 @@ METHOD(public_key_t, verify, bool,
 	}
 }
 
-METHOD(public_key_t, encrypt, bool,
+METHOD(public_key_t, strongswan_encrypt, bool,
 	private_wolfssl_ec_public_key_t *this, encryption_scheme_t scheme,
 	void *params, chunk_t crypto, chunk_t *plain)
 {
@@ -324,7 +324,7 @@ static private_wolfssl_ec_public_key_t *create_empty()
 			.key = {
 				.get_type = _get_type,
 				.verify = _verify,
-				.encrypt = _encrypt,
+				.encrypt = _strongswan_encrypt,
 				.get_keysize = _get_keysize,
 				.equals = public_key_equals,
 				.get_fingerprint = _get_fingerprint,

--- a/src/libstrongswan/plugins/wolfssl/wolfssl_ed_public_key.c
+++ b/src/libstrongswan/plugins/wolfssl/wolfssl_ed_public_key.c
@@ -111,7 +111,7 @@ METHOD(public_key_t, verify, bool,
 	return ret == 0 && res == 1;
 }
 
-METHOD(public_key_t, encrypt, bool,
+METHOD(public_key_t, strongswan_encrypt, bool,
 	private_public_key_t *this, encryption_scheme_t scheme,
 	void *params, chunk_t crypto, chunk_t *plain)
 {
@@ -368,7 +368,7 @@ static private_public_key_t *create_empty(key_type_t type)
 		.public = {
 			.get_type = _get_type,
 			.verify = _verify,
-			.encrypt = _encrypt,
+			.encrypt = _strongswan_encrypt,
 			.get_keysize = _get_keysize,
 			.equals = public_key_equals,
 			.get_fingerprint = _get_fingerprint,

--- a/src/libstrongswan/plugins/wolfssl/wolfssl_rsa_public_key.c
+++ b/src/libstrongswan/plugins/wolfssl/wolfssl_rsa_public_key.c
@@ -216,7 +216,7 @@ METHOD(public_key_t, verify, bool,
 	}
 }
 
-METHOD(public_key_t, encrypt, bool,
+METHOD(public_key_t, strongswan_encrypt, bool,
 	private_wolfssl_rsa_public_key_t *this, encryption_scheme_t scheme,
 	void *params, chunk_t plain, chunk_t *crypto)
 {
@@ -440,7 +440,7 @@ static private_wolfssl_rsa_public_key_t *create_empty()
 			.key = {
 				.get_type = _get_type,
 				.verify = _verify,
-				.encrypt = _encrypt,
+				.encrypt = _strongswan_encrypt,
 				.equals = public_key_equals,
 				.get_keysize = _get_keysize,
 				.get_fingerprint = _get_fingerprint,


### PR DESCRIPTION
Rename `encrypt` to `strongswan_encrypt` to avoid the following build failure when wolfssl is built with `--enable-opensslextra`:

```
In file included from ../../../../src/libstrongswan/utils/utils.h:59,
                 from ../../../../src/libstrongswan/library.h:101,
                 from wolfssl_common.h:29,
                 from wolfssl_aead.c:23:
wolfssl_aead.c:90:16: error: conflicting types for 'encrypt'; have '_Bool(union <anonymous>,  chunk_t,  chunk_t,  chunk_t,  chunk_t *)'
   90 | METHOD(aead_t, encrypt, bool,
      |                ^~~~~~~
../../../../src/libstrongswan/utils/utils/object.h:99:20: note: in definition of macro 'METHOD'
   99 |         static ret name(union {iface *_public; this;} \
      |                    ^~~~
In file included from /home/autobuild/autobuild/instance-5/output-1/host/powerpc64le-buildroot-linux-musl/sysroot/usr/include/wolfssl/wolfcrypt/wc_port.h:573,
                 from /home/autobuild/autobuild/instance-5/output-1/host/powerpc64le-buildroot-linux-musl/sysroot/usr/include/wolfssl/wolfcrypt/types.h:35,
                 from /home/autobuild/autobuild/instance-5/output-1/host/powerpc64le-buildroot-linux-musl/sysroot/usr/include/wolfssl/wolfcrypt/logging.h:33,
                 from /home/autobuild/autobuild/instance-5/output-1/host/powerpc64le-buildroot-linux-musl/sysroot/usr/include/wolfssl/ssl.h:35,
                 from wolfssl_common.h:64,
                 from wolfssl_aead.c:23:
/home/autobuild/autobuild/instance-5/output-1/host/powerpc64le-buildroot-linux-musl/sysroot/usr/include/unistd.h:149:6: note: previous declaration of 'encrypt' with type 'void(char *, int)'
  149 | void encrypt(char *, int);
      |      ^~~~~~~
```

Fixes:
 - http://autobuild.buildroot.org/results/02f080c2f6d8272cb8cc1de66e058d66fb7499bc

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>