### PR TITLE
Add missing testing css dir to make dist content

### DIFF
--- a/testing/Makefile.am
+++ b/testing/Makefile.am
@@ -1,6 +1,6 @@
 EXTRA_DIST = do-tests make-testing ssh start-testing stop-testing \
-             testing.conf ssh_config config hosts images scripts tests \
-			 README
+             testing.conf ssh_config config hosts images css scripts \
+			 tests README
 
 # exclude all files ignored by Git from the tarball
 dist-hook:


### PR DESCRIPTION
Add the css dir to the EXTRA_DIST variable in the makefile for the test
environment. This dir was missing when generating distribution tarballs.
Adding it enables successful builds of the test environment from the
dist tarballs.