### PR TITLE
testing: Add test set location config option

### DIFF
--- a/testing/do-tests
+++ b/testing/do-tests
@@ -20,7 +20,6 @@ DIR=$(dirname `readlink -f $0`)
 SSHCONF="-F $DIR/ssh_config"
 
 [ -d $DIR/hosts ] || die "Directory 'hosts' not found"
-[ -d $DIR/tests ] || die "Directory 'tests' not found"
 [ -d $BUILDDIR ] ||
 	die "Directory '$BUILDDIR' does not exist, please run make-testing first"
 running_any $STRONGSWANHOSTS || die "Please start test environment before running $0"
@@ -39,7 +38,8 @@ TODAYDIR=$TESTRESULTSDIR/$TESTDATE
 mkdir $TODAYDIR
 TESTRESULTSHTML=$TODAYDIR/all.html
 INDEX=$TODAYDIR/index.html
-DEFAULTTESTSDIR=$TESTDIR/testing/tests
+
+[ -d $TESTSETDIR ] || die "Directory $TESTSETDIR not found"
 
 SOURCEIP_ROUTING_TABLE=220
 
@@ -225,7 +225,7 @@ if [ $# -gt 0 ]
 then
     TESTS=$(printf "%s\n" $* | sort -u)
 else
-    TESTS=$(ls $DEFAULTTESTSDIR)
+    TESTS=$(ls $TESTSETDIR)
 fi
 
 for SUBDIR in $TESTS
@@ -234,11 +234,11 @@ do
 
 	if [ $SUBTESTS = $SUBDIR ]
 	then
-		SUBTESTS="`ls $DEFAULTTESTSDIR/$SUBDIR`"
+		SUBTESTS="`ls $TESTSETDIR/$SUBDIR`"
 	else
 		if [[ $SUBTESTS == *'*'* ]]
 		then
-			SUBTESTS="`basename -a $DEFAULTTESTSDIR/$SUBDIR`"
+			SUBTESTS="`basename -a $TESTSETDIR/$SUBDIR`"
 		fi
 		SUBDIR="`dirname $SUBDIR`"
 	fi
@@ -310,17 +310,17 @@ do
 
 	teststart=$(date +%s)
 
-	if [ ! -d $DEFAULTTESTSDIR/${testname} ]
+	if [ ! -d $TESTSETDIR/${testname} ]
 	then
 	    echo "is missing..skipped"
 	    continue
 	fi
 
-	[ ! -f $DEFAULTTESTSDIR/${testname}/description.txt ] && echo "!! File 'description.txt' is missing" && continue
-	[ ! -f $DEFAULTTESTSDIR/${testname}/test.conf ]       && echo "!! File 'test.conf' is missing" && continue
-	[ ! -f $DEFAULTTESTSDIR/${testname}/pretest.dat ]     && echo "!! File 'pretest.dat' is missing" && continue
-	[ ! -f $DEFAULTTESTSDIR/${testname}/posttest.dat ]    && echo "!! File 'posttest.dat' is missing" && continue
-	[ ! -f $DEFAULTTESTSDIR/${testname}/evaltest.dat ]    && echo "!! File 'evaltest.dat' is missing" && continue
+	[ ! -f $TESTSETDIR/${testname}/description.txt ] && echo "!! File 'description.txt' is missing" && continue
+	[ ! -f $TESTSETDIR/${testname}/test.conf ]       && echo "!! File 'test.conf' is missing" && continue
+	[ ! -f $TESTSETDIR/${testname}/pretest.dat ]     && echo "!! File 'pretest.dat' is missing" && continue
+	[ ! -f $TESTSETDIR/${testname}/posttest.dat ]    && echo "!! File 'posttest.dat' is missing" && continue
+	[ ! -f $TESTSETDIR/${testname}/evaltest.dat ]    && echo "!! File 'evaltest.dat' is missing" && continue
 
 	TESTRESULTDIR=$TODAYDIR/$testname
 	mkdir -p $TESTRESULTDIR

--- a/testing/testing.conf
+++ b/testing/testing.conf
@@ -116,3 +116,11 @@ bob,fec2::10"}
 # are sun, moon, dave, carol, alice, venus, bob, winnetou.
 #
 : ${STRONGSWANHOSTS="alice bob carol dave moon sun venus winnetou"}
+
+##############################################################
+# Test set definitions
+# Points to the dir with the test sets (test configurations and scripts)
+# Used by do-tests. Should be subdir of TESTDIR; do-tests links
+# $TESTDIR/testing to $TESTINGDIR so the default location below points to
+# <source>/testing/tests when you follow the symlink.
+: ${TESTSETDIR=$TESTDIR/testing/tests}


### PR DESCRIPTION
Adds configurable test set location, making it easier to specify a limited test set or include your own without changing files tracked by the repo. In other words, you can now specify your own dir with tests to run, from testing.conf.local.

Also renames the variable containing this location in the do-tests script to something that may be more descriptive.