### PR TITLE
Fixed apply_jitter function in case of jitter bigger than rekey value

### DIFF
--- a/src/libcharon/config/child_cfg.c
+++ b/src/libcharon/config/child_cfg.c
@@ -435,6 +435,10 @@ static uint64_t apply_jitter(uint64_t rekey, uint64_t jitter)
 		return rekey;
 	}
 	jitter = (jitter == UINT64_MAX) ? jitter : jitter + 1;
+	if (jitter > rekey)
+	{
+		jitter = rekey;
+	}
 	return rekey - jitter * (random() / (RAND_MAX + 1.0));
 }
 #define APPLY_JITTER(l) l.rekey = apply_jitter(l.rekey, l.jitter)


### PR DESCRIPTION
`uint64_t apply_jitter(uint64_t rekey, uint64_t jitter)` function could return values greater than rekey if jitter is greater than rekey.
 
Return value (`rekey - jitter * (random() / (RAND_MAX + 1.0))`) must not be less than zero (because function returns unsigned value), so quick fix is to limit jitter by rekey.