### PR TITLE
Add support for full HW offload

### DIFF
--- a/src/include/linux/xfrm.h
+++ b/src/include/linux/xfrm.h
@@ -503,6 +503,7 @@ struct xfrm_user_offload {
 };
 #define XFRM_OFFLOAD_IPV6	1
 #define XFRM_OFFLOAD_INBOUND	2
+#define XFRM_OFFLOAD_FULL	4
 
 #ifndef __KERNEL__
 /* backwards compatibility for userspace */

--- a/src/libcharon/plugins/vici/vici_config.c
+++ b/src/libcharon/plugins/vici/vici_config.c
@@ -1040,9 +1040,11 @@ CALLBACK(parse_hw_offload, bool,
 	action_t *out, chunk_t v)
 {
 	enum_map_t map[] = {
-		{ "no",		HW_OFFLOAD_NO	},
-		{ "yes",	HW_OFFLOAD_YES	},
-		{ "auto",	HW_OFFLOAD_AUTO	},
+		{ "no",		HW_OFFLOAD_NO		},
+		{ "yes",	HW_OFFLOAD_CRYPTO	},
+		{ "crypto",	HW_OFFLOAD_CRYPTO	},
+		{ "full",	HW_OFFLOAD_FULL		},
+		{ "auto",	HW_OFFLOAD_AUTO		},
 	};
 	int d;
 

--- a/src/libstrongswan/ipsec/ipsec_types.c
+++ b/src/libstrongswan/ipsec/ipsec_types.c
@@ -41,6 +41,8 @@ ENUM(ipcomp_transform_names, IPCOMP_NONE, IPCOMP_LZJH,
 ENUM(hw_offload_names, HW_OFFLOAD_NO, HW_OFFLOAD_AUTO,
 	"no",
 	"yes",
+	"crypto",
+	"full",
 	"auto",
 );
 

--- a/src/libstrongswan/ipsec/ipsec_types.h
+++ b/src/libstrongswan/ipsec/ipsec_types.h
@@ -126,7 +126,9 @@ extern enum_name_t *ipcomp_transform_names;
 enum hw_offload_t {
 	HW_OFFLOAD_NO = 0,
 	HW_OFFLOAD_YES = 1,
-	HW_OFFLOAD_AUTO = 2,
+	HW_OFFLOAD_CRYPTO = 2,
+	HW_OFFLOAD_FULL = 3,
+	HW_OFFLOAD_AUTO = 4,
 };
 
 /**


### PR DESCRIPTION
Added support for full HW offload since now IPsec full HW offload has been accepted by the upstream linux kernel.
This patch allows users to configure full HW offload by setting the hw_offload parameter to "full" or "auto" in the swanctl.conf files. The configuration will work if both the kernel and the device support it ("auto" fallbacks to crypto offload if full doesn't work, and if crypto offload doesn't work then it doesn't configure hw offload).
Also changed HW_OFFLOAD_YES to HW_OFFLOAD_CRYPTO to distinguish from HW_OFFLOAD_FULL, and added "crypto" option to the hw_offload parameter which is the same as "yes" was previously (kept "yes" option as legacy for backward compatibility).

Signed-off-by: Feras Bisharat <fbisharat@nvidia.com>