### PR TITLE
Include IPSEC_CONFDIR variable replacement in ipsec man

### DIFF
--- a/man/ipsec.conf.5.in
+++ b/man/ipsec.conf.5.in
@@ -690,7 +690,7 @@ but for the second authentication round (IKEv2 only).
 .BR leftcert " = <path>"
 the path to the left participant's X.509 certificate. The file can be encoded
 either in PEM or DER format. OpenPGP certificates are supported as well.
-Both absolute paths or paths relative to \fI/etc/ipsec.d/certs\fP
+Both absolute paths or paths relative to \fI@sysconfdir@/ipsec.d/certs\fP
 are accepted. By default
 .B leftcert
 sets
@@ -871,7 +871,7 @@ prefix in front of 0x or 0s, the public key is expected to be in either
 the RFC 3110 (not the full RR, only RSA key part) or RFC 4253 public key format,
 respectively.
 Also accepted is the path to a file containing the public key in PEM, DER or SSH
-encoding. Both absolute paths or paths relative to \fI/etc/ipsec.d/certs\fP
+encoding. Both absolute paths or paths relative to \fI@sysconfdir@/ipsec.d/certs\fP
 are accepted.
 .TP
 .BR leftsendcert " = never | no | " ifasked " | always | yes"
@@ -1219,7 +1219,7 @@ of this connection will be used as peer ID.
 .SH "CA SECTIONS"
 These are optional sections that can be used to assign special
 parameters to a Certification Authority (CA). Because the daemons
-automatically import CA certificates from \fI/etc/ipsec.d/cacerts\fP,
+automatically import CA certificates from \fI@sysconfdir@/ipsec.d/cacerts\fP,
 there is no need to explicitly add them with a CA section, unless you
 want to assign special parameters (like a CRL) to a CA.
 .TP
@@ -1235,7 +1235,7 @@ currently can have either the value
 .TP
 .BR cacert " = <path>"
 defines a path to the CA certificate either relative to
-\fI/etc/ipsec.d/cacerts\fP or as an absolute path.
+\fI@sysconfdir@/ipsec.d/cacerts\fP or as an absolute path.
 .br
 A value in the form
 .B %smartcard[<slot nr>[@<module>]]:<keyid>
@@ -1284,7 +1284,7 @@ section are:
 .BR cachecrls " = yes | " no
 if enabled, certificate revocation lists (CRLs) fetched via HTTP or LDAP will
 be cached in
-.I /etc/ipsec.d/crls/
+.I @sysconfdir@/ipsec.d/crls/
 under a unique file name derived from the certification authority's public key.
 .TP
 .BR charondebug " = <debug list>"
@@ -1463,12 +1463,12 @@ time equals zero and, thus, rekeying gets disabled.
 
 .SH FILES
 .nf
-/etc/ipsec.conf
-/etc/ipsec.d/aacerts
-/etc/ipsec.d/acerts
-/etc/ipsec.d/cacerts
-/etc/ipsec.d/certs
-/etc/ipsec.d/crls
+@sysconfdir@/ipsec.conf
+@sysconfdir@/ipsec.d/aacerts
+@sysconfdir@/ipsec.d/acerts
+@sysconfdir@/ipsec.d/cacerts
+@sysconfdir@/ipsec.d/certs
+@sysconfdir@/ipsec.d/crls
 
 .SH SEE ALSO
 strongswan.conf(5), ipsec.secrets(5), ipsec(8)

--- a/man/ipsec.secrets.5.in
+++ b/man/ipsec.secrets.5.in
@@ -15,7 +15,7 @@ Here is an example.
 .LP
 .RS
 .nf
-# /etc/ipsec.secrets - strongSwan IPsec secrets file
+# @sysconfdir@/ipsec.secrets - strongSwan IPsec secrets file
 192.168.0.1 %any : PSK "v+NkxY9LLZvwj4qCC2o/gGrWDF2d21jL"
 
 : RSA moonKey.pem
@@ -140,7 +140,7 @@ is interpreted as Base64 encoded binary data.
 .TQ
 .B : ECDSA <private key file> [ <passphrase> | %prompt ]
 For the private key file both absolute paths or paths relative to
-\fI/etc/ipsec.d/private\fP are accepted. If the private key file is
+\fI@sysconfdir@/ipsec.d/private\fP are accepted. If the private key file is
 encrypted, the \fIpassphrase\fP must be defined. Instead of a passphrase
 .B %prompt
 can be used which then causes the daemon to ask the user for the password
@@ -148,7 +148,7 @@ whenever it is required to decrypt the key.
 .TP
 .B : P12 <PKCS#12 file> [ <passphrase> | %prompt ]
 For the PKCS#12 file both absolute paths or paths relative to
-\fI/etc/ipsec.d/private\fP are accepted. If the container is
+\fI@sysconfdir@/ipsec.d/private\fP are accepted. If the container is
 encrypted, the \fIpassphrase\fP must be defined. Instead of a passphrase
 .B %prompt
 can be used which then causes the daemon to ask the user for the password
@@ -182,7 +182,7 @@ can be specified, which causes the daemon to ask the user for the pin code.
 .LP
 
 .SH FILES
-/etc/ipsec.secrets
+@sysconfdir@/ipsec.secrets
 .SH SEE ALSO
 ipsec.conf(5), strongswan.conf(5), ipsec(8)
 .br

--- a/src/ipsec/Makefile.am
+++ b/src/ipsec/Makefile.am
@@ -10,6 +10,7 @@ _ipsec.8 : _ipsec.8.in
 	-e "s:@IPSEC_SCRIPT@:$(ipsec_script):g" \
 	-e "s:@IPSEC_SCRIPT_UPPER@:$(ipsec_script_upper):g" \
 	-e "s:@IPSEC_DIR@:$(ipsecdir):" \
+	-e "s:@IPSEC_CONFDIR@:$(sysconfdir):" \
 	$(srcdir)/$@.in > $@
 
 _ipsec : _ipsec.in

--- a/src/ipsec/_ipsec.8.in
+++ b/src/ipsec/_ipsec.8.in
@@ -145,25 +145,25 @@ locally by the IKE daemon or received via the IKE protocol.
 .TP
 .BI "listcacerts [" --utc ]
 returns a list of X.509 Certification Authority (CA) certificates that were
-loaded locally by the IKE daemon from the \fI/etc/ipsec.d/cacerts/\fP
+loaded locally by the IKE daemon from the \fI@IPSEC_CONFDIR@/ipsec.d/cacerts/\fP
 directory or received via the IKE protocol.
 .
 .TP
 .BI "listaacerts [" --utc ]
 returns a list of X.509 Authorization Authority (AA) certificates that were
-loaded locally by the IKE daemon from the \fI/etc/ipsec.d/aacerts/\fP
+loaded locally by the IKE daemon from the \fI@IPSEC_CONFDIR@/ipsec.d/aacerts/\fP
 directory.
 .
 .TP
 .BI "listocspcerts [" --utc ]
 returns a list of X.509 OCSP Signer certificates that were either loaded
-locally by the IKE daemon from the \fI/etc/ipsec.d/ocspcerts/\fP
+locally by the IKE daemon from the \fI@IPSEC_CONFDIR@/ipsec.d/ocspcerts/\fP
 directory or were sent by an OCSP server.
 .
 .TP
 .BI "listacerts [" --utc ]
 returns a list of X.509 Attribute certificates that were loaded locally by
-the IKE daemon from the \fI/etc/ipsec.d/acerts/\fP directory.
+the IKE daemon from the \fI@IPSEC_CONFDIR@/ipsec.d/acerts/\fP directory.
 .
 .TP
 .BI "listgroups [" --utc ]
@@ -179,7 +179,7 @@ sections in \fIipsec.conf\fP.
 .TP
 .BI "listcrls [" --utc ]
 returns a list of Certificate Revocation Lists (CRLs) that were either loaded
-by the IKE daemon from the \fI/etc/ipsec.d/crls\fP directory or fetched from
+by the IKE daemon from the \fI@IPSEC_CONFDIR@/ipsec.d/crls\fP directory or fetched from
 an HTTP- or LDAP-based CRL distribution point.
 .
 .TP
@@ -211,7 +211,7 @@ flushes and rereads all secrets defined in \fIipsec.secrets\fP.
 .TP
 .B "rereadcacerts"
 removes previously loaded CA certificates, reads all certificate files
-contained in the \fI/etc/ipsec.d/cacerts\fP directory and adds them to the list
+contained in the \fI@IPSEC_CONFDIR@/ipsec.d/cacerts\fP directory and adds them to the list
 of Certification Authority (CA) certificates. This does not affect certificates
 explicitly defined in a
 .BR ipsec.conf (5)
@@ -220,23 +220,23 @@ ca section, which may be separately updated using the \fBupdate\fP command.
 .TP
 .B "rereadaacerts"
 removes previously loaded AA certificates, reads all certificate files
-contained in the \fI/etc/ipsec.d/aacerts\fP directory and adds them to the list
+contained in the \fI@IPSEC_CONFDIR@/ipsec.d/aacerts\fP directory and adds them to the list
 of Authorization Authority (AA) certificates.
 .
 .TP
 .B "rereadocspcerts"
-reads all certificate files contained in the \fI/etc/ipsec.d/ocspcerts/\fP
+reads all certificate files contained in the \fI@IPSEC_CONFDIR@/ipsec.d/ocspcerts/\fP
 directory and adds them to the list of OCSP signer certificates.
 .
 .TP
 .B "rereadacerts"
-reads all certificate files contained in the  \fI/etc/ipsec.d/acerts/\fP
+reads all certificate files contained in the  \fI@IPSEC_CONFDIR@/ipsec.d/acerts/\fP
 directory and adds them to the list of attribute certificates.
 .
 .TP
 .B "rereadcrls"
 reads  all Certificate  Revocation Lists (CRLs) contained in the
-\fI/etc/ipsec.d/crls/\fP directory and adds them to the list of CRLs.
+\fI@IPSEC_CONFDIR@/ipsec.d/crls/\fP directory and adds them to the list of CRLs.
 .
 .TP
 .B "rereadall"


### PR DESCRIPTION
Fedora chosen different default directory to avoid conflicts with libreswan. Use ${sysconfdir} variable to provide correct location.