### PR TITLE
pki: EST filter whitespace on base64 encoded responses

### DIFF
--- a/src/pki/est/est_tls.c
+++ b/src/pki/est/est_tls.c
@@ -15,6 +15,7 @@
  */
 
 #define _GNU_SOURCE /* for asprintf() */
+#include <ctype.h>
 #include <stdio.h>
 #include <unistd.h>
 #include <errno.h>
@@ -198,7 +199,6 @@ static bool parse_http_header(chunk_t *in,  u_int *http_code, u_int *content_len
 	return (*http_code < 300);
 }
 
-
 METHOD(est_tls_t, request, bool,
 	private_est_tls_t *this, est_op_t op, chunk_t in, chunk_t *out,
 	u_int *http_code, u_int *retry_after)
@@ -206,7 +206,7 @@ METHOD(est_tls_t, request, bool,
 	chunk_t http = chunk_empty, data = chunk_empty, response;
 	u_int content_len;
 	char buf[1024];
-	int len;
+	int i, len;
 
 	/* initialize output variables */
 	*out = chunk_empty;
@@ -276,6 +276,15 @@ METHOD(est_tls_t, request, bool,
 				return FALSE;
 			}
 		}
+
+		for (i = 0, len = 0; i < data.len; i++)
+		{
+			if (!isspace(data.ptr[i]))
+			{
+				data.ptr[len++] = data.ptr[i];
+			}
+		}
+		data.len = len;
 
 		*out = chunk_from_base64(data, NULL);
 		chunk_free(&data);


### PR DESCRIPTION
Hello together,

this PR arose from an response parsing issue using the EST protocol. Looking into the details it got clear that the responses base64 data formatting in combination with the method used for base64 decoding caused the issue.

The change only focuses on the `pki est` command, and adds a white space filter as per RFC in case the `Content-Type-Encoding` is `base64`.
It might be a consideration to adjust the implementation in `utils/chunk.c` `chunk_from_base64()` to only accept valid base64 characters before attempting to decode. As it was not clear to me if this section is performance critical I've limited the change to the `pki/est` section.

As C is not my typical language I'd be happy to receive any feedback on the implementation.


reference: EST Clarification [RFC 8951, Section 3.1](https://www.rfc-editor.org/rfc/rfc8951#name-white-space-processing)

Many thanks for your consideration.

Best regards,
Harald