### PR TITLE
openssl: fix x509 SubjectAlternativeName wildcard validation

### DIFF
--- a/src/libstrongswan/plugins/openssl/openssl_x509.c
+++ b/src/libstrongswan/plugins/openssl/openssl_x509.c
@@ -365,7 +365,7 @@ METHOD(certificate_t, has_subject, id_match_t,
 	enumerator = create_subjectAltName_enumerator(this);
 	while (enumerator->enumerate(enumerator, &current))
 	{
-		match = current->matches(current, subject);
+		match = current->matches(subject, current);
 		if (match > best)
 		{
 			best = match;


### PR DESCRIPTION
The patch fixes the x509 SubjectAlternativeName wildcard validation within the openssl plugin.

With inverted arguments the matches_string validation exits early on the length check. Further the wildcard validation does not work as expected.
