### PR TITLE
Charon : new accept_incomplete_chains parameter

### DIFF
--- a/conf/options/charon.opt
+++ b/conf/options/charon.opt
@@ -430,6 +430,9 @@ charon.send_delay_type = 0
 charon.send_vendor_id = no
 	Send strongSwan vendor ID payload
 
+charon.accept_incomplete_chains = no
+	Accept incomplete cert chains
+
 charon.signature_authentication = yes
 	Whether to enable Signature Authentication as per RFC 7427.
 

--- a/src/libstrongswan/credentials/credential_manager.c
+++ b/src/libstrongswan/credentials/credential_manager.c
@@ -93,6 +93,11 @@ struct private_credential_manager_t {
 	 * Registered data to pass to hook
 	 */
 	void *hook_data;
+
+	/**
+	 * Accept incomplete cert chains
+	 */
+	bool accept_incomplete_chains;
 };
 
 /** data to pass to create_private_enumerator */
@@ -1154,8 +1159,8 @@ static auth_cfg_t *build_trustchain(private_credential_manager_t *this,
 		issuer = get_issuer_cert(this, current, FALSE, NULL);
 		if (!issuer)
 		{
-			if (!has_anchor)
-			{	/* If no trust anchor specified, accept incomplete chains */
+			if (!has_anchor || this->accept_incomplete_chains)
+			{
 				return trustchain;
 			}
 			break;
@@ -1427,6 +1432,7 @@ credential_manager_t *credential_manager_create()
 
 	this->local_sets = thread_value_create((thread_cleanup_t)this->sets->destroy);
 	this->exclusive_local_sets = thread_value_create((thread_cleanup_t)this->sets->destroy);
+	this->accept_incomplete_chains = lib->settings->get_bool(lib->settings, "%s.accept_incomplete_chains", FALSE, lib->ns);
 	if (lib->settings->get_bool(lib->settings, "%s.cert_cache", TRUE, lib->ns))
 	{
 		this->cache = cert_cache_create();


### PR DESCRIPTION
Hi,

Certificate chain and cacerts folder look like:

right (10.92.200.3)
initiator
root1.cer->intermediate.cer->node1.cer
leftca="CN=root1"
/cacerts/

left (10.92.200.54)
responder
root2.cer->intermediate.cer->node2.cer
rightca="CN=root2"
/cacerts/root2.pem

If root1.pem is not stored in /cacerts/ then info about intermediate certificate in Payload: Certificate (37) is not sent to responder during IKE_AUTH. If the one is not sent by the right then the left responses IKE_AUTH AUTHENTICATION_FAILED:

Frame 12: 64 bytes on wire (512 bits), 64 bytes captured (512 bits) Raw packet data
Internet Protocol Version 4, Src: 10.92.200.54, Dst: 10.92.200.3 User Datagram Protocol, Src Port: 500, Dst Port: 500 Internet Security Association and Key Management Protocol
    Initiator SPI: 33e23c6d95b0ffff
    Responder SPI: e37b6821b276d3f1
    Next payload: Notify (41)
    Version: 2.0
    Exchange type: IKE_AUTH (35)
    Flags: 0x20 (Responder, No higher version, Response)
    Message ID: 0x00000001
    Length: 36
    Payload: Notify (41) - AUTHENTICATION_FAILED
        Next payload: NONE / No Next Payload  (0)
        0... .... = Critical Bit: Not Critical
        .000 0000 = Reserved: 0x00
        Payload length: 8
        Protocol ID: RESERVED (0)
        SPI Size: 0
        Notify Message Type: AUTHENTICATION_FAILED (24)
        Notification DATA: <MISSING>

The new parameter will help to solve the issue.