### PR TITLE
openssl: Require OpenSSL 3.0.0 for KDF

### DIFF
--- a/src/libstrongswan/plugins/openssl/openssl_plugin.c
+++ b/src/libstrongswan/plugins/openssl/openssl_plugin.c
@@ -494,8 +494,9 @@ METHOD(plugin_t, get_features, int,
 			PLUGIN_PROVIDE(SIGNER, AUTH_HMAC_SHA2_512_256),
 			PLUGIN_PROVIDE(SIGNER, AUTH_HMAC_SHA2_512_512),
 #endif
-#if OPENSSL_VERSION_NUMBER >= 0x10101000L
-		/* HKDF is available since 1.1.0, expand-only mode only since 1.1.1 */
+#if OPENSSL_VERSION_NUMBER >= 0x30000000L
+		/* HKDF is available since 1.1.0, expand-only mode only since 1.1.1,
+		 * salt size > 1024 only since 3.0.0 */
 		PLUGIN_REGISTER(KDF, openssl_kdf_create),
 			PLUGIN_PROVIDE(KDF, KDF_PRF),
 			PLUGIN_PROVIDE(KDF, KDF_PRF_PLUS),


### PR DESCRIPTION
Hello,

As seen in https://github.com/strongswan/strongswan/issues/1255, using modp8192 with openssl plugin enabled makes it impossible for CHILD_SA to rekey if using openssl < 3.0 (https://github.com/openssl/openssl/pull/19085 has only been merged in 3.0+)
This diff changes the required openssl version from 1.1.1 to 3.0.0 for KDF activation to avoid this problem

Regards