### PR TITLE
Extend strongSwan Android frontend with managed configuration support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,7 @@ fuzzing-corpora/
 *.tar.bz2
 *.tar.gz
 .DS_Store
+._.DS_Store
 coverage/
 *.gcno
 *.gcda

--- a/src/frontends/android/app/build.gradle
+++ b/src/frontends/android/app/build.gradle
@@ -16,6 +16,8 @@ android {
         jniLibs.srcDir 'src/main/libs'
     }
 
+    ndkVersion '26.1.10909125'
+
     task buildNative(type: Exec) {
         workingDir 'src/main/jni'
         commandLine "${android.ndkDirectory}/ndk-build", '-j', Runtime.runtime.availableProcessors()

--- a/src/frontends/android/app/build.gradle
+++ b/src/frontends/android/app/build.gradle
@@ -50,7 +50,6 @@ android {
 dependencies {
     implementation 'androidx.appcompat:appcompat:1.6.1'
     implementation 'androidx.preference:preference:1.2.1'
-    implementation 'androidx.legacy:legacy-support-v4:1.0.0'
     implementation 'com.google.android.material:material:1.9.0'
     testImplementation 'junit:junit:4.13.2'
     testImplementation 'org.mockito:mockito-core:3.11.2'

--- a/src/frontends/android/app/build.gradle
+++ b/src/frontends/android/app/build.gradle
@@ -49,7 +49,7 @@ android {
 
 dependencies {
     implementation 'androidx.appcompat:appcompat:1.6.1'
-    implementation 'androidx.preference:preference:1.2.0'
+    implementation 'androidx.preference:preference:1.2.1'
     implementation 'androidx.legacy:legacy-support-v4:1.0.0'
     implementation 'com.google.android.material:material:1.6.1'
     testImplementation 'junit:junit:4.13.2'

--- a/src/frontends/android/app/build.gradle
+++ b/src/frontends/android/app/build.gradle
@@ -51,7 +51,7 @@ dependencies {
     implementation 'androidx.appcompat:appcompat:1.6.1'
     implementation 'androidx.preference:preference:1.2.1'
     implementation 'androidx.legacy:legacy-support-v4:1.0.0'
-    implementation 'com.google.android.material:material:1.6.1'
+    implementation 'com.google.android.material:material:1.9.0'
     testImplementation 'junit:junit:4.13.2'
     testImplementation 'org.mockito:mockito-core:3.11.2'
     testImplementation 'org.powermock:powermock-core:2.0.9'

--- a/src/frontends/android/app/build.gradle
+++ b/src/frontends/android/app/build.gradle
@@ -51,6 +51,7 @@ dependencies {
     implementation 'androidx.appcompat:appcompat:1.6.1'
     implementation 'androidx.preference:preference:1.2.1'
     implementation 'com.google.android.material:material:1.9.0'
+    implementation 'androidx.lifecycle:lifecycle-process:2.5.1'
     testImplementation 'junit:junit:4.13.2'
     testImplementation 'org.mockito:mockito-core:3.11.2'
     testImplementation 'org.powermock:powermock-core:2.0.9'

--- a/src/frontends/android/app/build.gradle
+++ b/src/frontends/android/app/build.gradle
@@ -48,7 +48,7 @@ android {
 }
 
 dependencies {
-    implementation 'androidx.appcompat:appcompat:1.4.2'
+    implementation 'androidx.appcompat:appcompat:1.6.1'
     implementation 'androidx.preference:preference:1.2.0'
     implementation 'androidx.legacy:legacy-support-v4:1.0.0'
     implementation 'com.google.android.material:material:1.6.1'

--- a/src/frontends/android/app/build.gradle
+++ b/src/frontends/android/app/build.gradle
@@ -1,13 +1,12 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 33
-
     namespace 'org.strongswan.android'
 
     defaultConfig {
         applicationId "org.strongswan.android"
         minSdkVersion 21
+        compileSdk 33
         targetSdkVersion 33
         versionCode 80
         versionName "2.4.2"

--- a/src/frontends/android/app/build.gradle
+++ b/src/frontends/android/app/build.gradle
@@ -53,6 +53,7 @@ dependencies {
     implementation 'com.google.android.material:material:1.9.0'
     implementation 'androidx.lifecycle:lifecycle-process:2.5.1'
     testImplementation 'junit:junit:4.13.2'
+    testImplementation 'org.assertj:assertj-core:3.24.2'
     testImplementation 'org.mockito:mockito-core:3.11.2'
     testImplementation 'org.powermock:powermock-core:2.0.9'
     testImplementation 'org.powermock:powermock-module-junit4:2.0.9'

--- a/src/frontends/android/app/src/main/AndroidManifest.xml
+++ b/src/frontends/android/app/src/main/AndroidManifest.xml
@@ -154,6 +154,7 @@
             <intent-filter tools:ignore="AppLinkUrlError">
                 <action android:name="android.intent.action.VIEW" />
                 <category android:name="android.intent.category.DEFAULT" />
+
                 <data android:mimeType="application/x-x509-ca-cert" />
                 <data android:mimeType="application/x-x509-server-cert" />
                 <data android:mimeType="application/x-pem-file" />
@@ -161,10 +162,17 @@
             </intent-filter>
         </activity>
 
+        <!--
+            Managed configuration, called app restrictions for historical reasons
+            https://developer.android.com/work/managed-configurations
+        -->
+        <meta-data
+            android:name="android.content.APP_RESTRICTIONS"
+            android:resource="@xml/managed_configuration" />
+
         <service
             android:name=".logic.VpnStateService"
-            android:exported="false" >
-        </service>
+            android:exported="false"></service>
         <service
             android:name=".logic.CharonVpnService"
             android:exported="false"

--- a/src/frontends/android/app/src/main/java/org/strongswan/android/data/CaCertificate.java
+++ b/src/frontends/android/app/src/main/java/org/strongswan/android/data/CaCertificate.java
@@ -48,6 +48,6 @@ public class CaCertificate extends PkcsCertificate
 	@Override
 	public String toString()
 	{
-		return "CaCertificate {" + vpnProfileUuid + ", " + configuredAlias + "}";
+		return "CaCertificate {" + vpnProfileUuid + ", " + configuredAlias + ", " + effectiveAlias + "}";
 	}
 }

--- a/src/frontends/android/app/src/main/java/org/strongswan/android/data/CaCertificate.java
+++ b/src/frontends/android/app/src/main/java/org/strongswan/android/data/CaCertificate.java
@@ -1,0 +1,53 @@
+package org.strongswan.android.data;
+
+import android.database.Cursor;
+
+import java.util.Objects;
+
+import androidx.annotation.NonNull;
+
+public class CaCertificate extends PkcsCertificate
+{
+	public CaCertificate(
+		@NonNull final String vpnProfileUuid,
+		@NonNull final String alias,
+		@NonNull final String data)
+	{
+		super(vpnProfileUuid, alias, data);
+	}
+
+	public CaCertificate(@NonNull final Cursor cursor)
+	{
+		super(cursor);
+	}
+
+	@Override
+	public boolean equals(Object o)
+	{
+		if (this == o)
+		{
+			return true;
+		}
+		if (o == null || getClass() != o.getClass())
+		{
+			return false;
+		}
+		CaCertificate that = (CaCertificate)o;
+		return Objects.equals(vpnProfileUuid, that.vpnProfileUuid)
+			&& Objects.equals(configuredAlias, that.configuredAlias)
+			&& Objects.equals(data, that.data);
+	}
+
+	@Override
+	public int hashCode()
+	{
+		return Objects.hash(vpnProfileUuid, configuredAlias, data);
+	}
+
+	@NonNull
+	@Override
+	public String toString()
+	{
+		return "CaCertificate {" + vpnProfileUuid + ", " + configuredAlias + "}";
+	}
+}

--- a/src/frontends/android/app/src/main/java/org/strongswan/android/data/CaCertificateRepository.java
+++ b/src/frontends/android/app/src/main/java/org/strongswan/android/data/CaCertificateRepository.java
@@ -1,0 +1,93 @@
+package org.strongswan.android.data;
+
+import android.content.ContentValues;
+import android.database.Cursor;
+import android.database.sqlite.SQLiteDatabase;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import androidx.annotation.NonNull;
+
+public class CaCertificateRepository
+{
+	private static final DatabaseHelper.DbTable TABLE = DatabaseHelper.TABLE_CA_CERTIFICATE;
+
+	@NonNull
+	private final ManagedConfigurationService managedConfigurationService;
+	@NonNull
+	private final SQLiteDatabase database;
+
+	public CaCertificateRepository(
+		@NonNull final ManagedConfigurationService managedConfigurationService,
+		@NonNull final DatabaseHelper databaseHelper)
+	{
+		this.managedConfigurationService = managedConfigurationService;
+		this.database = databaseHelper.getWritableDatabase();
+	}
+
+	@NonNull
+	public List<CaCertificate> getConfiguredCertificates()
+	{
+		managedConfigurationService.loadConfiguration();
+
+		final List<ManagedVpnProfile> managedVpnProfiles = managedConfigurationService.getManagedProfiles();
+		final List<CaCertificate> keyStores = new ArrayList<>(managedVpnProfiles.size());
+
+		for (final ManagedVpnProfile vpnProfile : managedVpnProfiles)
+		{
+			final CaCertificate caCertificate = vpnProfile.getCaCertificate();
+			if (caCertificate != null)
+			{
+				keyStores.add(caCertificate);
+			}
+		}
+
+		return keyStores;
+	}
+
+	@NonNull
+	public List<CaCertificate> getInstalledCertificates()
+	{
+		final List<CaCertificate> certificates = new ArrayList<>();
+
+		final Cursor cursor = database.query(TABLE.Name, TABLE.columnNames(), null, null, null, null, null);
+
+		cursor.moveToFirst();
+		while (!cursor.isAfterLast())
+		{
+			final CaCertificate certificate = new CaCertificate(cursor);
+			certificates.add(certificate);
+			cursor.moveToNext();
+		}
+		return certificates;
+	}
+
+	@NonNull
+	public Map<String, CaCertificate> getInstalledCertificateMap()
+	{
+		final List<CaCertificate> certificates = getInstalledCertificates();
+		final Map<String, CaCertificate> map = new HashMap<>(certificates.size());
+
+		for (final CaCertificate caCertificate : certificates)
+		{
+			map.put(caCertificate.getVpnProfileUuid(), caCertificate);
+		}
+
+		return map;
+	}
+
+	public void addInstalledCertificate(@NonNull final CaCertificate caCertificate)
+	{
+		final ContentValues values = caCertificate.asContentValues();
+		database.insert(TABLE.Name, null, values);
+	}
+
+	public void removeInstalledCertificate(@NonNull final CaCertificate caCertificate)
+	{
+		final String vpnProfileUuid = caCertificate.getVpnProfileUuid();
+		database.delete(TABLE.Name, PkcsCertificate.KEY_VPN_PROFILE_UUID + " = ?", new String[]{vpnProfileUuid});
+	}
+}

--- a/src/frontends/android/app/src/main/java/org/strongswan/android/data/CaCertificateRepository.java
+++ b/src/frontends/android/app/src/main/java/org/strongswan/android/data/CaCertificateRepository.java
@@ -2,6 +2,10 @@ package org.strongswan.android.data;
 
 import android.database.Cursor;
 
+import org.strongswan.android.logic.TrustedCertificateManager;
+
+import java.security.cert.X509Certificate;
+
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
@@ -28,5 +32,14 @@ public class CaCertificateRepository extends CertificateRepository<CaCertificate
 	protected CaCertificate createCertificate(@NonNull Cursor cursor)
 	{
 		return new CaCertificate(cursor);
+	}
+
+	@Override
+	protected boolean isInstalled(@NonNull CaCertificate certificate)
+	{
+		TrustedCertificateManager certificateManager = TrustedCertificateManager.getInstance();
+		final X509Certificate x509Certificate = certificateManager.getCACertificateFromAlias(certificate.getAlias());
+
+		return x509Certificate != null;
 	}
 }

--- a/src/frontends/android/app/src/main/java/org/strongswan/android/data/CaCertificateRepository.java
+++ b/src/frontends/android/app/src/main/java/org/strongswan/android/data/CaCertificateRepository.java
@@ -1,93 +1,32 @@
 package org.strongswan.android.data;
 
-import android.content.ContentValues;
 import android.database.Cursor;
-import android.database.sqlite.SQLiteDatabase;
-
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
-public class CaCertificateRepository
+public class CaCertificateRepository extends CertificateRepository<CaCertificate>
 {
 	private static final DatabaseHelper.DbTable TABLE = DatabaseHelper.TABLE_CA_CERTIFICATE;
-
-	@NonNull
-	private final ManagedConfigurationService managedConfigurationService;
-	@NonNull
-	private final SQLiteDatabase database;
 
 	public CaCertificateRepository(
 		@NonNull final ManagedConfigurationService managedConfigurationService,
 		@NonNull final DatabaseHelper databaseHelper)
 	{
-		this.managedConfigurationService = managedConfigurationService;
-		this.database = databaseHelper.getWritableDatabase();
+		super(managedConfigurationService, databaseHelper, TABLE);
+	}
+
+	@Nullable
+	@Override
+	protected CaCertificate getCertificate(@NonNull ManagedVpnProfile vpnProfile)
+	{
+		return vpnProfile.getCaCertificate();
 	}
 
 	@NonNull
-	public List<CaCertificate> getConfiguredCertificates()
+	@Override
+	protected CaCertificate createCertificate(@NonNull Cursor cursor)
 	{
-		managedConfigurationService.loadConfiguration();
-
-		final List<ManagedVpnProfile> managedVpnProfiles = managedConfigurationService.getManagedProfiles();
-		final List<CaCertificate> keyStores = new ArrayList<>(managedVpnProfiles.size());
-
-		for (final ManagedVpnProfile vpnProfile : managedVpnProfiles)
-		{
-			final CaCertificate caCertificate = vpnProfile.getCaCertificate();
-			if (caCertificate != null)
-			{
-				keyStores.add(caCertificate);
-			}
-		}
-
-		return keyStores;
-	}
-
-	@NonNull
-	public List<CaCertificate> getInstalledCertificates()
-	{
-		final List<CaCertificate> certificates = new ArrayList<>();
-
-		final Cursor cursor = database.query(TABLE.Name, TABLE.columnNames(), null, null, null, null, null);
-
-		cursor.moveToFirst();
-		while (!cursor.isAfterLast())
-		{
-			final CaCertificate certificate = new CaCertificate(cursor);
-			certificates.add(certificate);
-			cursor.moveToNext();
-		}
-		return certificates;
-	}
-
-	@NonNull
-	public Map<String, CaCertificate> getInstalledCertificateMap()
-	{
-		final List<CaCertificate> certificates = getInstalledCertificates();
-		final Map<String, CaCertificate> map = new HashMap<>(certificates.size());
-
-		for (final CaCertificate caCertificate : certificates)
-		{
-			map.put(caCertificate.getVpnProfileUuid(), caCertificate);
-		}
-
-		return map;
-	}
-
-	public void addInstalledCertificate(@NonNull final CaCertificate caCertificate)
-	{
-		final ContentValues values = caCertificate.asContentValues();
-		database.insert(TABLE.Name, null, values);
-	}
-
-	public void removeInstalledCertificate(@NonNull final CaCertificate caCertificate)
-	{
-		final String vpnProfileUuid = caCertificate.getVpnProfileUuid();
-		database.delete(TABLE.Name, PkcsCertificate.KEY_VPN_PROFILE_UUID + " = ?", new String[]{vpnProfileUuid});
+		return new CaCertificate(cursor);
 	}
 }

--- a/src/frontends/android/app/src/main/java/org/strongswan/android/data/CertificateRepository.java
+++ b/src/frontends/android/app/src/main/java/org/strongswan/android/data/CertificateRepository.java
@@ -1,0 +1,104 @@
+package org.strongswan.android.data;
+
+import android.content.ContentValues;
+import android.database.Cursor;
+import android.database.sqlite.SQLiteDatabase;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+public abstract class CertificateRepository<T extends PkcsCertificate>
+{
+	@NonNull
+	private final ManagedConfigurationService managedConfigurationService;
+
+	@NonNull
+	private final SQLiteDatabase database;
+	@NonNull
+	private final DatabaseHelper.DbTable table;
+
+	protected CertificateRepository(
+		@NonNull final ManagedConfigurationService managedConfigurationService,
+		@NonNull final DatabaseHelper databaseHelper,
+		@NonNull final DatabaseHelper.DbTable table)
+	{
+		this.managedConfigurationService = managedConfigurationService;
+
+		this.database = databaseHelper.getReadableDatabase();
+		this.table = table;
+	}
+
+	@Nullable
+	protected abstract T getCertificate(@NonNull final ManagedVpnProfile vpnProfile);
+
+	@NonNull
+	protected abstract T createCertificate(@NonNull Cursor cursor);
+
+	@NonNull
+	public List<T> getConfiguredCertificates()
+	{
+		managedConfigurationService.loadConfiguration();
+
+		final List<ManagedVpnProfile> managedVpnProfiles = managedConfigurationService.getManagedProfiles();
+		final List<T> certificates = new ArrayList<>(managedVpnProfiles.size());
+
+		for (final ManagedVpnProfile vpnProfile : managedVpnProfiles)
+		{
+			final T certificate = getCertificate(vpnProfile);
+			if (certificate != null)
+			{
+				certificates.add(certificate);
+			}
+		}
+
+		return certificates;
+	}
+
+	@NonNull
+	public List<T> getInstalledCertificates()
+	{
+		final Cursor cursor = database.query(table.Name, table.columnNames(), null, null, null, null, null);
+
+		final List<T> certificates = new ArrayList<>();
+
+		cursor.moveToFirst();
+		while (!cursor.isAfterLast())
+		{
+			final T certificate = createCertificate(cursor);
+			certificates.add(certificate);
+			cursor.moveToNext();
+		}
+		return certificates;
+	}
+
+	@NonNull
+	public Map<String, T> getInstalledCertificateMap()
+	{
+		final List<T> certificates = getInstalledCertificates();
+		final Map<String, T> map = new HashMap<>(certificates.size());
+
+		for (final T certificate : certificates)
+		{
+			map.put(certificate.getVpnProfileUuid(), certificate);
+		}
+
+		return map;
+	}
+
+	public void addInstalledCertificate(@NonNull final T certificate)
+	{
+		final ContentValues values = certificate.asContentValues();
+		database.insert(table.Name, null, values);
+	}
+
+	public void removeInstalledCertificate(@NonNull final T certificate)
+	{
+		final String vpnProfileUuid = certificate.getVpnProfileUuid();
+		database.delete(table.Name, PkcsCertificate.KEY_VPN_PROFILE_UUID + " = ?", new String[]{vpnProfileUuid});
+	}
+}

--- a/src/frontends/android/app/src/main/java/org/strongswan/android/data/DatabaseHelper.java
+++ b/src/frontends/android/app/src/main/java/org/strongswan/android/data/DatabaseHelper.java
@@ -9,6 +9,9 @@ import android.database.sqlite.SQLiteQueryBuilder;
 import android.util.Log;
 
 import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 import java.util.UUID;
 
 public class DatabaseHelper extends SQLiteOpenHelper
@@ -16,11 +19,10 @@ public class DatabaseHelper extends SQLiteOpenHelper
 	private static final String TAG = DatabaseHelper.class.getSimpleName();
 
 	private static final String DATABASE_NAME = "strongswan.db";
-	static final String TABLE_VPNPROFILE = "vpnprofile";
 
-	private static final int DATABASE_VERSION = 17;
+	private static final String TABLE_NAME_VPN_PROFILE = "vpnprofile";
 
-	private static final DbColumn[] COLUMNS = new DbColumn[]{
+	static final DbTable TABLE_VPN_PROFILE = new DbTable(TABLE_NAME_VPN_PROFILE, 1, new DbColumn[]{
 		new DbColumn(VpnProfileDataSource.KEY_ID, "INTEGER PRIMARY KEY AUTOINCREMENT", 1),
 		new DbColumn(VpnProfileDataSource.KEY_UUID, "TEXT UNIQUE", 9),
 		new DbColumn(VpnProfileDataSource.KEY_NAME, "TEXT NOT NULL", 1),
@@ -44,7 +46,17 @@ public class DatabaseHelper extends SQLiteOpenHelper
 		new DbColumn(VpnProfileDataSource.KEY_IKE_PROPOSAL, "TEXT", 15),
 		new DbColumn(VpnProfileDataSource.KEY_ESP_PROPOSAL, "TEXT", 15),
 		new DbColumn(VpnProfileDataSource.KEY_DNS_SERVERS, "TEXT", 17),
-	};
+	});
+
+	private static final int DATABASE_VERSION = 17;
+
+	private static final Set<DbTable> TABLES;
+
+	static
+	{
+		TABLES = new HashSet<>();
+		TABLES.add(TABLE_VPN_PROFILE);
+	}
 
 	DatabaseHelper(Context context)
 	{
@@ -54,7 +66,10 @@ public class DatabaseHelper extends SQLiteOpenHelper
 	@Override
 	public void onCreate(SQLiteDatabase database)
 	{
-		database.execSQL(getDatabaseCreate(DATABASE_VERSION));
+		for (final String sql : getDatabaseCreate(DATABASE_VERSION))
+		{
+			database.execSQL(sql);
+		}
 	}
 
 	@Override
@@ -64,91 +79,75 @@ public class DatabaseHelper extends SQLiteOpenHelper
 			" to " + newVersion);
 		if (oldVersion < 2)
 		{
-			db.execSQL("ALTER TABLE " + TABLE_VPNPROFILE + " ADD " + VpnProfileDataSource.KEY_USER_CERTIFICATE +
-				           " TEXT;");
+			db.execSQL("ALTER TABLE " + TABLE_NAME_VPN_PROFILE + " ADD " + VpnProfileDataSource.KEY_USER_CERTIFICATE + " TEXT;");
 		}
 		if (oldVersion < 3)
 		{
-			db.execSQL("ALTER TABLE " + TABLE_VPNPROFILE + " ADD " + VpnProfileDataSource.KEY_VPN_TYPE +
-				           " TEXT DEFAULT '';");
+			db.execSQL("ALTER TABLE " + TABLE_NAME_VPN_PROFILE + " ADD " + VpnProfileDataSource.KEY_VPN_TYPE + " TEXT DEFAULT '';");
 		}
 		if (oldVersion < 4)
 		{    /* remove NOT NULL constraint from username column */
-			updateColumns(db, 4);
+			updateColumns(db, TABLE_VPN_PROFILE, 4);
 		}
 		if (oldVersion < 5)
 		{
-			db.execSQL("ALTER TABLE " + TABLE_VPNPROFILE + " ADD " + VpnProfileDataSource.KEY_MTU +
-				           " INTEGER;");
+			db.execSQL("ALTER TABLE " + TABLE_NAME_VPN_PROFILE + " ADD " + VpnProfileDataSource.KEY_MTU + " INTEGER;");
 		}
 		if (oldVersion < 6)
 		{
-			db.execSQL("ALTER TABLE " + TABLE_VPNPROFILE + " ADD " + VpnProfileDataSource.KEY_PORT +
-				           " INTEGER;");
+			db.execSQL("ALTER TABLE " + TABLE_NAME_VPN_PROFILE + " ADD " + VpnProfileDataSource.KEY_PORT + " INTEGER;");
 		}
 		if (oldVersion < 7)
 		{
-			db.execSQL("ALTER TABLE " + TABLE_VPNPROFILE + " ADD " + VpnProfileDataSource.KEY_SPLIT_TUNNELING +
-				           " INTEGER;");
+			db.execSQL("ALTER TABLE " + TABLE_NAME_VPN_PROFILE + " ADD " + VpnProfileDataSource.KEY_SPLIT_TUNNELING + " INTEGER;");
 		}
 		if (oldVersion < 8)
 		{
-			db.execSQL("ALTER TABLE " + TABLE_VPNPROFILE + " ADD " + VpnProfileDataSource.KEY_LOCAL_ID +
-				           " TEXT;");
-			db.execSQL("ALTER TABLE " + TABLE_VPNPROFILE + " ADD " + VpnProfileDataSource.KEY_REMOTE_ID +
-				           " TEXT;");
+			db.execSQL("ALTER TABLE " + TABLE_NAME_VPN_PROFILE + " ADD " + VpnProfileDataSource.KEY_LOCAL_ID + " TEXT;");
+			db.execSQL("ALTER TABLE " + TABLE_NAME_VPN_PROFILE + " ADD " + VpnProfileDataSource.KEY_REMOTE_ID + " TEXT;");
 		}
 		if (oldVersion < 9)
 		{
-			db.execSQL("ALTER TABLE " + TABLE_VPNPROFILE + " ADD " + VpnProfileDataSource.KEY_UUID +
-				           " TEXT;");
-			updateColumns(db, 9);
+			db.execSQL("ALTER TABLE " + TABLE_NAME_VPN_PROFILE + " ADD " + VpnProfileDataSource.KEY_UUID + " TEXT;");
+			updateColumns(db, TABLE_VPN_PROFILE, 9);
 		}
 		if (oldVersion < 10)
 		{
-			db.execSQL("ALTER TABLE " + TABLE_VPNPROFILE + " ADD " + VpnProfileDataSource.KEY_EXCLUDED_SUBNETS +
-				           " TEXT;");
+			db.execSQL("ALTER TABLE " + TABLE_NAME_VPN_PROFILE + " ADD " + VpnProfileDataSource.KEY_EXCLUDED_SUBNETS + " TEXT;");
 		}
 		if (oldVersion < 11)
 		{
-			db.execSQL("ALTER TABLE " + TABLE_VPNPROFILE + " ADD " + VpnProfileDataSource.KEY_INCLUDED_SUBNETS +
-				           " TEXT;");
+			db.execSQL("ALTER TABLE " + TABLE_NAME_VPN_PROFILE + " ADD " + VpnProfileDataSource.KEY_INCLUDED_SUBNETS + " TEXT;");
 		}
 		if (oldVersion < 12)
 		{
-			db.execSQL("ALTER TABLE " + TABLE_VPNPROFILE + " ADD " + VpnProfileDataSource.KEY_SELECTED_APPS +
-				           " INTEGER;");
-			db.execSQL("ALTER TABLE " + TABLE_VPNPROFILE + " ADD " + VpnProfileDataSource.KEY_SELECTED_APPS_LIST +
-				           " TEXT;");
+			db.execSQL("ALTER TABLE " + TABLE_NAME_VPN_PROFILE + " ADD " + VpnProfileDataSource.KEY_SELECTED_APPS + " INTEGER;");
+			db.execSQL("ALTER TABLE " + TABLE_NAME_VPN_PROFILE + " ADD " + VpnProfileDataSource.KEY_SELECTED_APPS_LIST + " TEXT;");
 		}
 		if (oldVersion < 13)
 		{
-			db.execSQL("ALTER TABLE " + TABLE_VPNPROFILE + " ADD " + VpnProfileDataSource.KEY_NAT_KEEPALIVE +
-				           " INTEGER;");
+			db.execSQL("ALTER TABLE " + TABLE_NAME_VPN_PROFILE + " ADD " + VpnProfileDataSource.KEY_NAT_KEEPALIVE + " INTEGER;");
 		}
 		if (oldVersion < 14)
 		{
-			db.execSQL("ALTER TABLE " + TABLE_VPNPROFILE + " ADD " + VpnProfileDataSource.KEY_FLAGS +
-				           " INTEGER;");
+			db.execSQL("ALTER TABLE " + TABLE_NAME_VPN_PROFILE + " ADD " + VpnProfileDataSource.KEY_FLAGS + " INTEGER;");
 		}
 		if (oldVersion < 15)
 		{
-			db.execSQL("ALTER TABLE " + TABLE_VPNPROFILE + " ADD " + VpnProfileDataSource.KEY_IKE_PROPOSAL +
-				           " TEXT;");
-			db.execSQL("ALTER TABLE " + TABLE_VPNPROFILE + " ADD " + VpnProfileDataSource.KEY_ESP_PROPOSAL +
-				           " TEXT;");
+			db.execSQL("ALTER TABLE " + TABLE_NAME_VPN_PROFILE + " ADD " + VpnProfileDataSource.KEY_IKE_PROPOSAL + " TEXT;");
+			db.execSQL("ALTER TABLE " + TABLE_NAME_VPN_PROFILE + " ADD " + VpnProfileDataSource.KEY_ESP_PROPOSAL + " TEXT;");
 		}
 		if (oldVersion < 16)
 		{    /* add a UUID to all entries that haven't one yet */
 			db.beginTransaction();
 			try
 			{
-				Cursor cursor = db.query(TABLE_VPNPROFILE, getColumns(16), VpnProfileDataSource.KEY_UUID + " is NULL", null, null, null, null);
+				Cursor cursor = db.query(TABLE_VPN_PROFILE.Name, TABLE_VPN_PROFILE.getColumnNames(16), VpnProfileDataSource.KEY_UUID + " is NULL", null, null, null, null);
 				for (cursor.moveToFirst(); !cursor.isAfterLast(); cursor.moveToNext())
 				{
 					ContentValues values = new ContentValues();
 					values.put(VpnProfileDataSource.KEY_UUID, UUID.randomUUID().toString());
-					db.update(TABLE_VPNPROFILE, values, VpnProfileDataSource.KEY_ID + " = " + cursor.getLong(cursor.getColumnIndexOrThrow(VpnProfileDataSource.KEY_ID)), null);
+					db.update(TABLE_VPN_PROFILE.Name, values, VpnProfileDataSource.KEY_ID + " = " + cursor.getLong(cursor.getColumnIndexOrThrow(VpnProfileDataSource.KEY_ID)), null);
 				}
 				cursor.close();
 				db.setTransactionSuccessful();
@@ -160,27 +159,21 @@ public class DatabaseHelper extends SQLiteOpenHelper
 		}
 		if (oldVersion < 17)
 		{
-			db.execSQL("ALTER TABLE " + TABLE_VPNPROFILE + " ADD " + VpnProfileDataSource.KEY_DNS_SERVERS +
-				           " TEXT;");
+			db.execSQL("ALTER TABLE " + TABLE_NAME_VPN_PROFILE + " ADD " + VpnProfileDataSource.KEY_DNS_SERVERS + " TEXT;");
 		}
 	}
 
-	public String[] getAllColumns()
-	{
-		return getColumns(DATABASE_VERSION);
-	}
-
-	private void updateColumns(SQLiteDatabase db, int version)
+	private void updateColumns(SQLiteDatabase db, DbTable table, int version)
 	{
 		db.beginTransaction();
 		try
 		{
-			db.execSQL("ALTER TABLE " + TABLE_VPNPROFILE + " RENAME TO tmp_" + TABLE_VPNPROFILE + ";");
-			db.execSQL(getDatabaseCreate(version));
-			StringBuilder insert = new StringBuilder("INSERT INTO " + TABLE_VPNPROFILE + " SELECT ");
-			SQLiteQueryBuilder.appendColumns(insert, getColumns(version));
-			db.execSQL(insert.append(" FROM tmp_" + TABLE_VPNPROFILE + ";").toString());
-			db.execSQL("DROP TABLE tmp_" + TABLE_VPNPROFILE + ";");
+			db.execSQL("ALTER TABLE " + table.Name + " RENAME TO tmp_" + table.Name + ";");
+			db.execSQL(getTableCreate(table, version));
+			StringBuilder insert = new StringBuilder("INSERT INTO " + table.Name + " SELECT ");
+			SQLiteQueryBuilder.appendColumns(insert, table.getColumnNames(version));
+			db.execSQL(insert.append(" FROM tmp_" + table.Name + ";").toString());
+			db.execSQL("DROP TABLE tmp_" + table.Name + ";");
 			db.setTransactionSuccessful();
 		}
 		finally
@@ -189,50 +182,93 @@ public class DatabaseHelper extends SQLiteOpenHelper
 		}
 	}
 
-	private String getDatabaseCreate(int version)
+	private List<String> getDatabaseCreate(final int version)
+	{
+		List<String> statements = new ArrayList<>(TABLES.size());
+		for (final DbTable table : TABLES)
+		{
+			if (table.Since <= version)
+			{
+				final String statement = getTableCreate(table, version);
+				statements.add(statement);
+			}
+		}
+		return statements;
+	}
+
+	private static String getTableCreate(DbTable table, int version)
 	{
 		boolean first = true;
-		StringBuilder create = new StringBuilder("CREATE TABLE ");
-		create.append(TABLE_VPNPROFILE);
+		StringBuilder create = new StringBuilder("CREATE TABLE IF NOT EXISTS ");
+		create.append(table.Name);
 		create.append(" (");
-		for (DbColumn column : COLUMNS)
+
+		final List<DbColumn> columns = table.getColumns(version);
+		for (final DbColumn column : columns)
 		{
-			if (column.Since <= version)
+			if (!first)
 			{
-				if (!first)
-				{
-					create.append(",");
-				}
-				first = false;
-				create.append(column.Name);
-				create.append(" ");
-				create.append(column.Type);
+				create.append(",");
 			}
+			first = false;
+			create.append(column.Name);
+			create.append(" ");
+			create.append(column.Type);
 		}
 		create.append(");");
 		return create.toString();
 	}
 
-	private String[] getColumns(int version)
+	static class DbTable
 	{
-		ArrayList<String> columns = new ArrayList<>();
-		for (DbColumn column : COLUMNS)
+		final String Name;
+		final int Since;
+		final DbColumn[] Columns;
+
+		private DbTable(final String name, final int since, final DbColumn[] columns)
 		{
-			if (column.Since <= version)
-			{
-				columns.add(column.Name);
-			}
+			Name = name;
+			Since = since;
+			Columns = columns;
 		}
-		return columns.toArray(new String[0]);
+
+		private List<DbColumn> getColumns(int version)
+		{
+			final List<DbColumn> columns = new ArrayList<>(Columns.length);
+			for (final DbColumn column : Columns)
+			{
+				if (column.Since <= version)
+				{
+					columns.add(column);
+				}
+			}
+			return columns;
+		}
+
+		private String[] getColumnNames(final int version)
+		{
+			final List<DbColumn> columns = getColumns(version);
+			final List<String> columnNames = new ArrayList<>(columns.size());
+			for (DbColumn column : columns)
+			{
+				columnNames.add(column.Name);
+			}
+			return columnNames.toArray(new String[0]);
+		}
+
+		public String[] columnNames()
+		{
+			return getColumnNames(DATABASE_VERSION);
+		}
 	}
 
-	private static class DbColumn
+	static class DbColumn
 	{
-		public final String Name;
-		public final String Type;
-		public final Integer Since;
+		final String Name;
+		final String Type;
+		final int Since;
 
-		public DbColumn(String name, String type, Integer since)
+		private DbColumn(String name, String type, int since)
 		{
 			Name = name;
 			Type = type;

--- a/src/frontends/android/app/src/main/java/org/strongswan/android/data/DatabaseHelper.java
+++ b/src/frontends/android/app/src/main/java/org/strongswan/android/data/DatabaseHelper.java
@@ -58,7 +58,7 @@ public class DatabaseHelper extends SQLiteOpenHelper
 		TABLES.add(TABLE_VPN_PROFILE);
 	}
 
-	DatabaseHelper(Context context)
+	public DatabaseHelper(Context context)
 	{
 		super(context, DATABASE_NAME, null, DATABASE_VERSION);
 	}

--- a/src/frontends/android/app/src/main/java/org/strongswan/android/data/DatabaseHelper.java
+++ b/src/frontends/android/app/src/main/java/org/strongswan/android/data/DatabaseHelper.java
@@ -21,6 +21,8 @@ public class DatabaseHelper extends SQLiteOpenHelper
 	private static final String DATABASE_NAME = "strongswan.db";
 
 	private static final String TABLE_NAME_VPN_PROFILE = "vpnprofile";
+	private static final String TABLE_NAME_CA_CERTIFICATE = "cacertificate";
+	private static final String TABLE_NAME_USER_CERTIFICATE = "usercertificate";
 
 	static final DbTable TABLE_VPN_PROFILE = new DbTable(TABLE_NAME_VPN_PROFILE, 1, new DbColumn[]{
 		new DbColumn(VpnProfileDataSource.KEY_ID, "INTEGER PRIMARY KEY AUTOINCREMENT", 1),
@@ -48,7 +50,24 @@ public class DatabaseHelper extends SQLiteOpenHelper
 		new DbColumn(VpnProfileDataSource.KEY_DNS_SERVERS, "TEXT", 17),
 	});
 
-	private static final int DATABASE_VERSION = 17;
+	public static final DbTable TABLE_CA_CERTIFICATE = new DbTable(TABLE_NAME_CA_CERTIFICATE, 18, new DbColumn[]{
+		new DbColumn(PkcsCertificate.KEY_ID, "INTEGER PRIMARY KEY AUTOINCREMENT", 18),
+		new DbColumn(PkcsCertificate.KEY_VPN_PROFILE_UUID, "TEXT UNIQUE", 18),
+		new DbColumn(PkcsCertificate.KEY_CONFIGURED_ALIAS, "TEXT NOT NULL", 18),
+		new DbColumn(PkcsCertificate.KEY_EFFECTIVE_ALIAS, "TEXT", 18),
+		new DbColumn(PkcsCertificate.KEY_DATA, "TEXT NOT NULL", 18),
+	});
+
+	public static final DbTable TABLE_USER_CERTIFICATE = new DbTable(TABLE_NAME_USER_CERTIFICATE, 18, new DbColumn[]{
+		new DbColumn(PkcsCertificate.KEY_ID, "INTEGER PRIMARY KEY AUTOINCREMENT", 18),
+		new DbColumn(PkcsCertificate.KEY_VPN_PROFILE_UUID, "TEXT UNIQUE", 18),
+		new DbColumn(PkcsCertificate.KEY_CONFIGURED_ALIAS, "TEXT NOT NULL", 18),
+		new DbColumn(PkcsCertificate.KEY_EFFECTIVE_ALIAS, "TEXT", 18),
+		new DbColumn(PkcsCertificate.KEY_DATA, "TEXT NOT NULL", 18),
+		new DbColumn(UserCertificate.KEY_PASSWORD, "TEXT", 18),
+	});
+
+	private static final int DATABASE_VERSION = 18;
 
 	private static final Set<DbTable> TABLES;
 
@@ -56,6 +75,8 @@ public class DatabaseHelper extends SQLiteOpenHelper
 	{
 		TABLES = new HashSet<>();
 		TABLES.add(TABLE_VPN_PROFILE);
+		TABLES.add(TABLE_CA_CERTIFICATE);
+		TABLES.add(TABLE_USER_CERTIFICATE);
 	}
 
 	public DatabaseHelper(Context context)

--- a/src/frontends/android/app/src/main/java/org/strongswan/android/data/DatabaseHelper.java
+++ b/src/frontends/android/app/src/main/java/org/strongswan/android/data/DatabaseHelper.java
@@ -1,0 +1,242 @@
+package org.strongswan.android.data;
+
+import android.content.ContentValues;
+import android.content.Context;
+import android.database.Cursor;
+import android.database.sqlite.SQLiteDatabase;
+import android.database.sqlite.SQLiteOpenHelper;
+import android.database.sqlite.SQLiteQueryBuilder;
+import android.util.Log;
+
+import java.util.ArrayList;
+import java.util.UUID;
+
+public class DatabaseHelper extends SQLiteOpenHelper
+{
+	private static final String TAG = DatabaseHelper.class.getSimpleName();
+
+	private static final String DATABASE_NAME = "strongswan.db";
+	static final String TABLE_VPNPROFILE = "vpnprofile";
+
+	private static final int DATABASE_VERSION = 17;
+
+	private static final DbColumn[] COLUMNS = new DbColumn[]{
+		new DbColumn(VpnProfileDataSource.KEY_ID, "INTEGER PRIMARY KEY AUTOINCREMENT", 1),
+		new DbColumn(VpnProfileDataSource.KEY_UUID, "TEXT UNIQUE", 9),
+		new DbColumn(VpnProfileDataSource.KEY_NAME, "TEXT NOT NULL", 1),
+		new DbColumn(VpnProfileDataSource.KEY_GATEWAY, "TEXT NOT NULL", 1),
+		new DbColumn(VpnProfileDataSource.KEY_VPN_TYPE, "TEXT NOT NULL", 3),
+		new DbColumn(VpnProfileDataSource.KEY_USERNAME, "TEXT", 1),
+		new DbColumn(VpnProfileDataSource.KEY_PASSWORD, "TEXT", 1),
+		new DbColumn(VpnProfileDataSource.KEY_CERTIFICATE, "TEXT", 1),
+		new DbColumn(VpnProfileDataSource.KEY_USER_CERTIFICATE, "TEXT", 2),
+		new DbColumn(VpnProfileDataSource.KEY_MTU, "INTEGER", 5),
+		new DbColumn(VpnProfileDataSource.KEY_PORT, "INTEGER", 6),
+		new DbColumn(VpnProfileDataSource.KEY_SPLIT_TUNNELING, "INTEGER", 7),
+		new DbColumn(VpnProfileDataSource.KEY_LOCAL_ID, "TEXT", 8),
+		new DbColumn(VpnProfileDataSource.KEY_REMOTE_ID, "TEXT", 8),
+		new DbColumn(VpnProfileDataSource.KEY_EXCLUDED_SUBNETS, "TEXT", 10),
+		new DbColumn(VpnProfileDataSource.KEY_INCLUDED_SUBNETS, "TEXT", 11),
+		new DbColumn(VpnProfileDataSource.KEY_SELECTED_APPS, "INTEGER", 12),
+		new DbColumn(VpnProfileDataSource.KEY_SELECTED_APPS_LIST, "TEXT", 12),
+		new DbColumn(VpnProfileDataSource.KEY_NAT_KEEPALIVE, "INTEGER", 13),
+		new DbColumn(VpnProfileDataSource.KEY_FLAGS, "INTEGER", 14),
+		new DbColumn(VpnProfileDataSource.KEY_IKE_PROPOSAL, "TEXT", 15),
+		new DbColumn(VpnProfileDataSource.KEY_ESP_PROPOSAL, "TEXT", 15),
+		new DbColumn(VpnProfileDataSource.KEY_DNS_SERVERS, "TEXT", 17),
+	};
+
+	DatabaseHelper(Context context)
+	{
+		super(context, DATABASE_NAME, null, DATABASE_VERSION);
+	}
+
+	@Override
+	public void onCreate(SQLiteDatabase database)
+	{
+		database.execSQL(getDatabaseCreate(DATABASE_VERSION));
+	}
+
+	@Override
+	public void onUpgrade(SQLiteDatabase db, int oldVersion, int newVersion)
+	{
+		Log.w(TAG, "Upgrading database from version " + oldVersion +
+			" to " + newVersion);
+		if (oldVersion < 2)
+		{
+			db.execSQL("ALTER TABLE " + TABLE_VPNPROFILE + " ADD " + VpnProfileDataSource.KEY_USER_CERTIFICATE +
+				           " TEXT;");
+		}
+		if (oldVersion < 3)
+		{
+			db.execSQL("ALTER TABLE " + TABLE_VPNPROFILE + " ADD " + VpnProfileDataSource.KEY_VPN_TYPE +
+				           " TEXT DEFAULT '';");
+		}
+		if (oldVersion < 4)
+		{    /* remove NOT NULL constraint from username column */
+			updateColumns(db, 4);
+		}
+		if (oldVersion < 5)
+		{
+			db.execSQL("ALTER TABLE " + TABLE_VPNPROFILE + " ADD " + VpnProfileDataSource.KEY_MTU +
+				           " INTEGER;");
+		}
+		if (oldVersion < 6)
+		{
+			db.execSQL("ALTER TABLE " + TABLE_VPNPROFILE + " ADD " + VpnProfileDataSource.KEY_PORT +
+				           " INTEGER;");
+		}
+		if (oldVersion < 7)
+		{
+			db.execSQL("ALTER TABLE " + TABLE_VPNPROFILE + " ADD " + VpnProfileDataSource.KEY_SPLIT_TUNNELING +
+				           " INTEGER;");
+		}
+		if (oldVersion < 8)
+		{
+			db.execSQL("ALTER TABLE " + TABLE_VPNPROFILE + " ADD " + VpnProfileDataSource.KEY_LOCAL_ID +
+				           " TEXT;");
+			db.execSQL("ALTER TABLE " + TABLE_VPNPROFILE + " ADD " + VpnProfileDataSource.KEY_REMOTE_ID +
+				           " TEXT;");
+		}
+		if (oldVersion < 9)
+		{
+			db.execSQL("ALTER TABLE " + TABLE_VPNPROFILE + " ADD " + VpnProfileDataSource.KEY_UUID +
+				           " TEXT;");
+			updateColumns(db, 9);
+		}
+		if (oldVersion < 10)
+		{
+			db.execSQL("ALTER TABLE " + TABLE_VPNPROFILE + " ADD " + VpnProfileDataSource.KEY_EXCLUDED_SUBNETS +
+				           " TEXT;");
+		}
+		if (oldVersion < 11)
+		{
+			db.execSQL("ALTER TABLE " + TABLE_VPNPROFILE + " ADD " + VpnProfileDataSource.KEY_INCLUDED_SUBNETS +
+				           " TEXT;");
+		}
+		if (oldVersion < 12)
+		{
+			db.execSQL("ALTER TABLE " + TABLE_VPNPROFILE + " ADD " + VpnProfileDataSource.KEY_SELECTED_APPS +
+				           " INTEGER;");
+			db.execSQL("ALTER TABLE " + TABLE_VPNPROFILE + " ADD " + VpnProfileDataSource.KEY_SELECTED_APPS_LIST +
+				           " TEXT;");
+		}
+		if (oldVersion < 13)
+		{
+			db.execSQL("ALTER TABLE " + TABLE_VPNPROFILE + " ADD " + VpnProfileDataSource.KEY_NAT_KEEPALIVE +
+				           " INTEGER;");
+		}
+		if (oldVersion < 14)
+		{
+			db.execSQL("ALTER TABLE " + TABLE_VPNPROFILE + " ADD " + VpnProfileDataSource.KEY_FLAGS +
+				           " INTEGER;");
+		}
+		if (oldVersion < 15)
+		{
+			db.execSQL("ALTER TABLE " + TABLE_VPNPROFILE + " ADD " + VpnProfileDataSource.KEY_IKE_PROPOSAL +
+				           " TEXT;");
+			db.execSQL("ALTER TABLE " + TABLE_VPNPROFILE + " ADD " + VpnProfileDataSource.KEY_ESP_PROPOSAL +
+				           " TEXT;");
+		}
+		if (oldVersion < 16)
+		{    /* add a UUID to all entries that haven't one yet */
+			db.beginTransaction();
+			try
+			{
+				Cursor cursor = db.query(TABLE_VPNPROFILE, getColumns(16), VpnProfileDataSource.KEY_UUID + " is NULL", null, null, null, null);
+				for (cursor.moveToFirst(); !cursor.isAfterLast(); cursor.moveToNext())
+				{
+					ContentValues values = new ContentValues();
+					values.put(VpnProfileDataSource.KEY_UUID, UUID.randomUUID().toString());
+					db.update(TABLE_VPNPROFILE, values, VpnProfileDataSource.KEY_ID + " = " + cursor.getLong(cursor.getColumnIndexOrThrow(VpnProfileDataSource.KEY_ID)), null);
+				}
+				cursor.close();
+				db.setTransactionSuccessful();
+			}
+			finally
+			{
+				db.endTransaction();
+			}
+		}
+		if (oldVersion < 17)
+		{
+			db.execSQL("ALTER TABLE " + TABLE_VPNPROFILE + " ADD " + VpnProfileDataSource.KEY_DNS_SERVERS +
+				           " TEXT;");
+		}
+	}
+
+	public String[] getAllColumns()
+	{
+		return getColumns(DATABASE_VERSION);
+	}
+
+	private void updateColumns(SQLiteDatabase db, int version)
+	{
+		db.beginTransaction();
+		try
+		{
+			db.execSQL("ALTER TABLE " + TABLE_VPNPROFILE + " RENAME TO tmp_" + TABLE_VPNPROFILE + ";");
+			db.execSQL(getDatabaseCreate(version));
+			StringBuilder insert = new StringBuilder("INSERT INTO " + TABLE_VPNPROFILE + " SELECT ");
+			SQLiteQueryBuilder.appendColumns(insert, getColumns(version));
+			db.execSQL(insert.append(" FROM tmp_" + TABLE_VPNPROFILE + ";").toString());
+			db.execSQL("DROP TABLE tmp_" + TABLE_VPNPROFILE + ";");
+			db.setTransactionSuccessful();
+		}
+		finally
+		{
+			db.endTransaction();
+		}
+	}
+
+	private String getDatabaseCreate(int version)
+	{
+		boolean first = true;
+		StringBuilder create = new StringBuilder("CREATE TABLE ");
+		create.append(TABLE_VPNPROFILE);
+		create.append(" (");
+		for (DbColumn column : COLUMNS)
+		{
+			if (column.Since <= version)
+			{
+				if (!first)
+				{
+					create.append(",");
+				}
+				first = false;
+				create.append(column.Name);
+				create.append(" ");
+				create.append(column.Type);
+			}
+		}
+		create.append(");");
+		return create.toString();
+	}
+
+	private String[] getColumns(int version)
+	{
+		ArrayList<String> columns = new ArrayList<>();
+		for (DbColumn column : COLUMNS)
+		{
+			if (column.Since <= version)
+			{
+				columns.add(column.Name);
+			}
+		}
+		return columns.toArray(new String[0]);
+	}
+
+	private static class DbColumn
+	{
+		public final String Name;
+		public final String Type;
+		public final Integer Since;
+
+		public DbColumn(String name, String type, Integer since)
+		{
+			Name = name;
+			Type = type;
+			Since = since;
+		}
+	}
+}

--- a/src/frontends/android/app/src/main/java/org/strongswan/android/data/ManagedConfiguration.java
+++ b/src/frontends/android/app/src/main/java/org/strongswan/android/data/ManagedConfiguration.java
@@ -117,6 +117,10 @@ public class ManagedConfiguration
 
 	public String getDefaultVpnProfile()
 	{
+		if (mDefaultVpnProfile != null && mDefaultVpnProfile.equalsIgnoreCase("mru"))
+		{
+			return Constants.PREF_DEFAULT_VPN_PROFILE_MRU;
+		}
 		return mDefaultVpnProfile;
 	}
 

--- a/src/frontends/android/app/src/main/java/org/strongswan/android/data/ManagedConfiguration.java
+++ b/src/frontends/android/app/src/main/java/org/strongswan/android/data/ManagedConfiguration.java
@@ -86,6 +86,8 @@ public class ManagedConfiguration
 			return;
 		}
 
+		assert uuid != null;
+
 		final ManagedVpnProfile vpnProfile = new ManagedVpnProfile(managedProfileBundle, uuid);
 		mManagedVpnProfiles.add(vpnProfile);
 		mProfileUuids.add(uuid);

--- a/src/frontends/android/app/src/main/java/org/strongswan/android/data/ManagedConfiguration.java
+++ b/src/frontends/android/app/src/main/java/org/strongswan/android/data/ManagedConfiguration.java
@@ -1,0 +1,132 @@
+package org.strongswan.android.data;
+
+import android.os.Build;
+import android.os.Bundle;
+import android.os.Parcelable;
+
+import org.strongswan.android.utils.Constants;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import androidx.annotation.NonNull;
+
+public class ManagedConfiguration
+{
+	private static final String KEY_ALLOW_PROFILE_CREATE = "allow_profile_create";
+	private static final String KEY_ALLOW_PROFILE_IMPORT = "allow_profile_import";
+	private static final String KEY_ALLOW_CERTIFICATE_IMPORT = "allow_certificate_import";
+	private static final String KEY_ALLOW_SETTINGS_ACCESS = "allow_settings_access";
+	private static final String KEY_MANAGED_PROFILES = "managed_profiles";
+
+	private final boolean mAllowProfileCreation;
+	private final boolean mAllowProfileImport;
+	private final boolean mAllowCertificateImport;
+
+	private final boolean mAllowSettingsAccess;
+	private final String mDefaultVpnProfile;
+	private final boolean mIgnoreBatteryOptimizations;
+
+	private final List<ManagedVpnProfile> mManagedVpnProfiles;
+
+	ManagedConfiguration()
+	{
+		mAllowProfileCreation = true;
+		mAllowProfileImport = true;
+		mAllowCertificateImport = true;
+
+		mAllowSettingsAccess = true;
+		mDefaultVpnProfile = null;
+		mIgnoreBatteryOptimizations = false;
+
+		mManagedVpnProfiles = Collections.emptyList();
+	}
+
+	ManagedConfiguration(final Bundle bundle)
+	{
+		mAllowProfileCreation = bundle.getBoolean(KEY_ALLOW_PROFILE_CREATE, true);
+		mAllowProfileImport = bundle.getBoolean(KEY_ALLOW_PROFILE_IMPORT, true);
+		mAllowCertificateImport = bundle.getBoolean(KEY_ALLOW_CERTIFICATE_IMPORT, true);
+
+		mAllowSettingsAccess = bundle.getBoolean(KEY_ALLOW_SETTINGS_ACCESS, true);
+		mDefaultVpnProfile = bundle.getString(Constants.PREF_DEFAULT_VPN_PROFILE, null);
+		mIgnoreBatteryOptimizations = bundle.getBoolean(Constants.PREF_IGNORE_POWER_WHITELIST, false);
+
+		final List<Bundle> managedProfileBundles = getBundleArrayList(bundle, KEY_MANAGED_PROFILES);
+		mManagedVpnProfiles = new ArrayList<>(managedProfileBundles.size());
+
+		long index = Long.MAX_VALUE;
+
+		for (final Bundle managedProfileBundle : managedProfileBundles)
+		{
+			final ManagedVpnProfile vpnProfile = new ManagedVpnProfile(managedProfileBundle);
+			vpnProfile.setId(index--);
+
+			mManagedVpnProfiles.add(vpnProfile);
+		}
+	}
+
+	private List<Bundle> getBundleArrayList(final Bundle bundle, String key)
+	{
+		if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU)
+		{
+			return getBundleArrayListCompat(bundle, key);
+		}
+
+		final Bundle[] bundles = bundle.getParcelableArray(key, Bundle.class);
+		if (bundles == null)
+		{
+			return Collections.emptyList();
+		}
+		return Arrays.asList(bundles);
+	}
+
+	@NonNull
+	private static List<Bundle> getBundleArrayListCompat(Bundle bundle, String key)
+	{
+		final Parcelable[] parcelables = bundle.getParcelableArray(key);
+		if (parcelables == null)
+		{
+			return Collections.emptyList();
+		}
+		final Bundle[] bundles = Arrays.copyOf(parcelables, parcelables.length, Bundle[].class);
+		return Arrays.asList(bundles);
+	}
+
+	public boolean isAllowProfileCreation()
+	{
+		return mAllowProfileCreation;
+	}
+
+	public boolean isAllowProfileImport()
+	{
+		return mAllowProfileImport;
+	}
+
+	public boolean isAllowCertificateImport()
+	{
+		return mAllowCertificateImport;
+	}
+
+	public boolean isAllowSettingsAccess()
+	{
+		return mAllowSettingsAccess;
+	}
+
+	public String getDefaultVpnProfile()
+	{
+		return mDefaultVpnProfile;
+	}
+
+	public boolean isIgnoreBatteryOptimizations()
+	{
+		return mIgnoreBatteryOptimizations;
+	}
+
+	public List<ManagedVpnProfile> getVpnProfiles()
+	{
+		return mManagedVpnProfiles;
+	}
+}

--- a/src/frontends/android/app/src/main/java/org/strongswan/android/data/ManagedConfiguration.java
+++ b/src/frontends/android/app/src/main/java/org/strongswan/android/data/ManagedConfiguration.java
@@ -57,13 +57,9 @@ public class ManagedConfiguration
 		final List<Bundle> managedProfileBundles = getBundleArrayList(bundle, KEY_MANAGED_PROFILES);
 		mManagedVpnProfiles = new ArrayList<>(managedProfileBundles.size());
 
-		long index = Long.MAX_VALUE;
-
 		for (final Bundle managedProfileBundle : managedProfileBundles)
 		{
 			final ManagedVpnProfile vpnProfile = new ManagedVpnProfile(managedProfileBundle);
-			vpnProfile.setId(index--);
-
 			mManagedVpnProfiles.add(vpnProfile);
 		}
 	}

--- a/src/frontends/android/app/src/main/java/org/strongswan/android/data/ManagedConfiguration.java
+++ b/src/frontends/android/app/src/main/java/org/strongswan/android/data/ManagedConfiguration.java
@@ -22,12 +22,14 @@ public class ManagedConfiguration
 
 	private static final String KEY_ALLOW_PROFILE_CREATE = "allow_profile_create";
 	private static final String KEY_ALLOW_PROFILE_IMPORT = "allow_profile_import";
+	private static final String KEY_ALLOW_EXISTING_PROFILES = "allow_existing_profiles";
 	private static final String KEY_ALLOW_CERTIFICATE_IMPORT = "allow_certificate_import";
 	private static final String KEY_ALLOW_SETTINGS_ACCESS = "allow_settings_access";
 	private static final String KEY_MANAGED_PROFILES = "managed_profiles";
 
 	private final boolean mAllowProfileCreation;
 	private final boolean mAllowProfileImport;
+	private final boolean mAllowExistingProfiles;
 	private final boolean mAllowCertificateImport;
 
 	private final boolean mAllowSettingsAccess;
@@ -43,6 +45,7 @@ public class ManagedConfiguration
 	{
 		mAllowProfileCreation = true;
 		mAllowProfileImport = true;
+		mAllowExistingProfiles = true;
 		mAllowCertificateImport = true;
 
 		mAllowSettingsAccess = true;
@@ -56,6 +59,8 @@ public class ManagedConfiguration
 	{
 		mAllowProfileCreation = bundle.getBoolean(KEY_ALLOW_PROFILE_CREATE, true);
 		mAllowProfileImport = bundle.getBoolean(KEY_ALLOW_PROFILE_IMPORT, true);
+		mAllowExistingProfiles = bundle.getBoolean(KEY_ALLOW_EXISTING_PROFILES, true);
+
 		mAllowCertificateImport = bundle.getBoolean(KEY_ALLOW_CERTIFICATE_IMPORT, true);
 
 		mAllowSettingsAccess = bundle.getBoolean(KEY_ALLOW_SETTINGS_ACCESS, true);
@@ -127,6 +132,11 @@ public class ManagedConfiguration
 	public boolean isAllowProfileImport()
 	{
 		return mAllowProfileImport;
+	}
+
+	public boolean isAllowExistingProfiles()
+	{
+		return mAllowExistingProfiles;
 	}
 
 	public boolean isAllowCertificateImport()

--- a/src/frontends/android/app/src/main/java/org/strongswan/android/data/ManagedConfigurationService.java
+++ b/src/frontends/android/app/src/main/java/org/strongswan/android/data/ManagedConfigurationService.java
@@ -1,0 +1,73 @@
+package org.strongswan.android.data;
+
+import android.content.Context;
+import android.content.RestrictionsManager;
+import android.content.SharedPreferences;
+import android.os.Build;
+import android.os.Bundle;
+
+import org.strongswan.android.utils.Constants;
+
+import java.util.Collections;
+import java.util.List;
+
+import androidx.preference.PreferenceManager;
+
+public class ManagedConfigurationService
+{
+	private final Context mContext;
+
+	private ManagedConfiguration mManagedConfiguration = new ManagedConfiguration();
+	private List<ManagedVpnProfile> mManagedVpnProfiles = Collections.emptyList();
+
+	public ManagedConfigurationService(final Context context)
+	{
+		this.mContext = context;
+	}
+
+	public void loadConfiguration()
+	{
+		if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M)
+		{
+			return;
+		}
+
+		final RestrictionsManager restrictionsService = mContext.getSystemService(RestrictionsManager.class);
+		if (restrictionsService == null)
+		{
+			return;
+		}
+
+		final Bundle configuration = restrictionsService.getApplicationRestrictions();
+		if (configuration == null)
+		{
+			return;
+		}
+
+		final ManagedConfiguration managedConfiguration = new ManagedConfiguration(configuration);
+		mManagedConfiguration = managedConfiguration;
+		mManagedVpnProfiles = managedConfiguration.getVpnProfiles();
+	}
+
+	public void updateSettings()
+	{
+		if (!mManagedConfiguration.isAllowSettingsAccess())
+		{
+			final SharedPreferences pref = PreferenceManager.getDefaultSharedPreferences(mContext);
+			final SharedPreferences.Editor editor = pref.edit();
+			editor.putBoolean(Constants.PREF_IGNORE_POWER_WHITELIST, mManagedConfiguration.isIgnoreBatteryOptimizations());
+			editor.putString(Constants.PREF_DEFAULT_VPN_PROFILE, mManagedConfiguration.getDefaultVpnProfile());
+			editor.apply();
+		}
+	}
+
+	public ManagedConfiguration getManagedConfiguration()
+	{
+		return mManagedConfiguration;
+	}
+
+	public List<ManagedVpnProfile> getManagedProfiles()
+	{
+		return mManagedVpnProfiles;
+	}
+}

--- a/src/frontends/android/app/src/main/java/org/strongswan/android/data/ManagedVpnProfile.java
+++ b/src/frontends/android/app/src/main/java/org/strongswan/android/data/ManagedVpnProfile.java
@@ -22,12 +22,12 @@ public class ManagedVpnProfile extends VpnProfile
 	private static final String KEY_SPLIT_TUNNELLING_BLOCK_IPV4_FLAG = "split_tunnelling_block_IPv4";
 	private static final String KEY_SPLIT_TUNNELLING_BLOCK_IPV6_FLAG = "split_tunnelling_block_IPv6";
 
-	ManagedVpnProfile(final Bundle bundle)
+	ManagedVpnProfile(final Bundle bundle, final String uuid)
 	{
 		int flags = 0;
 		int splitFlags = 0;
 
-		setUUID(UUID.fromString(bundle.getString(VpnProfileDataSource.KEY_UUID)));
+		setUUID(UUID.fromString(uuid));
 		setName(bundle.getString(VpnProfileDataSource.KEY_NAME));
 		setVpnType(VpnType.fromIdentifier(bundle.getString(VpnProfileDataSource.KEY_VPN_TYPE)));
 

--- a/src/frontends/android/app/src/main/java/org/strongswan/android/data/ManagedVpnProfile.java
+++ b/src/frontends/android/app/src/main/java/org/strongswan/android/data/ManagedVpnProfile.java
@@ -174,9 +174,27 @@ public class ManagedVpnProfile extends VpnProfile
 		return caCertificate;
 	}
 
+	public void setCaCertificate(CaCertificate caCertificate)
+	{
+		this.caCertificate = caCertificate;
+		if (caCertificate != null)
+		{
+			setCertificateAlias(caCertificate.getAlias());
+		}
+	}
+
 	public UserCertificate getUserCertificate()
 	{
 		return userCertificate;
+	}
+
+	public void setUserCertificate(UserCertificate userCertificate)
+	{
+		this.userCertificate = userCertificate;
+		if (userCertificate != null)
+		{
+			setUserCertificateAlias(userCertificate.getAlias());
+		}
 	}
 
 	@Override

--- a/src/frontends/android/app/src/main/java/org/strongswan/android/data/ManagedVpnProfile.java
+++ b/src/frontends/android/app/src/main/java/org/strongswan/android/data/ManagedVpnProfile.java
@@ -1,0 +1,109 @@
+package org.strongswan.android.data;
+
+import android.os.Bundle;
+import android.text.TextUtils;
+
+import java.util.UUID;
+
+public class ManagedVpnProfile extends VpnProfile
+{
+	private static final String KEY_REMOTE = "remote";
+	private static final String KEY_LOCAL = "local";
+	private static final String KEY_INCLUDED_APPS = "included_apps";
+	private static final String KEY_EXCLUDED_APPS = "excluded_apps";
+
+	private static final String KEY_TRANSPORT_IPV6_FLAG = "transport_IPv6";
+	private static final String KEY_REMOTE_CERT_REQ_FLAG = "remote_cert_req";
+	private static final String KEY_REMOTE_REVOCATION_CRL_FLAG = "remote_revocation_crl";
+	private static final String KEY_REMOTE_REVOCATION_OCSP_FLAG = "remote_revocation_ocsp";
+	private static final String KEY_REMOTE_REVOCATION_STRICT_FLAG = "remote_revocation_strict";
+	private static final String KEY_LOCAL_RSA_PSS_FLAG = "local_rsa_pss";
+
+	private static final String KEY_SPLIT_TUNNELLING_BLOCK_IPV4_FLAG = "split_tunnelling_block_IPv4";
+	private static final String KEY_SPLIT_TUNNELLING_BLOCK_IPV6_FLAG = "split_tunnelling_block_IPv6";
+
+	ManagedVpnProfile(final Bundle bundle)
+	{
+		int flags = 0;
+		int splitFlags = 0;
+
+		setUUID(UUID.fromString(bundle.getString(VpnProfileDataSource.KEY_UUID)));
+		setName(bundle.getString(VpnProfileDataSource.KEY_NAME));
+		setVpnType(VpnType.fromIdentifier(bundle.getString(VpnProfileDataSource.KEY_VPN_TYPE)));
+
+		final Bundle remote = bundle.getBundle(KEY_REMOTE);
+		if (remote != null)
+		{
+			setGateway(remote.getString(VpnProfileDataSource.KEY_GATEWAY));
+			setPort(remote.getInt(VpnProfileDataSource.KEY_PORT));
+			setRemoteId(remote.getString(VpnProfileDataSource.KEY_REMOTE_ID));
+			setCertificateAlias(remote.getString(VpnProfileDataSource.KEY_CERTIFICATE));
+
+			flags = addNegativeFlag(flags, remote, KEY_REMOTE_CERT_REQ_FLAG, VpnProfile.FLAGS_SUPPRESS_CERT_REQS);
+			flags = addNegativeFlag(flags, remote, KEY_REMOTE_REVOCATION_CRL_FLAG, VpnProfile.FLAGS_DISABLE_CRL);
+			flags = addNegativeFlag(flags, remote, KEY_REMOTE_REVOCATION_OCSP_FLAG, VpnProfile.FLAGS_DISABLE_OCSP);
+			flags = addPositiveFlag(flags, remote, KEY_REMOTE_REVOCATION_STRICT_FLAG, VpnProfile.FLAGS_STRICT_REVOCATION);
+		}
+
+		final Bundle local = bundle.getBundle(KEY_LOCAL);
+		if (local != null)
+		{
+			setLocalId(local.getString(VpnProfileDataSource.KEY_LOCAL_ID));
+			setUsername(local.getString(VpnProfileDataSource.KEY_USERNAME));
+
+			flags = addPositiveFlag(flags, local, KEY_LOCAL_RSA_PSS_FLAG, VpnProfile.FLAGS_RSA_PSS);
+		}
+
+		final String includedPackageNames = bundle.getString(KEY_INCLUDED_APPS);
+		final String excludedPackageNames = bundle.getString(KEY_EXCLUDED_APPS);
+
+		if (!TextUtils.isEmpty(includedPackageNames))
+		{
+			setSelectedAppsHandling(VpnProfile.SelectedAppsHandling.SELECTED_APPS_ONLY);
+			setSelectedApps(includedPackageNames);
+		}
+		else if (!TextUtils.isEmpty(excludedPackageNames))
+		{
+			setSelectedAppsHandling(VpnProfile.SelectedAppsHandling.SELECTED_APPS_EXCLUDE);
+			setSelectedApps(excludedPackageNames);
+		}
+
+		setMTU(bundle.getInt(VpnProfileDataSource.KEY_MTU));
+		setNATKeepAlive(bundle.getInt(VpnProfileDataSource.KEY_NAT_KEEPALIVE));
+		setIkeProposal(bundle.getString(VpnProfileDataSource.KEY_IKE_PROPOSAL));
+		setEspProposal(bundle.getString(VpnProfileDataSource.KEY_ESP_PROPOSAL));
+		setDnsServers(bundle.getString(VpnProfileDataSource.KEY_DNS_SERVERS));
+		flags = addPositiveFlag(flags, bundle, KEY_TRANSPORT_IPV6_FLAG, VpnProfile.FLAGS_IPv6_TRANSPORT);
+
+		final Bundle splitTunneling = bundle.getBundle(VpnProfileDataSource.KEY_SPLIT_TUNNELING);
+		if (splitTunneling != null)
+		{
+			splitFlags = addPositiveFlag(splitFlags, splitTunneling, KEY_SPLIT_TUNNELLING_BLOCK_IPV4_FLAG, VpnProfile.SPLIT_TUNNELING_BLOCK_IPV4);
+			splitFlags = addPositiveFlag(splitFlags, splitTunneling, KEY_SPLIT_TUNNELLING_BLOCK_IPV6_FLAG, VpnProfile.SPLIT_TUNNELING_BLOCK_IPV6);
+
+			setExcludedSubnets(splitTunneling.getString(VpnProfileDataSource.KEY_INCLUDED_SUBNETS));
+			setIncludedSubnets(splitTunneling.getString(VpnProfileDataSource.KEY_EXCLUDED_SUBNETS));
+		}
+
+		setSplitTunneling(splitFlags);
+		setFlags(flags);
+	}
+
+	private static int addPositiveFlag(int flags, Bundle bundle, String key, int flag)
+	{
+		if (bundle.getBoolean(key))
+		{
+			flags |= flag;
+		}
+		return flags;
+	}
+
+	private static int addNegativeFlag(int flags, Bundle bundle, String key, int flag)
+	{
+		if (!bundle.getBoolean(key))
+		{
+			flags |= flag;
+		}
+		return flags;
+	}
+}

--- a/src/frontends/android/app/src/main/java/org/strongswan/android/data/ManagedVpnProfile.java
+++ b/src/frontends/android/app/src/main/java/org/strongswan/android/data/ManagedVpnProfile.java
@@ -61,8 +61,8 @@ public class ManagedVpnProfile extends VpnProfile
 			splitFlags = addPositiveFlag(splitFlags, splitTunneling, KEY_SPLIT_TUNNELLING_BLOCK_IPV4_FLAG, VpnProfile.SPLIT_TUNNELING_BLOCK_IPV4);
 			splitFlags = addPositiveFlag(splitFlags, splitTunneling, KEY_SPLIT_TUNNELLING_BLOCK_IPV6_FLAG, VpnProfile.SPLIT_TUNNELING_BLOCK_IPV6);
 
-			setExcludedSubnets(splitTunneling.getString(VpnProfileDataSource.KEY_INCLUDED_SUBNETS));
-			setIncludedSubnets(splitTunneling.getString(VpnProfileDataSource.KEY_EXCLUDED_SUBNETS));
+			setExcludedSubnets(splitTunneling.getString(VpnProfileDataSource.KEY_EXCLUDED_SUBNETS));
+			setIncludedSubnets(splitTunneling.getString(VpnProfileDataSource.KEY_INCLUDED_SUBNETS));
 		}
 
 		setSplitTunneling(splitFlags);
@@ -125,7 +125,7 @@ public class ManagedVpnProfile extends VpnProfile
 
 		final String userCertificateAlias = local.getString(VpnProfileDataSource.KEY_USER_CERTIFICATE_ALIAS, "local:" + uuid);
 		final String userCertificateData = local.getString(VpnProfileDataSource.KEY_USER_CERTIFICATE);
-		final String userCertificatePassword = local.getString(VpnProfileDataSource.KEY_USER_CERTIFICATE_PASSWORD);
+		final String userCertificatePassword = local.getString(VpnProfileDataSource.KEY_USER_CERTIFICATE_PASSWORD, "");
 
 		if (!TextUtils.isEmpty(userCertificateAlias) && !TextUtils.isEmpty(userCertificateData))
 		{

--- a/src/frontends/android/app/src/main/java/org/strongswan/android/data/ManagedVpnProfile.java
+++ b/src/frontends/android/app/src/main/java/org/strongswan/android/data/ManagedVpnProfile.java
@@ -6,6 +6,9 @@ import android.text.TextUtils;
 import java.util.Objects;
 import java.util.UUID;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
 public class ManagedVpnProfile extends VpnProfile
 {
 	private static final String KEY_REMOTE = "remote";
@@ -26,7 +29,7 @@ public class ManagedVpnProfile extends VpnProfile
 	private CaCertificate caCertificate;
 	private UserCertificate userCertificate;
 
-	ManagedVpnProfile(final Bundle bundle, final String uuid)
+	ManagedVpnProfile(@NonNull final Bundle bundle, @NonNull final String uuid)
 	{
 		int flags = 0;
 		int splitFlags = 0;
@@ -36,10 +39,10 @@ public class ManagedVpnProfile extends VpnProfile
 		setVpnType(VpnType.fromIdentifier(bundle.getString(VpnProfileDataSource.KEY_VPN_TYPE)));
 
 		final Bundle remote = bundle.getBundle(KEY_REMOTE);
-		flags = configureRemote(flags, remote);
+		flags = configureRemote(uuid, remote, flags);
 
 		final Bundle local = bundle.getBundle(KEY_LOCAL);
-		flags = configureLocal(flags, local);
+		flags = configureLocal(uuid, local, flags);
 
 		final String includedPackageNames = bundle.getString(KEY_INCLUDED_APPS);
 		final String excludedPackageNames = bundle.getString(KEY_EXCLUDED_APPS);
@@ -80,7 +83,7 @@ public class ManagedVpnProfile extends VpnProfile
 		}
 	}
 
-	private int configureRemote(int flags, Bundle remote)
+	private int configureRemote(@NonNull String uuid, @Nullable Bundle remote, int flags)
 	{
 		if (remote == null)
 		{
@@ -91,9 +94,8 @@ public class ManagedVpnProfile extends VpnProfile
 		setPort(getInt(remote, VpnProfileDataSource.KEY_PORT, 1, 65_535));
 		setRemoteId(remote.getString(VpnProfileDataSource.KEY_REMOTE_ID));
 
-		final String certificateAlias = remote.getString(VpnProfileDataSource.KEY_CERTIFICATE_ALIAS);
+		final String certificateAlias = remote.getString(VpnProfileDataSource.KEY_CERTIFICATE_ALIAS, "remote:" + uuid);
 		final String certificateData = remote.getString(VpnProfileDataSource.KEY_CERTIFICATE);
-
 
 		if (!TextUtils.isEmpty(certificateAlias) && !TextUtils.isEmpty(certificateData))
 		{
@@ -111,7 +113,7 @@ public class ManagedVpnProfile extends VpnProfile
 		return flags;
 	}
 
-	private int configureLocal(int flags, Bundle local)
+	private int configureLocal(@NonNull String uuid, @Nullable Bundle local, int flags)
 	{
 		if (local == null)
 		{
@@ -121,7 +123,7 @@ public class ManagedVpnProfile extends VpnProfile
 		setLocalId(local.getString(VpnProfileDataSource.KEY_LOCAL_ID));
 		setUsername(local.getString(VpnProfileDataSource.KEY_USERNAME));
 
-		final String userCertificateAlias = local.getString(VpnProfileDataSource.KEY_USER_CERTIFICATE_ALIAS);
+		final String userCertificateAlias = local.getString(VpnProfileDataSource.KEY_USER_CERTIFICATE_ALIAS, "local:" + uuid);
 		final String userCertificateData = local.getString(VpnProfileDataSource.KEY_USER_CERTIFICATE);
 		final String userCertificatePassword = local.getString(VpnProfileDataSource.KEY_USER_CERTIFICATE_PASSWORD);
 

--- a/src/frontends/android/app/src/main/java/org/strongswan/android/data/PkcsCertificate.java
+++ b/src/frontends/android/app/src/main/java/org/strongswan/android/data/PkcsCertificate.java
@@ -1,0 +1,102 @@
+package org.strongswan.android.data;
+
+import android.content.ContentValues;
+import android.database.Cursor;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+public abstract class PkcsCertificate
+{
+	public static final String KEY_ID = "_id";
+	public static final String KEY_VPN_PROFILE_UUID = "vpn_profile_uuid";
+	public static final String KEY_CONFIGURED_ALIAS = "configured_alias";
+	public static final String KEY_EFFECTIVE_ALIAS = "effective_alias";
+	public static final String KEY_DATA = "data";
+
+	long id = -1;
+
+	@NonNull
+	final String vpnProfileUuid;
+
+	@NonNull
+	final String configuredAlias;
+	@Nullable
+	String effectiveAlias;
+
+	@NonNull
+	final String data;
+
+	PkcsCertificate(
+		@NonNull final String vpnProfileUuid,
+		@NonNull final String alias,
+		@NonNull final String data)
+	{
+		this.vpnProfileUuid = vpnProfileUuid;
+		this.configuredAlias = alias;
+		this.data = data;
+	}
+
+	PkcsCertificate(@NonNull final Cursor cursor)
+	{
+		id = cursor.getLong(cursor.getColumnIndexOrThrow(KEY_ID));
+		vpnProfileUuid = cursor.getString(cursor.getColumnIndexOrThrow(KEY_VPN_PROFILE_UUID));
+		configuredAlias = cursor.getString(cursor.getColumnIndexOrThrow(KEY_CONFIGURED_ALIAS));
+		effectiveAlias = cursor.getString(cursor.getColumnIndexOrThrow(KEY_EFFECTIVE_ALIAS));
+		data = cursor.getString(cursor.getColumnIndexOrThrow(KEY_DATA));
+	}
+
+	@NonNull
+	public ContentValues asContentValues()
+	{
+		final ContentValues values = new ContentValues();
+		values.put(KEY_VPN_PROFILE_UUID, vpnProfileUuid);
+		values.put(KEY_CONFIGURED_ALIAS, configuredAlias);
+		values.put(KEY_EFFECTIVE_ALIAS, effectiveAlias);
+		values.put(KEY_DATA, data);
+		return values;
+	}
+
+	public long getId()
+	{
+		return id;
+	}
+
+	public void setId(long id)
+	{
+		this.id = id;
+	}
+
+	@NonNull
+	public String getVpnProfileUuid()
+	{
+		return vpnProfileUuid;
+	}
+
+	@NonNull
+	public String getAlias()
+	{
+		if (effectiveAlias != null)
+		{
+			return effectiveAlias;
+		}
+		return configuredAlias;
+	}
+
+	@NonNull
+	public String getConfiguredAlias()
+	{
+		return configuredAlias;
+	}
+
+	public void setEffectiveAlias(@Nullable String effectiveAlias)
+	{
+		this.effectiveAlias = effectiveAlias;
+	}
+
+	@NonNull
+	public String getData()
+	{
+		return data;
+	}
+}

--- a/src/frontends/android/app/src/main/java/org/strongswan/android/data/UserCertificate.java
+++ b/src/frontends/android/app/src/main/java/org/strongswan/android/data/UserCertificate.java
@@ -73,6 +73,6 @@ public class UserCertificate extends PkcsCertificate
 	@Override
 	public String toString()
 	{
-		return "UserCertificate {" + vpnProfileUuid + ", " + configuredAlias + "}";
+		return "UserCertificate {" + vpnProfileUuid + ", " + configuredAlias + ", " + effectiveAlias + "}";
 	}
 }

--- a/src/frontends/android/app/src/main/java/org/strongswan/android/data/UserCertificate.java
+++ b/src/frontends/android/app/src/main/java/org/strongswan/android/data/UserCertificate.java
@@ -1,0 +1,78 @@
+package org.strongswan.android.data;
+
+import android.content.ContentValues;
+import android.database.Cursor;
+
+import java.util.Objects;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+public class UserCertificate extends PkcsCertificate
+{
+	public static final String KEY_PASSWORD = "password";
+
+	private final String privateKeyPassword;
+
+	public UserCertificate(
+		@NonNull final String vpnProfileUuid,
+		@NonNull final String alias,
+		@NonNull final String data,
+		@Nullable final String password)
+	{
+		super(vpnProfileUuid, alias, data);
+		privateKeyPassword = password;
+	}
+
+	public UserCertificate(@NonNull final Cursor cursor)
+	{
+		super(cursor);
+		privateKeyPassword = cursor.getString(cursor.getColumnIndexOrThrow(KEY_PASSWORD));
+	}
+
+	@NonNull
+	@Override
+	public ContentValues asContentValues()
+	{
+		final ContentValues values = super.asContentValues();
+		values.put(KEY_PASSWORD, privateKeyPassword);
+		return values;
+	}
+
+	@Nullable
+	public String getPrivateKeyPassword()
+	{
+		return privateKeyPassword;
+	}
+
+	@Override
+	public boolean equals(Object o)
+	{
+		if (this == o)
+		{
+			return true;
+		}
+		if (o == null || getClass() != o.getClass())
+		{
+			return false;
+		}
+		UserCertificate that = (UserCertificate)o;
+		return Objects.equals(vpnProfileUuid, that.vpnProfileUuid)
+			&& Objects.equals(configuredAlias, that.configuredAlias)
+			&& Objects.equals(data, that.data)
+			&& Objects.equals(privateKeyPassword, that.privateKeyPassword);
+	}
+
+	@Override
+	public int hashCode()
+	{
+		return Objects.hash(vpnProfileUuid, configuredAlias, data);
+	}
+
+	@NonNull
+	@Override
+	public String toString()
+	{
+		return "UserCertificate {" + vpnProfileUuid + ", " + configuredAlias + "}";
+	}
+}

--- a/src/frontends/android/app/src/main/java/org/strongswan/android/data/UserCertificateRepository.java
+++ b/src/frontends/android/app/src/main/java/org/strongswan/android/data/UserCertificateRepository.java
@@ -1,6 +1,8 @@
 package org.strongswan.android.data;
 
+import android.app.admin.DevicePolicyManager;
 import android.database.Cursor;
+import android.os.Build;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -9,11 +11,16 @@ public class UserCertificateRepository extends CertificateRepository<UserCertifi
 {
 	private static final DatabaseHelper.DbTable TABLE = DatabaseHelper.TABLE_USER_CERTIFICATE;
 
+	@NonNull
+	private final DevicePolicyManager devicePolicyManager;
+
 	public UserCertificateRepository(
 		@NonNull final ManagedConfigurationService managedConfigurationService,
+		@NonNull final DevicePolicyManager devicePolicyManager,
 		@NonNull final DatabaseHelper databaseHelper)
 	{
 		super(managedConfigurationService, databaseHelper, TABLE);
+		this.devicePolicyManager = devicePolicyManager;
 	}
 
 	@Nullable
@@ -28,5 +35,18 @@ public class UserCertificateRepository extends CertificateRepository<UserCertifi
 	protected UserCertificate createCertificate(@NonNull Cursor cursor)
 	{
 		return new UserCertificate(cursor);
+	}
+
+	@Override
+	protected boolean isInstalled(@NonNull UserCertificate certificate)
+	{
+		if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S)
+		{
+			return devicePolicyManager.hasKeyPair(certificate.getAlias());
+		}
+
+		// We don't know, so we assume a certificate we installed may have been removed by the
+		// user, so we install it again to make sure it's still there
+		return false;
 	}
 }

--- a/src/frontends/android/app/src/main/java/org/strongswan/android/data/UserCertificateRepository.java
+++ b/src/frontends/android/app/src/main/java/org/strongswan/android/data/UserCertificateRepository.java
@@ -1,93 +1,32 @@
 package org.strongswan.android.data;
 
-import android.content.ContentValues;
 import android.database.Cursor;
-import android.database.sqlite.SQLiteDatabase;
-
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
-public class UserCertificateRepository
+public class UserCertificateRepository extends CertificateRepository<UserCertificate>
 {
 	private static final DatabaseHelper.DbTable TABLE = DatabaseHelper.TABLE_USER_CERTIFICATE;
-
-	@NonNull
-	private final ManagedConfigurationService managedConfigurationService;
-	@NonNull
-	private final SQLiteDatabase database;
 
 	public UserCertificateRepository(
 		@NonNull final ManagedConfigurationService managedConfigurationService,
 		@NonNull final DatabaseHelper databaseHelper)
 	{
-		this.managedConfigurationService = managedConfigurationService;
-		this.database = databaseHelper.getWritableDatabase();
+		super(managedConfigurationService, databaseHelper, TABLE);
+	}
+
+	@Nullable
+	@Override
+	protected UserCertificate getCertificate(@NonNull ManagedVpnProfile vpnProfile)
+	{
+		return vpnProfile.getUserCertificate();
 	}
 
 	@NonNull
-	public List<UserCertificate> getConfiguredKeyStores()
+	@Override
+	protected UserCertificate createCertificate(@NonNull Cursor cursor)
 	{
-		managedConfigurationService.loadConfiguration();
-
-		final List<ManagedVpnProfile> managedVpnProfiles = managedConfigurationService.getManagedProfiles();
-		final List<UserCertificate> keyStores = new ArrayList<>(managedVpnProfiles.size());
-
-		for (final ManagedVpnProfile vpnProfile : managedVpnProfiles)
-		{
-			final UserCertificate userCertificate = vpnProfile.getUserCertificate();
-			if (userCertificate != null)
-			{
-				keyStores.add(userCertificate);
-			}
-		}
-
-		return keyStores;
-	}
-
-	@NonNull
-	public List<UserCertificate> getInstalledKeyStores()
-	{
-		final List<UserCertificate> certificates = new ArrayList<>();
-
-		final Cursor cursor = database.query(TABLE.Name, TABLE.columnNames(), null, null, null, null, null);
-
-		cursor.moveToFirst();
-		while (!cursor.isAfterLast())
-		{
-			final UserCertificate certificate = new UserCertificate(cursor);
-			certificates.add(certificate);
-			cursor.moveToNext();
-		}
-		return certificates;
-	}
-
-	@NonNull
-	public Map<String, UserCertificate> getInstalledKeyStoreMap()
-	{
-		final List<UserCertificate> keyStores = getInstalledKeyStores();
-		final Map<String, UserCertificate> map = new HashMap<>(keyStores.size());
-
-		for (final UserCertificate keyStore : keyStores)
-		{
-			map.put(keyStore.getVpnProfileUuid(), keyStore);
-		}
-
-		return map;
-	}
-
-	public void addInstalledKeyStore(@NonNull final UserCertificate userCertificate)
-	{
-		final ContentValues values = userCertificate.asContentValues();
-		database.insert(TABLE.Name, null, values);
-	}
-
-	public void removeInstalledKeyStore(@NonNull final UserCertificate userCertificate)
-	{
-		final String vpnProfileUuid = userCertificate.getVpnProfileUuid();
-		database.delete(TABLE.Name, PkcsCertificate.KEY_VPN_PROFILE_UUID + " = ?", new String[]{vpnProfileUuid});
+		return new UserCertificate(cursor);
 	}
 }

--- a/src/frontends/android/app/src/main/java/org/strongswan/android/data/UserCertificateRepository.java
+++ b/src/frontends/android/app/src/main/java/org/strongswan/android/data/UserCertificateRepository.java
@@ -1,0 +1,93 @@
+package org.strongswan.android.data;
+
+import android.content.ContentValues;
+import android.database.Cursor;
+import android.database.sqlite.SQLiteDatabase;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import androidx.annotation.NonNull;
+
+public class UserCertificateRepository
+{
+	private static final DatabaseHelper.DbTable TABLE = DatabaseHelper.TABLE_USER_CERTIFICATE;
+
+	@NonNull
+	private final ManagedConfigurationService managedConfigurationService;
+	@NonNull
+	private final SQLiteDatabase database;
+
+	public UserCertificateRepository(
+		@NonNull final ManagedConfigurationService managedConfigurationService,
+		@NonNull final DatabaseHelper databaseHelper)
+	{
+		this.managedConfigurationService = managedConfigurationService;
+		this.database = databaseHelper.getWritableDatabase();
+	}
+
+	@NonNull
+	public List<UserCertificate> getConfiguredKeyStores()
+	{
+		managedConfigurationService.loadConfiguration();
+
+		final List<ManagedVpnProfile> managedVpnProfiles = managedConfigurationService.getManagedProfiles();
+		final List<UserCertificate> keyStores = new ArrayList<>(managedVpnProfiles.size());
+
+		for (final ManagedVpnProfile vpnProfile : managedVpnProfiles)
+		{
+			final UserCertificate userCertificate = vpnProfile.getUserCertificate();
+			if (userCertificate != null)
+			{
+				keyStores.add(userCertificate);
+			}
+		}
+
+		return keyStores;
+	}
+
+	@NonNull
+	public List<UserCertificate> getInstalledKeyStores()
+	{
+		final List<UserCertificate> certificates = new ArrayList<>();
+
+		final Cursor cursor = database.query(TABLE.Name, TABLE.columnNames(), null, null, null, null, null);
+
+		cursor.moveToFirst();
+		while (!cursor.isAfterLast())
+		{
+			final UserCertificate certificate = new UserCertificate(cursor);
+			certificates.add(certificate);
+			cursor.moveToNext();
+		}
+		return certificates;
+	}
+
+	@NonNull
+	public Map<String, UserCertificate> getInstalledKeyStoreMap()
+	{
+		final List<UserCertificate> keyStores = getInstalledKeyStores();
+		final Map<String, UserCertificate> map = new HashMap<>(keyStores.size());
+
+		for (final UserCertificate keyStore : keyStores)
+		{
+			map.put(keyStore.getVpnProfileUuid(), keyStore);
+		}
+
+		return map;
+	}
+
+	public void addInstalledKeyStore(@NonNull final UserCertificate userCertificate)
+	{
+		final ContentValues values = userCertificate.asContentValues();
+		database.insert(TABLE.Name, null, values);
+	}
+
+	public void removeInstalledKeyStore(@NonNull final UserCertificate userCertificate)
+	{
+		final String vpnProfileUuid = userCertificate.getVpnProfileUuid();
+		database.delete(TABLE.Name, PkcsCertificate.KEY_VPN_PROFILE_UUID + " = ?", new String[]{vpnProfileUuid});
+	}
+}

--- a/src/frontends/android/app/src/main/java/org/strongswan/android/data/VpnProfile.java
+++ b/src/frontends/android/app/src/main/java/org/strongswan/android/data/VpnProfile.java
@@ -22,6 +22,7 @@ package org.strongswan.android.data;
 import android.text.TextUtils;
 
 import java.util.Arrays;
+import java.util.Objects;
 import java.util.SortedSet;
 import java.util.TreeSet;
 import java.util.UUID;
@@ -361,16 +362,22 @@ public class VpnProfile implements Cloneable
 	@Override
 	public boolean equals(Object o)
 	{
-		if (o != null && o instanceof VpnProfile)
+		if (o == this)
 		{
-			VpnProfile other = (VpnProfile)o;
-			if (this.mUUID != null && other.getUUID() != null)
-			{
-				return this.mUUID.equals(other.getUUID());
-			}
-			return this.mId == other.getId();
+			return true;
 		}
-		return false;
+		if (o == null || getClass() != o.getClass())
+		{
+			return false;
+		}
+		VpnProfile that = (VpnProfile)o;
+		return Objects.equals(mUUID, that.mUUID);
+	}
+
+	@Override
+	public int hashCode()
+	{
+		return Objects.hash(mUUID);
 	}
 
 	@Override

--- a/src/frontends/android/app/src/main/java/org/strongswan/android/data/VpnProfile.java
+++ b/src/frontends/android/app/src/main/java/org/strongswan/android/data/VpnProfile.java
@@ -47,6 +47,7 @@ public class VpnProfile implements Cloneable
 	private VpnType mVpnType;
 	private UUID mUUID;
 	private long mId = -1;
+	private boolean mReadOnly;
 
 	public enum SelectedAppsHandling
 	{
@@ -54,7 +55,7 @@ public class VpnProfile implements Cloneable
 		SELECTED_APPS_EXCLUDE(1),
 		SELECTED_APPS_ONLY(2);
 
-		private Integer mValue;
+		private final Integer mValue;
 
 		SelectedAppsHandling(int value)
 		{
@@ -328,6 +329,16 @@ public class VpnProfile implements Cloneable
 	public void setFlags(Integer flags)
 	{
 		this.mFlags = flags;
+	}
+
+	public boolean isReadOnly()
+	{
+		return mReadOnly;
+	}
+
+	public void setReadOnly(boolean readOnly)
+	{
+		this.mReadOnly = readOnly;
 	}
 
 	@Override

--- a/src/frontends/android/app/src/main/java/org/strongswan/android/data/VpnProfile.java
+++ b/src/frontends/android/app/src/main/java/org/strongswan/android/data/VpnProfile.java
@@ -48,6 +48,7 @@ public class VpnProfile implements Cloneable
 	private UUID mUUID;
 	private long mId = -1;
 	private boolean mReadOnly;
+	private VpnProfileDataSource mDataSource;
 
 	public enum SelectedAppsHandling
 	{
@@ -339,6 +340,16 @@ public class VpnProfile implements Cloneable
 	public void setReadOnly(boolean readOnly)
 	{
 		this.mReadOnly = readOnly;
+	}
+
+	public VpnProfileDataSource getDataSource()
+	{
+		return mDataSource;
+	}
+
+	public void setDataSource(VpnProfileDataSource mDataSource)
+	{
+		this.mDataSource = mDataSource;
 	}
 
 	@Override

--- a/src/frontends/android/app/src/main/java/org/strongswan/android/data/VpnProfileDataSource.java
+++ b/src/frontends/android/app/src/main/java/org/strongswan/android/data/VpnProfileDataSource.java
@@ -72,14 +72,6 @@ public interface VpnProfileDataSource
 	boolean deleteVpnProfile(VpnProfile profile);
 
 	/**
-	 * Get a single VPN profile from the database.
-	 *
-	 * @param id the ID of the VPN profile
-	 * @return the profile or null, if not found
-	 */
-	VpnProfile getVpnProfile(long id);
-
-	/**
 	 * Get a single VPN profile from the database by its UUID.
 	 *
 	 * @param uuid the UUID of the VPN profile

--- a/src/frontends/android/app/src/main/java/org/strongswan/android/data/VpnProfileDataSource.java
+++ b/src/frontends/android/app/src/main/java/org/strongswan/android/data/VpnProfileDataSource.java
@@ -30,6 +30,7 @@ public interface VpnProfileDataSource
 	String KEY_IKE_PROPOSAL = "ike_proposal";
 	String KEY_ESP_PROPOSAL = "esp_proposal";
 	String KEY_DNS_SERVERS = "dns_servers";
+	String KEY_READ_ONLY = "read_only";
 
 	/**
 	 * Open the VPN profile data source. The database is automatically created

--- a/src/frontends/android/app/src/main/java/org/strongswan/android/data/VpnProfileDataSource.java
+++ b/src/frontends/android/app/src/main/java/org/strongswan/android/data/VpnProfileDataSource.java
@@ -15,7 +15,10 @@ public interface VpnProfileDataSource
 	String KEY_USERNAME = "username";
 	String KEY_PASSWORD = "password";
 	String KEY_CERTIFICATE = "certificate";
+	String KEY_CERTIFICATE_ALIAS = "certificate_alias";
 	String KEY_USER_CERTIFICATE = "user_certificate";
+	String KEY_USER_CERTIFICATE_ALIAS = "user_certificate_alias";
+	String KEY_USER_CERTIFICATE_PASSWORD = "user_certificate_password";
 	String KEY_MTU = "mtu";
 	String KEY_PORT = "port";
 	String KEY_SPLIT_TUNNELING = "split_tunneling";

--- a/src/frontends/android/app/src/main/java/org/strongswan/android/data/VpnProfileDataSource.java
+++ b/src/frontends/android/app/src/main/java/org/strongswan/android/data/VpnProfileDataSource.java
@@ -92,12 +92,27 @@ public interface VpnProfileDataSource
 	 * @param uuid the UUID of the VPN profile as String
 	 * @return the profile or null, if not found
 	 */
-	VpnProfile getVpnProfile(String uuid);
+	default VpnProfile getVpnProfile(String uuid)
+	{
+		try
+		{
+			if (uuid != null)
+			{
+				return getVpnProfile(UUID.fromString(uuid));
+			}
+			return null;
+		}
+		catch (IllegalArgumentException e)
+		{
+			e.printStackTrace();
+			return null;
+		}
+	}
 
 	/**
 	 * Get a list of all VPN profiles stored in the database.
 	 *
 	 * @return list of VPN profiles
 	 */
-	List<VpnProfile> getAllVpnProfiles();
+	List<? extends VpnProfile> getAllVpnProfiles();
 }

--- a/src/frontends/android/app/src/main/java/org/strongswan/android/data/VpnProfileDataSource.java
+++ b/src/frontends/android/app/src/main/java/org/strongswan/android/data/VpnProfileDataSource.java
@@ -1,315 +1,49 @@
-/*
- * Copyright (C) 2012-2019 Tobias Brunner
- * Copyright (C) 2012 Giuliano Grassi
- * Copyright (C) 2012 Ralf Sager
- *
- * Copyright (C) secunet Security Networks AG
- *
- * This program is free software; you can redistribute it and/or modify it
- * under the terms of the GNU General Public License as published by the
- * Free Software Foundation; either version 2 of the License, or (at your
- * option) any later version.  See <http://www.fsf.org/copyleft/gpl.txt>.
- *
- * This program is distributed in the hope that it will be useful, but
- * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
- * or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
- * for more details.
- */
-
 package org.strongswan.android.data;
 
-import android.content.ContentValues;
-import android.content.Context;
-import android.database.Cursor;
 import android.database.SQLException;
-import android.database.sqlite.SQLiteDatabase;
-import android.database.sqlite.SQLiteOpenHelper;
-import android.database.sqlite.SQLiteQueryBuilder;
-import android.util.Log;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 
-public class VpnProfileDataSource
+public interface VpnProfileDataSource
 {
-	private static final String TAG = VpnProfileDataSource.class.getSimpleName();
-	public static final String KEY_ID = "_id";
-	public static final String KEY_UUID = "_uuid";
-	public static final String KEY_NAME = "name";
-	public static final String KEY_GATEWAY = "gateway";
-	public static final String KEY_VPN_TYPE = "vpn_type";
-	public static final String KEY_USERNAME = "username";
-	public static final String KEY_PASSWORD = "password";
-	public static final String KEY_CERTIFICATE = "certificate";
-	public static final String KEY_USER_CERTIFICATE = "user_certificate";
-	public static final String KEY_MTU = "mtu";
-	public static final String KEY_PORT = "port";
-	public static final String KEY_SPLIT_TUNNELING = "split_tunneling";
-	public static final String KEY_LOCAL_ID = "local_id";
-	public static final String KEY_REMOTE_ID = "remote_id";
-	public static final String KEY_EXCLUDED_SUBNETS = "excluded_subnets";
-	public static final String KEY_INCLUDED_SUBNETS = "included_subnets";
-	public static final String KEY_SELECTED_APPS = "selected_apps";
-	public static final String KEY_SELECTED_APPS_LIST = "selected_apps_list";
-	public static final String KEY_NAT_KEEPALIVE = "nat_keepalive";
-	public static final String KEY_FLAGS = "flags";
-	public static final String KEY_IKE_PROPOSAL = "ike_proposal";
-	public static final String KEY_ESP_PROPOSAL = "esp_proposal";
-	public static final String KEY_DNS_SERVERS = "dns_servers";
-
-	private DatabaseHelper mDbHelper;
-	private SQLiteDatabase mDatabase;
-	private final Context mContext;
-
-	private static final String DATABASE_NAME = "strongswan.db";
-	private static final String TABLE_VPNPROFILE = "vpnprofile";
-
-	private static final int DATABASE_VERSION = 17;
-
-	public static final DbColumn[] COLUMNS = new DbColumn[] {
-								new DbColumn(KEY_ID, "INTEGER PRIMARY KEY AUTOINCREMENT", 1),
-								new DbColumn(KEY_UUID, "TEXT UNIQUE", 9),
-								new DbColumn(KEY_NAME, "TEXT NOT NULL", 1),
-								new DbColumn(KEY_GATEWAY, "TEXT NOT NULL", 1),
-								new DbColumn(KEY_VPN_TYPE, "TEXT NOT NULL", 3),
-								new DbColumn(KEY_USERNAME, "TEXT", 1),
-								new DbColumn(KEY_PASSWORD, "TEXT", 1),
-								new DbColumn(KEY_CERTIFICATE, "TEXT", 1),
-								new DbColumn(KEY_USER_CERTIFICATE, "TEXT", 2),
-								new DbColumn(KEY_MTU, "INTEGER", 5),
-								new DbColumn(KEY_PORT, "INTEGER", 5),
-								new DbColumn(KEY_SPLIT_TUNNELING, "INTEGER", 7),
-								new DbColumn(KEY_LOCAL_ID, "TEXT", 8),
-								new DbColumn(KEY_REMOTE_ID, "TEXT", 8),
-								new DbColumn(KEY_EXCLUDED_SUBNETS, "TEXT", 10),
-								new DbColumn(KEY_INCLUDED_SUBNETS, "TEXT", 11),
-								new DbColumn(KEY_SELECTED_APPS, "INTEGER", 12),
-								new DbColumn(KEY_SELECTED_APPS_LIST, "TEXT", 12),
-								new DbColumn(KEY_NAT_KEEPALIVE, "INTEGER", 13),
-								new DbColumn(KEY_FLAGS, "INTEGER", 14),
-								new DbColumn(KEY_IKE_PROPOSAL, "TEXT", 15),
-								new DbColumn(KEY_ESP_PROPOSAL, "TEXT", 15),
-								new DbColumn(KEY_DNS_SERVERS, "TEXT", 17),
-							};
-
-	private static final String[] ALL_COLUMNS = getColumns(DATABASE_VERSION);
-
-	private static String getDatabaseCreate(int version)
-	{
-		boolean first = true;
-		StringBuilder create = new StringBuilder("CREATE TABLE ");
-		create.append(TABLE_VPNPROFILE);
-		create.append(" (");
-		for (DbColumn column : COLUMNS)
-		{
-			if (column.Since <= version)
-			{
-				if (!first)
-				{
-					create.append(",");
-				}
-				first = false;
-				create.append(column.Name);
-				create.append(" ");
-				create.append(column.Type);
-			}
-		}
-		create.append(");");
-		return create.toString();
-	}
-
-	private static String[] getColumns(int version)
-	{
-		ArrayList<String> columns = new ArrayList<>();
-		for (DbColumn column : COLUMNS)
-		{
-			if (column.Since <= version)
-			{
-				columns.add(column.Name);
-			}
-		}
-		return columns.toArray(new String[0]);
-	}
-
-	private static class DatabaseHelper extends SQLiteOpenHelper
-	{
-		public DatabaseHelper(Context context)
-		{
-			super(context, DATABASE_NAME, null, DATABASE_VERSION);
-		}
-
-		@Override
-		public void onCreate(SQLiteDatabase database)
-		{
-			database.execSQL(getDatabaseCreate(DATABASE_VERSION));
-		}
-
-		@Override
-		public void onUpgrade(SQLiteDatabase db, int oldVersion, int newVersion)
-		{
-			Log.w(TAG, "Upgrading database from version " + oldVersion +
-				  " to " + newVersion);
-			if (oldVersion < 2)
-			{
-				db.execSQL("ALTER TABLE " + TABLE_VPNPROFILE + " ADD " + KEY_USER_CERTIFICATE +
-						   " TEXT;");
-			}
-			if (oldVersion < 3)
-			{
-				db.execSQL("ALTER TABLE " + TABLE_VPNPROFILE + " ADD " + KEY_VPN_TYPE +
-						   " TEXT DEFAULT '';");
-			}
-			if (oldVersion < 4)
-			{	/* remove NOT NULL constraint from username column */
-				updateColumns(db, 4);
-			}
-			if (oldVersion < 5)
-			{
-				db.execSQL("ALTER TABLE " + TABLE_VPNPROFILE + " ADD " + KEY_MTU +
-						   " INTEGER;");
-			}
-			if (oldVersion < 6)
-			{
-				db.execSQL("ALTER TABLE " + TABLE_VPNPROFILE + " ADD " + KEY_PORT +
-						   " INTEGER;");
-			}
-			if (oldVersion < 7)
-			{
-				db.execSQL("ALTER TABLE " + TABLE_VPNPROFILE + " ADD " + KEY_SPLIT_TUNNELING +
-						   " INTEGER;");
-			}
-			if (oldVersion < 8)
-			{
-				db.execSQL("ALTER TABLE " + TABLE_VPNPROFILE + " ADD " + KEY_LOCAL_ID +
-						   " TEXT;");
-				db.execSQL("ALTER TABLE " + TABLE_VPNPROFILE + " ADD " + KEY_REMOTE_ID +
-						   " TEXT;");
-			}
-			if (oldVersion < 9)
-			{
-				db.execSQL("ALTER TABLE " + TABLE_VPNPROFILE + " ADD " + KEY_UUID +
-						   " TEXT;");
-				updateColumns(db, 9);
-			}
-			if (oldVersion < 10)
-			{
-				db.execSQL("ALTER TABLE " + TABLE_VPNPROFILE + " ADD " + KEY_EXCLUDED_SUBNETS +
-						   " TEXT;");
-			}
-			if (oldVersion < 11)
-			{
-				db.execSQL("ALTER TABLE " + TABLE_VPNPROFILE + " ADD " + KEY_INCLUDED_SUBNETS +
-						   " TEXT;");
-			}
-			if (oldVersion < 12)
-			{
-				db.execSQL("ALTER TABLE " + TABLE_VPNPROFILE + " ADD " + KEY_SELECTED_APPS +
-						   " INTEGER;");
-				db.execSQL("ALTER TABLE " + TABLE_VPNPROFILE + " ADD " + KEY_SELECTED_APPS_LIST +
-						   " TEXT;");
-			}
-			if (oldVersion < 13)
-			{
-				db.execSQL("ALTER TABLE " + TABLE_VPNPROFILE + " ADD " + KEY_NAT_KEEPALIVE +
-						   " INTEGER;");
-			}
-			if (oldVersion < 14)
-			{
-				db.execSQL("ALTER TABLE " + TABLE_VPNPROFILE + " ADD " + KEY_FLAGS +
-						   " INTEGER;");
-			}
-			if (oldVersion < 15)
-			{
-				db.execSQL("ALTER TABLE " + TABLE_VPNPROFILE + " ADD " + KEY_IKE_PROPOSAL +
-						   " TEXT;");
-				db.execSQL("ALTER TABLE " + TABLE_VPNPROFILE + " ADD " + KEY_ESP_PROPOSAL +
-						   " TEXT;");
-			}
-			if (oldVersion < 16)
-			{	/* add a UUID to all entries that haven't one yet */
-				db.beginTransaction();
-				try
-				{
-					Cursor cursor = db.query(TABLE_VPNPROFILE, getColumns(16), KEY_UUID + " is NULL", null, null, null, null);
-					for (cursor.moveToFirst(); !cursor.isAfterLast(); cursor.moveToNext())
-					{
-						ContentValues values = new ContentValues();
-						values.put(KEY_UUID, UUID.randomUUID().toString());
-						db.update(TABLE_VPNPROFILE, values, KEY_ID + " = " + cursor.getLong(cursor.getColumnIndexOrThrow(KEY_ID)), null);
-					}
-					cursor.close();
-					db.setTransactionSuccessful();
-				}
-				finally
-				{
-					db.endTransaction();
-				}
-			}
-			if (oldVersion < 17)
-			{
-				db.execSQL("ALTER TABLE " + TABLE_VPNPROFILE + " ADD " + KEY_DNS_SERVERS +
-						   " TEXT;");
-			}
-		}
-
-		private void updateColumns(SQLiteDatabase db, int version)
-		{
-			db.beginTransaction();
-			try
-			{
-				db.execSQL("ALTER TABLE " + TABLE_VPNPROFILE + " RENAME TO tmp_" + TABLE_VPNPROFILE + ";");
-				db.execSQL(getDatabaseCreate(version));
-				StringBuilder insert = new StringBuilder("INSERT INTO " + TABLE_VPNPROFILE + " SELECT ");
-				SQLiteQueryBuilder.appendColumns(insert, getColumns(version));
-				db.execSQL(insert.append(" FROM tmp_" + TABLE_VPNPROFILE + ";").toString());
-				db.execSQL("DROP TABLE tmp_" + TABLE_VPNPROFILE + ";");
-				db.setTransactionSuccessful();
-			}
-			finally
-			{
-				db.endTransaction();
-			}
-		}
-	}
-
-	/**
-	 * Construct a new VPN profile data source. The context is used to
-	 * open/create the database.
-	 * @param context context used to access the database
-	 */
-	public VpnProfileDataSource(Context context)
-	{
-		this.mContext = context;
-	}
+	String KEY_ID = "_id";
+	String KEY_UUID = "_uuid";
+	String KEY_NAME = "name";
+	String KEY_GATEWAY = "gateway";
+	String KEY_VPN_TYPE = "vpn_type";
+	String KEY_USERNAME = "username";
+	String KEY_PASSWORD = "password";
+	String KEY_CERTIFICATE = "certificate";
+	String KEY_USER_CERTIFICATE = "user_certificate";
+	String KEY_MTU = "mtu";
+	String KEY_PORT = "port";
+	String KEY_SPLIT_TUNNELING = "split_tunneling";
+	String KEY_LOCAL_ID = "local_id";
+	String KEY_REMOTE_ID = "remote_id";
+	String KEY_EXCLUDED_SUBNETS = "excluded_subnets";
+	String KEY_INCLUDED_SUBNETS = "included_subnets";
+	String KEY_SELECTED_APPS = "selected_apps";
+	String KEY_SELECTED_APPS_LIST = "selected_apps_list";
+	String KEY_NAT_KEEPALIVE = "nat_keepalive";
+	String KEY_FLAGS = "flags";
+	String KEY_IKE_PROPOSAL = "ike_proposal";
+	String KEY_ESP_PROPOSAL = "esp_proposal";
+	String KEY_DNS_SERVERS = "dns_servers";
 
 	/**
 	 * Open the VPN profile data source. The database is automatically created
 	 * if it does not yet exist. If that fails an exception is thrown.
+	 *
 	 * @return itself (allows to chain initialization calls)
 	 * @throws SQLException if the database could not be opened or created
 	 */
-	public VpnProfileDataSource open() throws SQLException
-	{
-		if (mDbHelper == null)
-		{
-			mDbHelper = new DatabaseHelper(mContext);
-			mDatabase = mDbHelper.getWritableDatabase();
-		}
-		return this;
-	}
+	VpnProfileDataSource open() throws SQLException;
 
 	/**
 	 * Close the data source.
 	 */
-	public void close()
-	{
-		if (mDbHelper != null)
-		{
-			mDbHelper.close();
-			mDbHelper = null;
-		}
-	}
+	void close();
 
 	/**
 	 * Insert the given VPN profile into the database.  On success the Id of
@@ -318,192 +52,52 @@ public class VpnProfileDataSource
 	 * @param profile the profile to add
 	 * @return the added VPN profile or null, if failed
 	 */
-	public VpnProfile insertProfile(VpnProfile profile)
-	{
-		ContentValues values = ContentValuesFromVpnProfile(profile);
-		long insertId = mDatabase.insert(TABLE_VPNPROFILE, null, values);
-		if (insertId == -1)
-		{
-			return null;
-		}
-		profile.setId(insertId);
-		return profile;
-	}
+	VpnProfile insertProfile(VpnProfile profile);
 
 	/**
 	 * Updates the given VPN profile in the database.
+	 *
 	 * @param profile the profile to update
 	 * @return true if update succeeded, false otherwise
 	 */
-	public boolean updateVpnProfile(VpnProfile profile)
-	{
-		long id = profile.getId();
-		ContentValues values = ContentValuesFromVpnProfile(profile);
-		return mDatabase.update(TABLE_VPNPROFILE, values, KEY_ID + " = " + id, null) > 0;
-	}
+	boolean updateVpnProfile(VpnProfile profile);
 
 	/**
 	 * Delete the given VPN profile from the database.
+	 *
 	 * @param profile the profile to delete
 	 * @return true if deleted, false otherwise
 	 */
-	public boolean deleteVpnProfile(VpnProfile profile)
-	{
-		long id = profile.getId();
-		return mDatabase.delete(TABLE_VPNPROFILE, KEY_ID + " = " + id, null) > 0;
-	}
+	boolean deleteVpnProfile(VpnProfile profile);
 
 	/**
 	 * Get a single VPN profile from the database.
+	 *
 	 * @param id the ID of the VPN profile
 	 * @return the profile or null, if not found
 	 */
-	public VpnProfile getVpnProfile(long id)
-	{
-		VpnProfile profile = null;
-		Cursor cursor = mDatabase.query(TABLE_VPNPROFILE, ALL_COLUMNS,
-										KEY_ID + "=" + id, null, null, null, null);
-		if (cursor.moveToFirst())
-		{
-			profile = VpnProfileFromCursor(cursor);
-		}
-		cursor.close();
-		return profile;
-	}
+	VpnProfile getVpnProfile(long id);
 
 	/**
 	 * Get a single VPN profile from the database by its UUID.
+	 *
 	 * @param uuid the UUID of the VPN profile
 	 * @return the profile or null, if not found
 	 */
-	public VpnProfile getVpnProfile(UUID uuid)
-	{
-		VpnProfile profile = null;
-		Cursor cursor = mDatabase.query(TABLE_VPNPROFILE, ALL_COLUMNS,
-										KEY_UUID + "='" + uuid.toString() + "'", null, null, null, null);
-		if (cursor.moveToFirst())
-		{
-			profile = VpnProfileFromCursor(cursor);
-		}
-		cursor.close();
-		return profile;
-	}
+	VpnProfile getVpnProfile(UUID uuid);
 
 	/**
 	 * Get a single VPN profile from the database by its UUID as String.
+	 *
 	 * @param uuid the UUID of the VPN profile as String
 	 * @return the profile or null, if not found
 	 */
-	public VpnProfile getVpnProfile(String uuid)
-	{
-		try
-		{
-			if (uuid != null)
-			{
-				return getVpnProfile(UUID.fromString(uuid));
-			}
-			return null;
-		}
-		catch (IllegalArgumentException e)
-		{
-			e.printStackTrace();
-			return null;
-		}
-	}
+	VpnProfile getVpnProfile(String uuid);
 
 	/**
 	 * Get a list of all VPN profiles stored in the database.
+	 *
 	 * @return list of VPN profiles
 	 */
-	public List<VpnProfile> getAllVpnProfiles()
-	{
-		List<VpnProfile> vpnProfiles = new ArrayList<VpnProfile>();
-
-		Cursor cursor = mDatabase.query(TABLE_VPNPROFILE, ALL_COLUMNS, null, null, null, null, null);
-		cursor.moveToFirst();
-		while (!cursor.isAfterLast())
-		{
-			VpnProfile vpnProfile = VpnProfileFromCursor(cursor);
-			vpnProfiles.add(vpnProfile);
-			cursor.moveToNext();
-		}
-		cursor.close();
-		return vpnProfiles;
-	}
-
-	private VpnProfile VpnProfileFromCursor(Cursor cursor)
-	{
-		VpnProfile profile = new VpnProfile();
-		profile.setId(cursor.getLong(cursor.getColumnIndexOrThrow(KEY_ID)));
-		profile.setUUID(UUID.fromString(cursor.getString(cursor.getColumnIndexOrThrow(KEY_UUID))));
-		profile.setName(cursor.getString(cursor.getColumnIndexOrThrow(KEY_NAME)));
-		profile.setGateway(cursor.getString(cursor.getColumnIndexOrThrow(KEY_GATEWAY)));
-		profile.setVpnType(VpnType.fromIdentifier(cursor.getString(cursor.getColumnIndexOrThrow(KEY_VPN_TYPE))));
-		profile.setUsername(cursor.getString(cursor.getColumnIndexOrThrow(KEY_USERNAME)));
-		profile.setPassword(cursor.getString(cursor.getColumnIndexOrThrow(KEY_PASSWORD)));
-		profile.setCertificateAlias(cursor.getString(cursor.getColumnIndexOrThrow(KEY_CERTIFICATE)));
-		profile.setUserCertificateAlias(cursor.getString(cursor.getColumnIndexOrThrow(KEY_USER_CERTIFICATE)));
-		profile.setMTU(getInt(cursor, cursor.getColumnIndexOrThrow(KEY_MTU)));
-		profile.setPort(getInt(cursor, cursor.getColumnIndexOrThrow(KEY_PORT)));
-		profile.setSplitTunneling(getInt(cursor, cursor.getColumnIndexOrThrow(KEY_SPLIT_TUNNELING)));
-		profile.setLocalId(cursor.getString(cursor.getColumnIndexOrThrow(KEY_LOCAL_ID)));
-		profile.setRemoteId(cursor.getString(cursor.getColumnIndexOrThrow(KEY_REMOTE_ID)));
-		profile.setExcludedSubnets(cursor.getString(cursor.getColumnIndexOrThrow(KEY_EXCLUDED_SUBNETS)));
-		profile.setIncludedSubnets(cursor.getString(cursor.getColumnIndexOrThrow(KEY_INCLUDED_SUBNETS)));
-		profile.setSelectedAppsHandling(getInt(cursor, cursor.getColumnIndexOrThrow(KEY_SELECTED_APPS)));
-		profile.setSelectedApps(cursor.getString(cursor.getColumnIndexOrThrow(KEY_SELECTED_APPS_LIST)));
-		profile.setNATKeepAlive(getInt(cursor, cursor.getColumnIndexOrThrow(KEY_NAT_KEEPALIVE)));
-		profile.setFlags(getInt(cursor, cursor.getColumnIndexOrThrow(KEY_FLAGS)));
-		profile.setIkeProposal(cursor.getString(cursor.getColumnIndexOrThrow(KEY_IKE_PROPOSAL)));
-		profile.setEspProposal(cursor.getString(cursor.getColumnIndexOrThrow(KEY_ESP_PROPOSAL)));
-		profile.setDnsServers(cursor.getString(cursor.getColumnIndexOrThrow(KEY_DNS_SERVERS)));
-		return profile;
-	}
-
-	private ContentValues ContentValuesFromVpnProfile(VpnProfile profile)
-	{
-		ContentValues values = new ContentValues();
-		values.put(KEY_UUID, profile.getUUID().toString());
-		values.put(KEY_NAME, profile.getName());
-		values.put(KEY_GATEWAY, profile.getGateway());
-		values.put(KEY_VPN_TYPE, profile.getVpnType().getIdentifier());
-		values.put(KEY_USERNAME, profile.getUsername());
-		values.put(KEY_PASSWORD, profile.getPassword());
-		values.put(KEY_CERTIFICATE, profile.getCertificateAlias());
-		values.put(KEY_USER_CERTIFICATE, profile.getUserCertificateAlias());
-		values.put(KEY_MTU, profile.getMTU());
-		values.put(KEY_PORT, profile.getPort());
-		values.put(KEY_SPLIT_TUNNELING, profile.getSplitTunneling());
-		values.put(KEY_LOCAL_ID, profile.getLocalId());
-		values.put(KEY_REMOTE_ID, profile.getRemoteId());
-		values.put(KEY_EXCLUDED_SUBNETS, profile.getExcludedSubnets());
-		values.put(KEY_INCLUDED_SUBNETS, profile.getIncludedSubnets());
-		values.put(KEY_SELECTED_APPS, profile.getSelectedAppsHandling().getValue());
-		values.put(KEY_SELECTED_APPS_LIST, profile.getSelectedApps());
-		values.put(KEY_NAT_KEEPALIVE, profile.getNATKeepAlive());
-		values.put(KEY_FLAGS, profile.getFlags());
-		values.put(KEY_IKE_PROPOSAL, profile.getIkeProposal());
-		values.put(KEY_ESP_PROPOSAL, profile.getEspProposal());
-		values.put(KEY_DNS_SERVERS, profile.getDnsServers());
-		return values;
-	}
-
-	private Integer getInt(Cursor cursor, int columnIndex)
-	{
-		return cursor.isNull(columnIndex) ? null : cursor.getInt(columnIndex);
-	}
-
-	private static class DbColumn
-	{
-		public final String Name;
-		public final String Type;
-		public final Integer Since;
-
-		public DbColumn(String name, String type, Integer since)
-		{
-			Name = name;
-			Type = type;
-			Since = since;
-		}
-	}
+	List<VpnProfile> getAllVpnProfiles();
 }

--- a/src/frontends/android/app/src/main/java/org/strongswan/android/data/VpnProfileManagedDataSource.java
+++ b/src/frontends/android/app/src/main/java/org/strongswan/android/data/VpnProfileManagedDataSource.java
@@ -113,8 +113,8 @@ public class VpnProfileManagedDataSource implements VpnProfileDataSource
 	{
 		mManagedConfigurationService.loadConfiguration();
 
-		final Map<String, CaCertificate> caCertificateMap = mCaCertificateRepository.getInstalledCertificateMap();
-		final Map<String, UserCertificate> userCertificateMap = mUserCertificateRepository.getInstalledCertificateMap();
+		final Map<String, CaCertificate> caCertificateMap = mCaCertificateRepository.getCertificateMap();
+		final Map<String, UserCertificate> userCertificateMap = mUserCertificateRepository.getCertificateMap();
 
 		final List<ManagedVpnProfile> managedVpnProfiles = mManagedConfigurationService.getManagedProfiles();
 		for (final ManagedVpnProfile vpnProfile : managedVpnProfiles)

--- a/src/frontends/android/app/src/main/java/org/strongswan/android/data/VpnProfileManagedDataSource.java
+++ b/src/frontends/android/app/src/main/java/org/strongswan/android/data/VpnProfileManagedDataSource.java
@@ -1,0 +1,121 @@
+package org.strongswan.android.data;
+
+import android.content.Context;
+import android.content.SharedPreferences;
+import android.database.SQLException;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+
+public class VpnProfileManagedDataSource implements VpnProfileDataSource
+{
+	private static final String NAME_MANAGED_VPN_PROFILES = "org.strongswan.android.data.VpnProfileManagedDataSource.preferences";
+
+	private final ManagedConfigurationService mManagedConfigurationService;
+	private final SharedPreferences mSharedPreferences;
+
+	public VpnProfileManagedDataSource(final Context context)
+	{
+		this.mManagedConfigurationService = new ManagedConfigurationService(context);
+		this.mSharedPreferences = context.getSharedPreferences(NAME_MANAGED_VPN_PROFILES, Context.MODE_PRIVATE);
+	}
+
+	@Override
+	public VpnProfileDataSource open() throws SQLException
+	{
+		mManagedConfigurationService.loadConfiguration();
+
+		final Set<String> actualKeys = new HashSet<>();
+		for (final VpnProfile profile : getAllVpnProfiles())
+		{
+			actualKeys.add(profile.getUUID().toString());
+		}
+
+		final Set<String> storedKeys = new HashSet<>(mSharedPreferences.getAll().keySet());
+		storedKeys.removeAll(actualKeys);
+
+		final SharedPreferences.Editor editor = mSharedPreferences.edit();
+		for (String key : storedKeys)
+		{
+			editor.remove(key);
+		}
+
+		editor.apply();
+		return this;
+	}
+
+	@Override
+	public void close()
+	{
+		// Do nothing
+	}
+
+	@Override
+	public VpnProfile insertProfile(VpnProfile profile)
+	{
+		return null;
+	}
+
+	@Override
+	public boolean updateVpnProfile(VpnProfile profile)
+	{
+		final VpnProfile existingProfile = getVpnProfile(profile.getUUID());
+		if (existingProfile == null)
+		{
+			return false;
+		}
+
+		final String password = profile.getPassword();
+		existingProfile.setPassword(password);
+
+		final SharedPreferences.Editor editor = mSharedPreferences.edit();
+		editor.putString(profile.getUUID().toString(), password);
+		return editor.commit();
+	}
+
+	@Override
+	public boolean deleteVpnProfile(VpnProfile profile)
+	{
+		return false;
+	}
+
+	@Override
+	public ManagedVpnProfile getVpnProfile(long id)
+	{
+		for (ManagedVpnProfile vpnProfile : getAllVpnProfiles())
+		{
+			if (vpnProfile.getId() == id)
+			{
+				return vpnProfile;
+			}
+		}
+		return null;
+	}
+
+	@Override
+	public ManagedVpnProfile getVpnProfile(UUID uuid)
+	{
+		for (ManagedVpnProfile vpnProfile : getAllVpnProfiles())
+		{
+			if (uuid != null && uuid.equals(vpnProfile.getUUID()))
+			{
+				return vpnProfile;
+			}
+		}
+		return null;
+	}
+
+	@Override
+	public List<ManagedVpnProfile> getAllVpnProfiles()
+	{
+		final List<ManagedVpnProfile> managedVpnProfiles = mManagedConfigurationService.getManagedProfiles();
+		for (final ManagedVpnProfile vpnProfile : managedVpnProfiles)
+		{
+			final String password = mSharedPreferences.getString(vpnProfile.getUUID().toString(), vpnProfile.getPassword());
+			vpnProfile.setPassword(password);
+		}
+		return managedVpnProfiles;
+	}
+}

--- a/src/frontends/android/app/src/main/java/org/strongswan/android/data/VpnProfileManagedDataSource.java
+++ b/src/frontends/android/app/src/main/java/org/strongswan/android/data/VpnProfileManagedDataSource.java
@@ -115,6 +115,7 @@ public class VpnProfileManagedDataSource implements VpnProfileDataSource
 		{
 			final String password = mSharedPreferences.getString(vpnProfile.getUUID().toString(), vpnProfile.getPassword());
 			vpnProfile.setPassword(password);
+			vpnProfile.setDataSource(this);
 			vpnProfile.setReadOnly(true);
 		}
 		return managedVpnProfiles;

--- a/src/frontends/android/app/src/main/java/org/strongswan/android/data/VpnProfileManagedDataSource.java
+++ b/src/frontends/android/app/src/main/java/org/strongswan/android/data/VpnProfileManagedDataSource.java
@@ -111,7 +111,7 @@ public class VpnProfileManagedDataSource implements VpnProfileDataSource
 		mManagedConfigurationService.loadConfiguration();
 
 		final Map<String, CaCertificate> caCertificateMap = mCaCertificateRepository.getInstalledCertificateMap();
-		final Map<String, UserCertificate> userCertificateMap = mUserCertificateRepository.getInstalledKeyStoreMap();
+		final Map<String, UserCertificate> userCertificateMap = mUserCertificateRepository.getInstalledCertificateMap();
 
 		final List<ManagedVpnProfile> managedVpnProfiles = mManagedConfigurationService.getManagedProfiles();
 		for (final ManagedVpnProfile vpnProfile : managedVpnProfiles)

--- a/src/frontends/android/app/src/main/java/org/strongswan/android/data/VpnProfileManagedDataSource.java
+++ b/src/frontends/android/app/src/main/java/org/strongswan/android/data/VpnProfileManagedDataSource.java
@@ -122,16 +122,10 @@ public class VpnProfileManagedDataSource implements VpnProfileDataSource
 			final String uuid = vpnProfile.getUUID().toString();
 			final String password = mSharedPreferences.getString(uuid, vpnProfile.getPassword());
 			final CaCertificate caCertificate = caCertificateMap.get(uuid);
-			if (caCertificate != null)
-			{
-				vpnProfile.setCertificateAlias(caCertificate.getAlias());
-			}
 			final UserCertificate userCertificate = userCertificateMap.get(uuid);
-			if (userCertificate != null)
-			{
-				vpnProfile.setUserCertificateAlias(userCertificate.getAlias());
-			}
 
+			vpnProfile.setCaCertificate(caCertificate);
+			vpnProfile.setUserCertificate(userCertificate);
 			vpnProfile.setPassword(password);
 			vpnProfile.setDataSource(this);
 			vpnProfile.setReadOnly(true);

--- a/src/frontends/android/app/src/main/java/org/strongswan/android/data/VpnProfileManagedDataSource.java
+++ b/src/frontends/android/app/src/main/java/org/strongswan/android/data/VpnProfileManagedDataSource.java
@@ -82,19 +82,6 @@ public class VpnProfileManagedDataSource implements VpnProfileDataSource
 	}
 
 	@Override
-	public ManagedVpnProfile getVpnProfile(long id)
-	{
-		for (ManagedVpnProfile vpnProfile : getAllVpnProfiles())
-		{
-			if (vpnProfile.getId() == id)
-			{
-				return vpnProfile;
-			}
-		}
-		return null;
-	}
-
-	@Override
 	public ManagedVpnProfile getVpnProfile(UUID uuid)
 	{
 		for (ManagedVpnProfile vpnProfile : getAllVpnProfiles())

--- a/src/frontends/android/app/src/main/java/org/strongswan/android/data/VpnProfileManagedDataSource.java
+++ b/src/frontends/android/app/src/main/java/org/strongswan/android/data/VpnProfileManagedDataSource.java
@@ -4,6 +4,7 @@ import android.app.admin.DevicePolicyManager;
 import android.content.Context;
 import android.content.SharedPreferences;
 import android.database.SQLException;
+import android.util.Log;
 
 import org.strongswan.android.logic.StrongSwanApplication;
 
@@ -15,6 +16,8 @@ import java.util.UUID;
 
 public class VpnProfileManagedDataSource implements VpnProfileDataSource
 {
+	private static final String TAG = VpnProfileManagedDataSource.class.getSimpleName();
+
 	private static final String NAME_MANAGED_VPN_PROFILES = "org.strongswan.android.data.VpnProfileManagedDataSource.preferences";
 
 	private final ManagedConfigurationService mManagedConfigurationService;
@@ -120,13 +123,21 @@ public class VpnProfileManagedDataSource implements VpnProfileDataSource
 		for (final ManagedVpnProfile vpnProfile : managedVpnProfiles)
 		{
 			final String uuid = vpnProfile.getUUID().toString();
-			final String password = mSharedPreferences.getString(uuid, vpnProfile.getPassword());
+			final String name = vpnProfile.getName();
+			Log.d(TAG, "Load managed profile " + name + " {" + uuid + "}");
+
 			final CaCertificate caCertificate = caCertificateMap.get(uuid);
 			final UserCertificate userCertificate = userCertificateMap.get(uuid);
 
+			Log.d(TAG, "Set CA certificate of " + name + " to " + caCertificate);
 			vpnProfile.setCaCertificate(caCertificate);
+
+			Log.d(TAG, "Set user certificate of " + name + " to " + userCertificate);
 			vpnProfile.setUserCertificate(userCertificate);
+
+			final String password = mSharedPreferences.getString(uuid, vpnProfile.getPassword());
 			vpnProfile.setPassword(password);
+
 			vpnProfile.setDataSource(this);
 			vpnProfile.setReadOnly(true);
 		}

--- a/src/frontends/android/app/src/main/java/org/strongswan/android/data/VpnProfileManagedDataSource.java
+++ b/src/frontends/android/app/src/main/java/org/strongswan/android/data/VpnProfileManagedDataSource.java
@@ -1,5 +1,6 @@
 package org.strongswan.android.data;
 
+import android.app.admin.DevicePolicyManager;
 import android.content.Context;
 import android.content.SharedPreferences;
 import android.database.SQLException;
@@ -30,8 +31,10 @@ public class VpnProfileManagedDataSource implements VpnProfileDataSource
 		this.mSharedPreferences = context.getSharedPreferences(NAME_MANAGED_VPN_PROFILES, Context.MODE_PRIVATE);
 
 		final DatabaseHelper databaseHelper = application.getDatabaseHelper();
+		final DevicePolicyManager devicePolicyManager = (DevicePolicyManager)application.getSystemService(Context.DEVICE_POLICY_SERVICE);
+
 		this.mCaCertificateRepository = new CaCertificateRepository(mManagedConfigurationService, databaseHelper);
-		this.mUserCertificateRepository = new UserCertificateRepository(mManagedConfigurationService, databaseHelper);
+		this.mUserCertificateRepository = new UserCertificateRepository(mManagedConfigurationService, devicePolicyManager, databaseHelper);
 	}
 
 	@Override

--- a/src/frontends/android/app/src/main/java/org/strongswan/android/data/VpnProfileManagedDataSource.java
+++ b/src/frontends/android/app/src/main/java/org/strongswan/android/data/VpnProfileManagedDataSource.java
@@ -115,6 +115,7 @@ public class VpnProfileManagedDataSource implements VpnProfileDataSource
 		{
 			final String password = mSharedPreferences.getString(vpnProfile.getUUID().toString(), vpnProfile.getPassword());
 			vpnProfile.setPassword(password);
+			vpnProfile.setReadOnly(true);
 		}
 		return managedVpnProfiles;
 	}

--- a/src/frontends/android/app/src/main/java/org/strongswan/android/data/VpnProfileManagedDataSource.java
+++ b/src/frontends/android/app/src/main/java/org/strongswan/android/data/VpnProfileManagedDataSource.java
@@ -25,8 +25,14 @@ public class VpnProfileManagedDataSource implements VpnProfileDataSource
 	@Override
 	public VpnProfileDataSource open() throws SQLException
 	{
-		mManagedConfigurationService.loadConfiguration();
+		// Do nothing
+		return this;
+	}
 
+	@Override
+	public void close()
+	{
+		// Remove passwords that are no longer referenced by a VPN profile
 		final Set<String> actualKeys = new HashSet<>();
 		for (final VpnProfile profile : getAllVpnProfiles())
 		{
@@ -43,13 +49,6 @@ public class VpnProfileManagedDataSource implements VpnProfileDataSource
 		}
 
 		editor.apply();
-		return this;
-	}
-
-	@Override
-	public void close()
-	{
-		// Do nothing
 	}
 
 	@Override
@@ -97,6 +96,8 @@ public class VpnProfileManagedDataSource implements VpnProfileDataSource
 	@Override
 	public List<ManagedVpnProfile> getAllVpnProfiles()
 	{
+		mManagedConfigurationService.loadConfiguration();
+
 		final List<ManagedVpnProfile> managedVpnProfiles = mManagedConfigurationService.getManagedProfiles();
 		for (final ManagedVpnProfile vpnProfile : managedVpnProfiles)
 		{

--- a/src/frontends/android/app/src/main/java/org/strongswan/android/data/VpnProfileManagedDataSource.java
+++ b/src/frontends/android/app/src/main/java/org/strongswan/android/data/VpnProfileManagedDataSource.java
@@ -111,6 +111,8 @@ public class VpnProfileManagedDataSource implements VpnProfileDataSource
 
 	public boolean areUnmanagedSourcesAllowed()
 	{
+		mManagedConfigurationService.loadConfiguration();
+
 		final ManagedConfiguration managedConfiguration = mManagedConfigurationService.getManagedConfiguration();
 		return managedConfiguration.isAllowExistingProfiles();
 	}

--- a/src/frontends/android/app/src/main/java/org/strongswan/android/data/VpnProfileManagedDataSource.java
+++ b/src/frontends/android/app/src/main/java/org/strongswan/android/data/VpnProfileManagedDataSource.java
@@ -108,4 +108,10 @@ public class VpnProfileManagedDataSource implements VpnProfileDataSource
 		}
 		return managedVpnProfiles;
 	}
+
+	public boolean areUnmanagedSourcesAllowed()
+	{
+		final ManagedConfiguration managedConfiguration = mManagedConfigurationService.getManagedConfiguration();
+		return managedConfiguration.isAllowExistingProfiles();
+	}
 }

--- a/src/frontends/android/app/src/main/java/org/strongswan/android/data/VpnProfileSource.java
+++ b/src/frontends/android/app/src/main/java/org/strongswan/android/data/VpnProfileSource.java
@@ -15,7 +15,9 @@ public class VpnProfileSource implements VpnProfileDataSource
 	public VpnProfileSource(Context context)
 	{
 		vpnProfileSqlDataSource = new VpnProfileSqlDataSource(context);
+
 		dataSources.add(vpnProfileSqlDataSource);
+		dataSources.add(new VpnProfileManagedDataSource(context));
 	}
 
 	@Override
@@ -81,24 +83,6 @@ public class VpnProfileSource implements VpnProfileDataSource
 			}
 		}
 		return null;
-	}
-
-	@Override
-	public VpnProfile getVpnProfile(String uuid)
-	{
-		try
-		{
-			if (uuid != null)
-			{
-				return getVpnProfile(UUID.fromString(uuid));
-			}
-			return null;
-		}
-		catch (IllegalArgumentException e)
-		{
-			e.printStackTrace();
-			return null;
-		}
 	}
 
 	@Override

--- a/src/frontends/android/app/src/main/java/org/strongswan/android/data/VpnProfileSource.java
+++ b/src/frontends/android/app/src/main/java/org/strongswan/android/data/VpnProfileSource.java
@@ -58,20 +58,6 @@ public class VpnProfileSource implements VpnProfileDataSource
 	}
 
 	@Override
-	public VpnProfile getVpnProfile(long id)
-	{
-		for (final VpnProfileDataSource source : dataSources)
-		{
-			final VpnProfile profile = source.getVpnProfile(id);
-			if (profile != null)
-			{
-				return profile;
-			}
-		}
-		return null;
-	}
-
-	@Override
 	public VpnProfile getVpnProfile(UUID uuid)
 	{
 		for (final VpnProfileDataSource source : dataSources)

--- a/src/frontends/android/app/src/main/java/org/strongswan/android/data/VpnProfileSource.java
+++ b/src/frontends/android/app/src/main/java/org/strongswan/android/data/VpnProfileSource.java
@@ -1,0 +1,116 @@
+package org.strongswan.android.data;
+
+import android.content.Context;
+import android.database.SQLException;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+public class VpnProfileSource implements VpnProfileDataSource
+{
+	private final List<VpnProfileDataSource> dataSources = new ArrayList<>();
+	private final VpnProfileSqlDataSource vpnProfileSqlDataSource;
+
+	public VpnProfileSource(Context context)
+	{
+		vpnProfileSqlDataSource = new VpnProfileSqlDataSource(context);
+		dataSources.add(vpnProfileSqlDataSource);
+	}
+
+	@Override
+	public VpnProfileDataSource open() throws SQLException
+	{
+		for (final VpnProfileDataSource source : dataSources)
+		{
+			source.open();
+		}
+		return this;
+	}
+
+	@Override
+	public void close()
+	{
+		for (final VpnProfileDataSource source : dataSources)
+		{
+			source.close();
+		}
+	}
+
+	@Override
+	public VpnProfile insertProfile(VpnProfile profile)
+	{
+		return vpnProfileSqlDataSource.insertProfile(profile);
+	}
+
+	@Override
+	public boolean updateVpnProfile(VpnProfile profile)
+	{
+		return vpnProfileSqlDataSource.updateVpnProfile(profile);
+	}
+
+	@Override
+	public boolean deleteVpnProfile(VpnProfile profile)
+	{
+		return vpnProfileSqlDataSource.deleteVpnProfile(profile);
+	}
+
+	@Override
+	public VpnProfile getVpnProfile(long id)
+	{
+		for (final VpnProfileDataSource source : dataSources)
+		{
+			final VpnProfile profile = source.getVpnProfile(id);
+			if (profile != null)
+			{
+				return profile;
+			}
+		}
+		return null;
+	}
+
+	@Override
+	public VpnProfile getVpnProfile(UUID uuid)
+	{
+		for (final VpnProfileDataSource source : dataSources)
+		{
+			final VpnProfile profile = source.getVpnProfile(uuid);
+			if (profile != null)
+			{
+				return profile;
+			}
+		}
+		return null;
+	}
+
+	@Override
+	public VpnProfile getVpnProfile(String uuid)
+	{
+		try
+		{
+			if (uuid != null)
+			{
+				return getVpnProfile(UUID.fromString(uuid));
+			}
+			return null;
+		}
+		catch (IllegalArgumentException e)
+		{
+			e.printStackTrace();
+			return null;
+		}
+	}
+
+	@Override
+	public List<VpnProfile> getAllVpnProfiles()
+	{
+		final List<VpnProfile> profiles = new ArrayList<>();
+
+		for (final VpnProfileDataSource source : dataSources)
+		{
+			profiles.addAll(source.getAllVpnProfiles());
+		}
+
+		return profiles;
+	}
+}

--- a/src/frontends/android/app/src/main/java/org/strongswan/android/data/VpnProfileSource.java
+++ b/src/frontends/android/app/src/main/java/org/strongswan/android/data/VpnProfileSource.java
@@ -48,13 +48,13 @@ public class VpnProfileSource implements VpnProfileDataSource
 	@Override
 	public boolean updateVpnProfile(VpnProfile profile)
 	{
-		return vpnProfileSqlDataSource.updateVpnProfile(profile);
+		return profile.getDataSource().updateVpnProfile(profile);
 	}
 
 	@Override
 	public boolean deleteVpnProfile(VpnProfile profile)
 	{
-		return vpnProfileSqlDataSource.deleteVpnProfile(profile);
+		return profile.getDataSource().deleteVpnProfile(profile);
 	}
 
 	@Override

--- a/src/frontends/android/app/src/main/java/org/strongswan/android/data/VpnProfileSource.java
+++ b/src/frontends/android/app/src/main/java/org/strongswan/android/data/VpnProfileSource.java
@@ -14,10 +14,14 @@ public class VpnProfileSource implements VpnProfileDataSource
 
 	public VpnProfileSource(Context context)
 	{
+		VpnProfileManagedDataSource vpnProfileManagedDataSource = new VpnProfileManagedDataSource(context);
 		vpnProfileSqlDataSource = new VpnProfileSqlDataSource(context);
 
-		dataSources.add(vpnProfileSqlDataSource);
-		dataSources.add(new VpnProfileManagedDataSource(context));
+		if (vpnProfileManagedDataSource.areUnmanagedSourcesAllowed())
+		{
+			dataSources.add(vpnProfileSqlDataSource);
+		}
+		dataSources.add(vpnProfileManagedDataSource);
 	}
 
 	@Override

--- a/src/frontends/android/app/src/main/java/org/strongswan/android/data/VpnProfileSqlDataSource.java
+++ b/src/frontends/android/app/src/main/java/org/strongswan/android/data/VpnProfileSqlDataSource.java
@@ -23,9 +23,6 @@ import android.content.Context;
 import android.database.Cursor;
 import android.database.SQLException;
 import android.database.sqlite.SQLiteDatabase;
-import android.database.sqlite.SQLiteOpenHelper;
-import android.database.sqlite.SQLiteQueryBuilder;
-import android.util.Log;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -33,222 +30,9 @@ import java.util.UUID;
 
 public class VpnProfileSqlDataSource implements VpnProfileDataSource
 {
-	private static final String TAG = VpnProfileSqlDataSource.class.getSimpleName();
-
-	private static final DbColumn[] COLUMNS = new VpnProfileSqlDataSource.DbColumn[]{
-		new VpnProfileSqlDataSource.DbColumn(KEY_ID, "INTEGER PRIMARY KEY AUTOINCREMENT", 1),
-		new VpnProfileSqlDataSource.DbColumn(KEY_UUID, "TEXT UNIQUE", 9),
-		new VpnProfileSqlDataSource.DbColumn(KEY_NAME, "TEXT NOT NULL", 1),
-		new VpnProfileSqlDataSource.DbColumn(KEY_GATEWAY, "TEXT NOT NULL", 1),
-		new VpnProfileSqlDataSource.DbColumn(KEY_VPN_TYPE, "TEXT NOT NULL", 3),
-		new VpnProfileSqlDataSource.DbColumn(KEY_USERNAME, "TEXT", 1),
-		new VpnProfileSqlDataSource.DbColumn(KEY_PASSWORD, "TEXT", 1),
-		new VpnProfileSqlDataSource.DbColumn(KEY_CERTIFICATE, "TEXT", 1),
-		new VpnProfileSqlDataSource.DbColumn(KEY_USER_CERTIFICATE, "TEXT", 2),
-		new VpnProfileSqlDataSource.DbColumn(KEY_MTU, "INTEGER", 5),
-		new VpnProfileSqlDataSource.DbColumn(KEY_PORT, "INTEGER", 6),
-		new VpnProfileSqlDataSource.DbColumn(KEY_SPLIT_TUNNELING, "INTEGER", 7),
-		new VpnProfileSqlDataSource.DbColumn(KEY_LOCAL_ID, "TEXT", 8),
-		new VpnProfileSqlDataSource.DbColumn(KEY_REMOTE_ID, "TEXT", 8),
-		new VpnProfileSqlDataSource.DbColumn(KEY_EXCLUDED_SUBNETS, "TEXT", 10),
-		new VpnProfileSqlDataSource.DbColumn(KEY_INCLUDED_SUBNETS, "TEXT", 11),
-		new VpnProfileSqlDataSource.DbColumn(KEY_SELECTED_APPS, "INTEGER", 12),
-		new VpnProfileSqlDataSource.DbColumn(KEY_SELECTED_APPS_LIST, "TEXT", 12),
-		new VpnProfileSqlDataSource.DbColumn(KEY_NAT_KEEPALIVE, "INTEGER", 13),
-		new VpnProfileSqlDataSource.DbColumn(KEY_FLAGS, "INTEGER", 14),
-		new VpnProfileSqlDataSource.DbColumn(KEY_IKE_PROPOSAL, "TEXT", 15),
-		new VpnProfileSqlDataSource.DbColumn(KEY_ESP_PROPOSAL, "TEXT", 15),
-		new VpnProfileSqlDataSource.DbColumn(KEY_DNS_SERVERS, "TEXT", 17),
-	};
-
 	private DatabaseHelper mDbHelper;
 	private SQLiteDatabase mDatabase;
 	private final Context mContext;
-
-	private static final String DATABASE_NAME = "strongswan.db";
-	private static final String TABLE_VPNPROFILE = "vpnprofile";
-
-	private static final int DATABASE_VERSION = 17;
-
-	private static final String[] ALL_COLUMNS = getColumns(DATABASE_VERSION);
-
-	private static String getDatabaseCreate(int version)
-	{
-		boolean first = true;
-		StringBuilder create = new StringBuilder("CREATE TABLE ");
-		create.append(TABLE_VPNPROFILE);
-		create.append(" (");
-		for (DbColumn column : COLUMNS)
-		{
-			if (column.Since <= version)
-			{
-				if (!first)
-				{
-					create.append(",");
-				}
-				first = false;
-				create.append(column.Name);
-				create.append(" ");
-				create.append(column.Type);
-			}
-		}
-		create.append(");");
-		return create.toString();
-	}
-
-	private static String[] getColumns(int version)
-	{
-		ArrayList<String> columns = new ArrayList<>();
-		for (DbColumn column : COLUMNS)
-		{
-			if (column.Since <= version)
-			{
-				columns.add(column.Name);
-			}
-		}
-		return columns.toArray(new String[0]);
-	}
-
-	private static class DatabaseHelper extends SQLiteOpenHelper
-	{
-		public DatabaseHelper(Context context)
-		{
-			super(context, DATABASE_NAME, null, DATABASE_VERSION);
-		}
-
-		@Override
-		public void onCreate(SQLiteDatabase database)
-		{
-			database.execSQL(getDatabaseCreate(DATABASE_VERSION));
-		}
-
-		@Override
-		public void onUpgrade(SQLiteDatabase db, int oldVersion, int newVersion)
-		{
-			Log.w(TAG, "Upgrading database from version " + oldVersion +
-				" to " + newVersion);
-			if (oldVersion < 2)
-			{
-				db.execSQL("ALTER TABLE " + TABLE_VPNPROFILE + " ADD " + KEY_USER_CERTIFICATE +
-					           " TEXT;");
-			}
-			if (oldVersion < 3)
-			{
-				db.execSQL("ALTER TABLE " + TABLE_VPNPROFILE + " ADD " + KEY_VPN_TYPE +
-					           " TEXT DEFAULT '';");
-			}
-			if (oldVersion < 4)
-			{    /* remove NOT NULL constraint from username column */
-				updateColumns(db, 4);
-			}
-			if (oldVersion < 5)
-			{
-				db.execSQL("ALTER TABLE " + TABLE_VPNPROFILE + " ADD " + KEY_MTU +
-					           " INTEGER;");
-			}
-			if (oldVersion < 6)
-			{
-				db.execSQL("ALTER TABLE " + TABLE_VPNPROFILE + " ADD " + KEY_PORT +
-					           " INTEGER;");
-			}
-			if (oldVersion < 7)
-			{
-				db.execSQL("ALTER TABLE " + TABLE_VPNPROFILE + " ADD " + KEY_SPLIT_TUNNELING +
-					           " INTEGER;");
-			}
-			if (oldVersion < 8)
-			{
-				db.execSQL("ALTER TABLE " + TABLE_VPNPROFILE + " ADD " + KEY_LOCAL_ID +
-					           " TEXT;");
-				db.execSQL("ALTER TABLE " + TABLE_VPNPROFILE + " ADD " + KEY_REMOTE_ID +
-					           " TEXT;");
-			}
-			if (oldVersion < 9)
-			{
-				db.execSQL("ALTER TABLE " + TABLE_VPNPROFILE + " ADD " + KEY_UUID +
-					           " TEXT;");
-				updateColumns(db, 9);
-			}
-			if (oldVersion < 10)
-			{
-				db.execSQL("ALTER TABLE " + TABLE_VPNPROFILE + " ADD " + KEY_EXCLUDED_SUBNETS +
-					           " TEXT;");
-			}
-			if (oldVersion < 11)
-			{
-				db.execSQL("ALTER TABLE " + TABLE_VPNPROFILE + " ADD " + KEY_INCLUDED_SUBNETS +
-					           " TEXT;");
-			}
-			if (oldVersion < 12)
-			{
-				db.execSQL("ALTER TABLE " + TABLE_VPNPROFILE + " ADD " + KEY_SELECTED_APPS +
-					           " INTEGER;");
-				db.execSQL("ALTER TABLE " + TABLE_VPNPROFILE + " ADD " + KEY_SELECTED_APPS_LIST +
-					           " TEXT;");
-			}
-			if (oldVersion < 13)
-			{
-				db.execSQL("ALTER TABLE " + TABLE_VPNPROFILE + " ADD " + KEY_NAT_KEEPALIVE +
-					           " INTEGER;");
-			}
-			if (oldVersion < 14)
-			{
-				db.execSQL("ALTER TABLE " + TABLE_VPNPROFILE + " ADD " + KEY_FLAGS +
-					           " INTEGER;");
-			}
-			if (oldVersion < 15)
-			{
-				db.execSQL("ALTER TABLE " + TABLE_VPNPROFILE + " ADD " + KEY_IKE_PROPOSAL +
-					           " TEXT;");
-				db.execSQL("ALTER TABLE " + TABLE_VPNPROFILE + " ADD " + KEY_ESP_PROPOSAL +
-					           " TEXT;");
-			}
-			if (oldVersion < 16)
-			{    /* add a UUID to all entries that haven't one yet */
-				db.beginTransaction();
-				try
-				{
-					Cursor cursor = db.query(TABLE_VPNPROFILE, getColumns(16), KEY_UUID + " is NULL", null, null, null, null);
-					for (cursor.moveToFirst(); !cursor.isAfterLast(); cursor.moveToNext())
-					{
-						ContentValues values = new ContentValues();
-						values.put(KEY_UUID, UUID.randomUUID().toString());
-						db.update(TABLE_VPNPROFILE, values, KEY_ID + " = " + cursor.getLong(cursor.getColumnIndexOrThrow(KEY_ID)), null);
-					}
-					cursor.close();
-					db.setTransactionSuccessful();
-				}
-				finally
-				{
-					db.endTransaction();
-				}
-			}
-			if (oldVersion < 17)
-			{
-				db.execSQL("ALTER TABLE " + TABLE_VPNPROFILE + " ADD " + KEY_DNS_SERVERS +
-					           " TEXT;");
-			}
-		}
-
-		private void updateColumns(SQLiteDatabase db, int version)
-		{
-			db.beginTransaction();
-			try
-			{
-				db.execSQL("ALTER TABLE " + TABLE_VPNPROFILE + " RENAME TO tmp_" + TABLE_VPNPROFILE + ";");
-				db.execSQL(getDatabaseCreate(version));
-				StringBuilder insert = new StringBuilder("INSERT INTO " + TABLE_VPNPROFILE + " SELECT ");
-				SQLiteQueryBuilder.appendColumns(insert, getColumns(version));
-				db.execSQL(insert.append(" FROM tmp_" + TABLE_VPNPROFILE + ";").toString());
-				db.execSQL("DROP TABLE tmp_" + TABLE_VPNPROFILE + ";");
-				db.setTransactionSuccessful();
-			}
-			finally
-			{
-				db.endTransaction();
-			}
-		}
-	}
 
 	/**
 	 * Construct a new VPN profile data source. The context is used to
@@ -286,7 +70,7 @@ public class VpnProfileSqlDataSource implements VpnProfileDataSource
 	public VpnProfile insertProfile(VpnProfile profile)
 	{
 		ContentValues values = ContentValuesFromVpnProfile(profile);
-		long insertId = mDatabase.insert(TABLE_VPNPROFILE, null, values);
+		long insertId = mDatabase.insert(DatabaseHelper.TABLE_VPNPROFILE, null, values);
 		if (insertId == -1)
 		{
 			return null;
@@ -301,21 +85,21 @@ public class VpnProfileSqlDataSource implements VpnProfileDataSource
 	{
 		final UUID uuid = profile.getUUID();
 		ContentValues values = ContentValuesFromVpnProfile(profile);
-		return mDatabase.update(TABLE_VPNPROFILE, values, KEY_UUID + " = ?", new String[]{uuid.toString()}) > 0;
+		return mDatabase.update(DatabaseHelper.TABLE_VPNPROFILE, values, KEY_UUID + " = ?", new String[]{uuid.toString()}) > 0;
 	}
 
 	@Override
 	public boolean deleteVpnProfile(VpnProfile profile)
 	{
 		final UUID uuid = profile.getUUID();
-		return mDatabase.delete(TABLE_VPNPROFILE, KEY_UUID + " = ?", new String[]{uuid.toString()}) > 0;
+		return mDatabase.delete(DatabaseHelper.TABLE_VPNPROFILE, KEY_UUID + " = ?", new String[]{uuid.toString()}) > 0;
 	}
 
 	@Override
 	public VpnProfile getVpnProfile(UUID uuid)
 	{
 		VpnProfile profile = null;
-		Cursor cursor = mDatabase.query(TABLE_VPNPROFILE, ALL_COLUMNS,
+		Cursor cursor = mDatabase.query(DatabaseHelper.TABLE_VPNPROFILE, mDbHelper.getAllColumns(),
 		                                KEY_UUID + " = ?", new String[]{uuid.toString()}, null, null, null);
 		if (cursor.moveToFirst())
 		{
@@ -329,9 +113,9 @@ public class VpnProfileSqlDataSource implements VpnProfileDataSource
 	@Override
 	public List<VpnProfile> getAllVpnProfiles()
 	{
-		List<VpnProfile> vpnProfiles = new ArrayList<VpnProfile>();
+		List<VpnProfile> vpnProfiles = new ArrayList<>();
 
-		Cursor cursor = mDatabase.query(TABLE_VPNPROFILE, ALL_COLUMNS, null, null, null, null, null);
+		Cursor cursor = mDatabase.query(DatabaseHelper.TABLE_VPNPROFILE, mDbHelper.getAllColumns(), null, null, null, null, null);
 		cursor.moveToFirst();
 		while (!cursor.isAfterLast())
 		{
@@ -403,19 +187,5 @@ public class VpnProfileSqlDataSource implements VpnProfileDataSource
 	private Integer getInt(Cursor cursor, int columnIndex)
 	{
 		return cursor.isNull(columnIndex) ? null : cursor.getInt(columnIndex);
-	}
-
-	private static class DbColumn
-	{
-		public final String Name;
-		public final String Type;
-		public final Integer Since;
-
-		public DbColumn(String name, String type, Integer since)
-		{
-			Name = name;
-			Type = type;
-			Since = since;
-		}
 	}
 }

--- a/src/frontends/android/app/src/main/java/org/strongswan/android/data/VpnProfileSqlDataSource.java
+++ b/src/frontends/android/app/src/main/java/org/strongswan/android/data/VpnProfileSqlDataSource.java
@@ -46,7 +46,7 @@ public class VpnProfileSqlDataSource implements VpnProfileDataSource
 		new VpnProfileSqlDataSource.DbColumn(KEY_CERTIFICATE, "TEXT", 1),
 		new VpnProfileSqlDataSource.DbColumn(KEY_USER_CERTIFICATE, "TEXT", 2),
 		new VpnProfileSqlDataSource.DbColumn(KEY_MTU, "INTEGER", 5),
-		new VpnProfileSqlDataSource.DbColumn(KEY_PORT, "INTEGER", 5),
+		new VpnProfileSqlDataSource.DbColumn(KEY_PORT, "INTEGER", 6),
 		new VpnProfileSqlDataSource.DbColumn(KEY_SPLIT_TUNNELING, "INTEGER", 7),
 		new VpnProfileSqlDataSource.DbColumn(KEY_LOCAL_ID, "TEXT", 8),
 		new VpnProfileSqlDataSource.DbColumn(KEY_REMOTE_ID, "TEXT", 8),

--- a/src/frontends/android/app/src/main/java/org/strongswan/android/data/VpnProfileSqlDataSource.java
+++ b/src/frontends/android/app/src/main/java/org/strongswan/android/data/VpnProfileSqlDataSource.java
@@ -1,0 +1,451 @@
+/*
+ * Copyright (C) 2012-2019 Tobias Brunner
+ * Copyright (C) 2012 Giuliano Grassi
+ * Copyright (C) 2012 Ralf Sager
+ *
+ * Copyright (C) secunet Security Networks AG
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation; either version 2 of the License, or (at your
+ * option) any later version.  See <http://www.fsf.org/copyleft/gpl.txt>.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * for more details.
+ */
+
+package org.strongswan.android.data;
+
+import android.content.ContentValues;
+import android.content.Context;
+import android.database.Cursor;
+import android.database.SQLException;
+import android.database.sqlite.SQLiteDatabase;
+import android.database.sqlite.SQLiteOpenHelper;
+import android.database.sqlite.SQLiteQueryBuilder;
+import android.util.Log;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+public class VpnProfileSqlDataSource implements VpnProfileDataSource
+{
+	private static final String TAG = VpnProfileSqlDataSource.class.getSimpleName();
+
+	private static final DbColumn[] COLUMNS = new VpnProfileSqlDataSource.DbColumn[]{
+		new VpnProfileSqlDataSource.DbColumn(KEY_ID, "INTEGER PRIMARY KEY AUTOINCREMENT", 1),
+		new VpnProfileSqlDataSource.DbColumn(KEY_UUID, "TEXT UNIQUE", 9),
+		new VpnProfileSqlDataSource.DbColumn(KEY_NAME, "TEXT NOT NULL", 1),
+		new VpnProfileSqlDataSource.DbColumn(KEY_GATEWAY, "TEXT NOT NULL", 1),
+		new VpnProfileSqlDataSource.DbColumn(KEY_VPN_TYPE, "TEXT NOT NULL", 3),
+		new VpnProfileSqlDataSource.DbColumn(KEY_USERNAME, "TEXT", 1),
+		new VpnProfileSqlDataSource.DbColumn(KEY_PASSWORD, "TEXT", 1),
+		new VpnProfileSqlDataSource.DbColumn(KEY_CERTIFICATE, "TEXT", 1),
+		new VpnProfileSqlDataSource.DbColumn(KEY_USER_CERTIFICATE, "TEXT", 2),
+		new VpnProfileSqlDataSource.DbColumn(KEY_MTU, "INTEGER", 5),
+		new VpnProfileSqlDataSource.DbColumn(KEY_PORT, "INTEGER", 5),
+		new VpnProfileSqlDataSource.DbColumn(KEY_SPLIT_TUNNELING, "INTEGER", 7),
+		new VpnProfileSqlDataSource.DbColumn(KEY_LOCAL_ID, "TEXT", 8),
+		new VpnProfileSqlDataSource.DbColumn(KEY_REMOTE_ID, "TEXT", 8),
+		new VpnProfileSqlDataSource.DbColumn(KEY_EXCLUDED_SUBNETS, "TEXT", 10),
+		new VpnProfileSqlDataSource.DbColumn(KEY_INCLUDED_SUBNETS, "TEXT", 11),
+		new VpnProfileSqlDataSource.DbColumn(KEY_SELECTED_APPS, "INTEGER", 12),
+		new VpnProfileSqlDataSource.DbColumn(KEY_SELECTED_APPS_LIST, "TEXT", 12),
+		new VpnProfileSqlDataSource.DbColumn(KEY_NAT_KEEPALIVE, "INTEGER", 13),
+		new VpnProfileSqlDataSource.DbColumn(KEY_FLAGS, "INTEGER", 14),
+		new VpnProfileSqlDataSource.DbColumn(KEY_IKE_PROPOSAL, "TEXT", 15),
+		new VpnProfileSqlDataSource.DbColumn(KEY_ESP_PROPOSAL, "TEXT", 15),
+		new VpnProfileSqlDataSource.DbColumn(KEY_DNS_SERVERS, "TEXT", 17),
+	};
+
+	private DatabaseHelper mDbHelper;
+	private SQLiteDatabase mDatabase;
+	private final Context mContext;
+
+	private static final String DATABASE_NAME = "strongswan.db";
+	private static final String TABLE_VPNPROFILE = "vpnprofile";
+
+	private static final int DATABASE_VERSION = 17;
+
+	private static final String[] ALL_COLUMNS = getColumns(DATABASE_VERSION);
+
+	private static String getDatabaseCreate(int version)
+	{
+		boolean first = true;
+		StringBuilder create = new StringBuilder("CREATE TABLE ");
+		create.append(TABLE_VPNPROFILE);
+		create.append(" (");
+		for (DbColumn column : COLUMNS)
+		{
+			if (column.Since <= version)
+			{
+				if (!first)
+				{
+					create.append(",");
+				}
+				first = false;
+				create.append(column.Name);
+				create.append(" ");
+				create.append(column.Type);
+			}
+		}
+		create.append(");");
+		return create.toString();
+	}
+
+	private static String[] getColumns(int version)
+	{
+		ArrayList<String> columns = new ArrayList<>();
+		for (DbColumn column : COLUMNS)
+		{
+			if (column.Since <= version)
+			{
+				columns.add(column.Name);
+			}
+		}
+		return columns.toArray(new String[0]);
+	}
+
+	private static class DatabaseHelper extends SQLiteOpenHelper
+	{
+		public DatabaseHelper(Context context)
+		{
+			super(context, DATABASE_NAME, null, DATABASE_VERSION);
+		}
+
+		@Override
+		public void onCreate(SQLiteDatabase database)
+		{
+			database.execSQL(getDatabaseCreate(DATABASE_VERSION));
+		}
+
+		@Override
+		public void onUpgrade(SQLiteDatabase db, int oldVersion, int newVersion)
+		{
+			Log.w(TAG, "Upgrading database from version " + oldVersion +
+				" to " + newVersion);
+			if (oldVersion < 2)
+			{
+				db.execSQL("ALTER TABLE " + TABLE_VPNPROFILE + " ADD " + KEY_USER_CERTIFICATE +
+					           " TEXT;");
+			}
+			if (oldVersion < 3)
+			{
+				db.execSQL("ALTER TABLE " + TABLE_VPNPROFILE + " ADD " + KEY_VPN_TYPE +
+					           " TEXT DEFAULT '';");
+			}
+			if (oldVersion < 4)
+			{    /* remove NOT NULL constraint from username column */
+				updateColumns(db, 4);
+			}
+			if (oldVersion < 5)
+			{
+				db.execSQL("ALTER TABLE " + TABLE_VPNPROFILE + " ADD " + KEY_MTU +
+					           " INTEGER;");
+			}
+			if (oldVersion < 6)
+			{
+				db.execSQL("ALTER TABLE " + TABLE_VPNPROFILE + " ADD " + KEY_PORT +
+					           " INTEGER;");
+			}
+			if (oldVersion < 7)
+			{
+				db.execSQL("ALTER TABLE " + TABLE_VPNPROFILE + " ADD " + KEY_SPLIT_TUNNELING +
+					           " INTEGER;");
+			}
+			if (oldVersion < 8)
+			{
+				db.execSQL("ALTER TABLE " + TABLE_VPNPROFILE + " ADD " + KEY_LOCAL_ID +
+					           " TEXT;");
+				db.execSQL("ALTER TABLE " + TABLE_VPNPROFILE + " ADD " + KEY_REMOTE_ID +
+					           " TEXT;");
+			}
+			if (oldVersion < 9)
+			{
+				db.execSQL("ALTER TABLE " + TABLE_VPNPROFILE + " ADD " + KEY_UUID +
+					           " TEXT;");
+				updateColumns(db, 9);
+			}
+			if (oldVersion < 10)
+			{
+				db.execSQL("ALTER TABLE " + TABLE_VPNPROFILE + " ADD " + KEY_EXCLUDED_SUBNETS +
+					           " TEXT;");
+			}
+			if (oldVersion < 11)
+			{
+				db.execSQL("ALTER TABLE " + TABLE_VPNPROFILE + " ADD " + KEY_INCLUDED_SUBNETS +
+					           " TEXT;");
+			}
+			if (oldVersion < 12)
+			{
+				db.execSQL("ALTER TABLE " + TABLE_VPNPROFILE + " ADD " + KEY_SELECTED_APPS +
+					           " INTEGER;");
+				db.execSQL("ALTER TABLE " + TABLE_VPNPROFILE + " ADD " + KEY_SELECTED_APPS_LIST +
+					           " TEXT;");
+			}
+			if (oldVersion < 13)
+			{
+				db.execSQL("ALTER TABLE " + TABLE_VPNPROFILE + " ADD " + KEY_NAT_KEEPALIVE +
+					           " INTEGER;");
+			}
+			if (oldVersion < 14)
+			{
+				db.execSQL("ALTER TABLE " + TABLE_VPNPROFILE + " ADD " + KEY_FLAGS +
+					           " INTEGER;");
+			}
+			if (oldVersion < 15)
+			{
+				db.execSQL("ALTER TABLE " + TABLE_VPNPROFILE + " ADD " + KEY_IKE_PROPOSAL +
+					           " TEXT;");
+				db.execSQL("ALTER TABLE " + TABLE_VPNPROFILE + " ADD " + KEY_ESP_PROPOSAL +
+					           " TEXT;");
+			}
+			if (oldVersion < 16)
+			{    /* add a UUID to all entries that haven't one yet */
+				db.beginTransaction();
+				try
+				{
+					Cursor cursor = db.query(TABLE_VPNPROFILE, getColumns(16), KEY_UUID + " is NULL", null, null, null, null);
+					for (cursor.moveToFirst(); !cursor.isAfterLast(); cursor.moveToNext())
+					{
+						ContentValues values = new ContentValues();
+						values.put(KEY_UUID, UUID.randomUUID().toString());
+						db.update(TABLE_VPNPROFILE, values, KEY_ID + " = " + cursor.getLong(cursor.getColumnIndexOrThrow(KEY_ID)), null);
+					}
+					cursor.close();
+					db.setTransactionSuccessful();
+				}
+				finally
+				{
+					db.endTransaction();
+				}
+			}
+			if (oldVersion < 17)
+			{
+				db.execSQL("ALTER TABLE " + TABLE_VPNPROFILE + " ADD " + KEY_DNS_SERVERS +
+					           " TEXT;");
+			}
+		}
+
+		private void updateColumns(SQLiteDatabase db, int version)
+		{
+			db.beginTransaction();
+			try
+			{
+				db.execSQL("ALTER TABLE " + TABLE_VPNPROFILE + " RENAME TO tmp_" + TABLE_VPNPROFILE + ";");
+				db.execSQL(getDatabaseCreate(version));
+				StringBuilder insert = new StringBuilder("INSERT INTO " + TABLE_VPNPROFILE + " SELECT ");
+				SQLiteQueryBuilder.appendColumns(insert, getColumns(version));
+				db.execSQL(insert.append(" FROM tmp_" + TABLE_VPNPROFILE + ";").toString());
+				db.execSQL("DROP TABLE tmp_" + TABLE_VPNPROFILE + ";");
+				db.setTransactionSuccessful();
+			}
+			finally
+			{
+				db.endTransaction();
+			}
+		}
+	}
+
+	/**
+	 * Construct a new VPN profile data source. The context is used to
+	 * open/create the database.
+	 *
+	 * @param context context used to access the database
+	 */
+	public VpnProfileSqlDataSource(Context context)
+	{
+		this.mContext = context;
+	}
+
+	@Override
+	public VpnProfileDataSource open() throws SQLException
+	{
+		if (mDbHelper == null)
+		{
+			mDbHelper = new DatabaseHelper(mContext);
+			mDatabase = mDbHelper.getWritableDatabase();
+		}
+		return this;
+	}
+
+	@Override
+	public void close()
+	{
+		if (mDbHelper != null)
+		{
+			mDbHelper.close();
+			mDbHelper = null;
+		}
+	}
+
+	@Override
+	public VpnProfile insertProfile(VpnProfile profile)
+	{
+		ContentValues values = ContentValuesFromVpnProfile(profile);
+		long insertId = mDatabase.insert(TABLE_VPNPROFILE, null, values);
+		if (insertId == -1)
+		{
+			return null;
+		}
+		profile.setId(insertId);
+		return profile;
+	}
+
+	@Override
+	public boolean updateVpnProfile(VpnProfile profile)
+	{
+		long id = profile.getId();
+		ContentValues values = ContentValuesFromVpnProfile(profile);
+		return mDatabase.update(TABLE_VPNPROFILE, values, KEY_ID + " = " + id, null) > 0;
+	}
+
+	@Override
+	public boolean deleteVpnProfile(VpnProfile profile)
+	{
+		long id = profile.getId();
+		return mDatabase.delete(TABLE_VPNPROFILE, KEY_ID + " = " + id, null) > 0;
+	}
+
+	@Override
+	public VpnProfile getVpnProfile(long id)
+	{
+		VpnProfile profile = null;
+		Cursor cursor = mDatabase.query(TABLE_VPNPROFILE, ALL_COLUMNS,
+		                                KEY_ID + "=" + id, null, null, null, null);
+		if (cursor.moveToFirst())
+		{
+			profile = VpnProfileFromCursor(cursor);
+		}
+		cursor.close();
+		return profile;
+	}
+
+	@Override
+	public VpnProfile getVpnProfile(UUID uuid)
+	{
+		VpnProfile profile = null;
+		Cursor cursor = mDatabase.query(TABLE_VPNPROFILE, ALL_COLUMNS,
+		                                KEY_UUID + "='" + uuid.toString() + "'", null, null, null, null);
+		if (cursor.moveToFirst())
+		{
+			profile = VpnProfileFromCursor(cursor);
+		}
+		cursor.close();
+		return profile;
+	}
+
+	@Override
+	public VpnProfile getVpnProfile(String uuid)
+	{
+		try
+		{
+			if (uuid != null)
+			{
+				return getVpnProfile(UUID.fromString(uuid));
+			}
+			return null;
+		}
+		catch (IllegalArgumentException e)
+		{
+			e.printStackTrace();
+			return null;
+		}
+	}
+
+	@Override
+	public List<VpnProfile> getAllVpnProfiles()
+	{
+		List<VpnProfile> vpnProfiles = new ArrayList<VpnProfile>();
+
+		Cursor cursor = mDatabase.query(TABLE_VPNPROFILE, ALL_COLUMNS, null, null, null, null, null);
+		cursor.moveToFirst();
+		while (!cursor.isAfterLast())
+		{
+			VpnProfile vpnProfile = VpnProfileFromCursor(cursor);
+			vpnProfiles.add(vpnProfile);
+			cursor.moveToNext();
+		}
+		cursor.close();
+		return vpnProfiles;
+	}
+
+	private VpnProfile VpnProfileFromCursor(Cursor cursor)
+	{
+		VpnProfile profile = new VpnProfile();
+		profile.setId(cursor.getLong(cursor.getColumnIndexOrThrow(KEY_ID)));
+		profile.setUUID(UUID.fromString(cursor.getString(cursor.getColumnIndexOrThrow(KEY_UUID))));
+		profile.setName(cursor.getString(cursor.getColumnIndexOrThrow(KEY_NAME)));
+		profile.setGateway(cursor.getString(cursor.getColumnIndexOrThrow(KEY_GATEWAY)));
+		profile.setVpnType(VpnType.fromIdentifier(cursor.getString(cursor.getColumnIndexOrThrow(KEY_VPN_TYPE))));
+		profile.setUsername(cursor.getString(cursor.getColumnIndexOrThrow(KEY_USERNAME)));
+		profile.setPassword(cursor.getString(cursor.getColumnIndexOrThrow(KEY_PASSWORD)));
+		profile.setCertificateAlias(cursor.getString(cursor.getColumnIndexOrThrow(KEY_CERTIFICATE)));
+		profile.setUserCertificateAlias(cursor.getString(cursor.getColumnIndexOrThrow(KEY_USER_CERTIFICATE)));
+		profile.setMTU(getInt(cursor, cursor.getColumnIndexOrThrow(KEY_MTU)));
+		profile.setPort(getInt(cursor, cursor.getColumnIndexOrThrow(KEY_PORT)));
+		profile.setSplitTunneling(getInt(cursor, cursor.getColumnIndexOrThrow(KEY_SPLIT_TUNNELING)));
+		profile.setLocalId(cursor.getString(cursor.getColumnIndexOrThrow(KEY_LOCAL_ID)));
+		profile.setRemoteId(cursor.getString(cursor.getColumnIndexOrThrow(KEY_REMOTE_ID)));
+		profile.setExcludedSubnets(cursor.getString(cursor.getColumnIndexOrThrow(KEY_EXCLUDED_SUBNETS)));
+		profile.setIncludedSubnets(cursor.getString(cursor.getColumnIndexOrThrow(KEY_INCLUDED_SUBNETS)));
+		profile.setSelectedAppsHandling(getInt(cursor, cursor.getColumnIndexOrThrow(KEY_SELECTED_APPS)));
+		profile.setSelectedApps(cursor.getString(cursor.getColumnIndexOrThrow(KEY_SELECTED_APPS_LIST)));
+		profile.setNATKeepAlive(getInt(cursor, cursor.getColumnIndexOrThrow(KEY_NAT_KEEPALIVE)));
+		profile.setFlags(getInt(cursor, cursor.getColumnIndexOrThrow(KEY_FLAGS)));
+		profile.setIkeProposal(cursor.getString(cursor.getColumnIndexOrThrow(KEY_IKE_PROPOSAL)));
+		profile.setEspProposal(cursor.getString(cursor.getColumnIndexOrThrow(KEY_ESP_PROPOSAL)));
+		profile.setDnsServers(cursor.getString(cursor.getColumnIndexOrThrow(KEY_DNS_SERVERS)));
+		return profile;
+	}
+
+	private ContentValues ContentValuesFromVpnProfile(VpnProfile profile)
+	{
+		ContentValues values = new ContentValues();
+		values.put(KEY_UUID, profile.getUUID().toString());
+		values.put(KEY_NAME, profile.getName());
+		values.put(KEY_GATEWAY, profile.getGateway());
+		values.put(KEY_VPN_TYPE, profile.getVpnType().getIdentifier());
+		values.put(KEY_USERNAME, profile.getUsername());
+		values.put(KEY_PASSWORD, profile.getPassword());
+		values.put(KEY_CERTIFICATE, profile.getCertificateAlias());
+		values.put(KEY_USER_CERTIFICATE, profile.getUserCertificateAlias());
+		values.put(KEY_MTU, profile.getMTU());
+		values.put(KEY_PORT, profile.getPort());
+		values.put(KEY_SPLIT_TUNNELING, profile.getSplitTunneling());
+		values.put(KEY_LOCAL_ID, profile.getLocalId());
+		values.put(KEY_REMOTE_ID, profile.getRemoteId());
+		values.put(KEY_EXCLUDED_SUBNETS, profile.getExcludedSubnets());
+		values.put(KEY_INCLUDED_SUBNETS, profile.getIncludedSubnets());
+		values.put(KEY_SELECTED_APPS, profile.getSelectedAppsHandling().getValue());
+		values.put(KEY_SELECTED_APPS_LIST, profile.getSelectedApps());
+		values.put(KEY_NAT_KEEPALIVE, profile.getNATKeepAlive());
+		values.put(KEY_FLAGS, profile.getFlags());
+		values.put(KEY_IKE_PROPOSAL, profile.getIkeProposal());
+		values.put(KEY_ESP_PROPOSAL, profile.getEspProposal());
+		values.put(KEY_DNS_SERVERS, profile.getDnsServers());
+		return values;
+	}
+
+	private Integer getInt(Cursor cursor, int columnIndex)
+	{
+		return cursor.isNull(columnIndex) ? null : cursor.getInt(columnIndex);
+	}
+
+	private static class DbColumn
+	{
+		public final String Name;
+		public final String Type;
+		public final Integer Since;
+
+		public DbColumn(String name, String type, Integer since)
+		{
+			Name = name;
+			Type = type;
+			Since = since;
+		}
+	}
+}

--- a/src/frontends/android/app/src/main/java/org/strongswan/android/data/VpnProfileSqlDataSource.java
+++ b/src/frontends/android/app/src/main/java/org/strongswan/android/data/VpnProfileSqlDataSource.java
@@ -24,15 +24,17 @@ import android.database.Cursor;
 import android.database.SQLException;
 import android.database.sqlite.SQLiteDatabase;
 
+import org.strongswan.android.logic.StrongSwanApplication;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 
 public class VpnProfileSqlDataSource implements VpnProfileDataSource
 {
-	private DatabaseHelper mDbHelper;
+	private final DatabaseHelper mDbHelper;
+
 	private SQLiteDatabase mDatabase;
-	private final Context mContext;
 
 	/**
 	 * Construct a new VPN profile data source. The context is used to
@@ -42,15 +44,15 @@ public class VpnProfileSqlDataSource implements VpnProfileDataSource
 	 */
 	public VpnProfileSqlDataSource(Context context)
 	{
-		this.mContext = context;
+		final Context applicationContext = context.getApplicationContext();
+		mDbHelper = ((StrongSwanApplication)applicationContext).getDatabaseHelper();
 	}
 
 	@Override
 	public VpnProfileDataSource open() throws SQLException
 	{
-		if (mDbHelper == null)
+		if (mDatabase == null)
 		{
-			mDbHelper = new DatabaseHelper(mContext);
 			mDatabase = mDbHelper.getWritableDatabase();
 		}
 		return this;
@@ -59,10 +61,9 @@ public class VpnProfileSqlDataSource implements VpnProfileDataSource
 	@Override
 	public void close()
 	{
-		if (mDbHelper != null)
+		if (mDatabase != null)
 		{
-			mDbHelper.close();
-			mDbHelper = null;
+			mDatabase = null;
 		}
 	}
 

--- a/src/frontends/android/app/src/main/java/org/strongswan/android/data/VpnProfileSqlDataSource.java
+++ b/src/frontends/android/app/src/main/java/org/strongswan/android/data/VpnProfileSqlDataSource.java
@@ -70,7 +70,7 @@ public class VpnProfileSqlDataSource implements VpnProfileDataSource
 	public VpnProfile insertProfile(VpnProfile profile)
 	{
 		ContentValues values = ContentValuesFromVpnProfile(profile);
-		long insertId = mDatabase.insert(DatabaseHelper.TABLE_VPNPROFILE, null, values);
+		long insertId = mDatabase.insert(DatabaseHelper.TABLE_VPN_PROFILE.Name, null, values);
 		if (insertId == -1)
 		{
 			return null;
@@ -85,22 +85,22 @@ public class VpnProfileSqlDataSource implements VpnProfileDataSource
 	{
 		final UUID uuid = profile.getUUID();
 		ContentValues values = ContentValuesFromVpnProfile(profile);
-		return mDatabase.update(DatabaseHelper.TABLE_VPNPROFILE, values, KEY_UUID + " = ?", new String[]{uuid.toString()}) > 0;
+		return mDatabase.update(DatabaseHelper.TABLE_VPN_PROFILE.Name, values, KEY_UUID + " = ?", new String[]{uuid.toString()}) > 0;
 	}
 
 	@Override
 	public boolean deleteVpnProfile(VpnProfile profile)
 	{
 		final UUID uuid = profile.getUUID();
-		return mDatabase.delete(DatabaseHelper.TABLE_VPNPROFILE, KEY_UUID + " = ?", new String[]{uuid.toString()}) > 0;
+		return mDatabase.delete(DatabaseHelper.TABLE_VPN_PROFILE.Name, KEY_UUID + " = ?", new String[]{uuid.toString()}) > 0;
 	}
 
 	@Override
 	public VpnProfile getVpnProfile(UUID uuid)
 	{
 		VpnProfile profile = null;
-		Cursor cursor = mDatabase.query(DatabaseHelper.TABLE_VPNPROFILE, mDbHelper.getAllColumns(),
-		                                KEY_UUID + " = ?", new String[]{uuid.toString()}, null, null, null);
+		DatabaseHelper.DbTable table = DatabaseHelper.TABLE_VPN_PROFILE;
+		Cursor cursor = mDatabase.query(table.Name, table.columnNames(), KEY_UUID + " = ?", new String[]{uuid.toString()}, null, null, null);
 		if (cursor.moveToFirst())
 		{
 			profile = VpnProfileFromCursor(cursor);
@@ -115,7 +115,8 @@ public class VpnProfileSqlDataSource implements VpnProfileDataSource
 	{
 		List<VpnProfile> vpnProfiles = new ArrayList<>();
 
-		Cursor cursor = mDatabase.query(DatabaseHelper.TABLE_VPNPROFILE, mDbHelper.getAllColumns(), null, null, null, null, null);
+		DatabaseHelper.DbTable table = DatabaseHelper.TABLE_VPN_PROFILE;
+		Cursor cursor = mDatabase.query(table.Name, table.columnNames(), null, null, null, null, null);
 		cursor.moveToFirst();
 		while (!cursor.isAfterLast())
 		{

--- a/src/frontends/android/app/src/main/java/org/strongswan/android/data/VpnProfileSqlDataSource.java
+++ b/src/frontends/android/app/src/main/java/org/strongswan/android/data/VpnProfileSqlDataSource.java
@@ -291,6 +291,7 @@ public class VpnProfileSqlDataSource implements VpnProfileDataSource
 		{
 			return null;
 		}
+		profile.setDataSource(this);
 		profile.setId(insertId);
 		return profile;
 	}
@@ -319,6 +320,7 @@ public class VpnProfileSqlDataSource implements VpnProfileDataSource
 		if (cursor.moveToFirst())
 		{
 			profile = VpnProfileFromCursor(cursor);
+			profile.setDataSource(this);
 		}
 		cursor.close();
 		return profile;
@@ -333,6 +335,7 @@ public class VpnProfileSqlDataSource implements VpnProfileDataSource
 		if (cursor.moveToFirst())
 		{
 			profile = VpnProfileFromCursor(cursor);
+			profile.setDataSource(this);
 		}
 		cursor.close();
 		return profile;
@@ -348,6 +351,7 @@ public class VpnProfileSqlDataSource implements VpnProfileDataSource
 		while (!cursor.isAfterLast())
 		{
 			VpnProfile vpnProfile = VpnProfileFromCursor(cursor);
+			vpnProfile.setDataSource(this);
 			vpnProfiles.add(vpnProfile);
 			cursor.moveToNext();
 		}

--- a/src/frontends/android/app/src/main/java/org/strongswan/android/data/VpnProfileSqlDataSource.java
+++ b/src/frontends/android/app/src/main/java/org/strongswan/android/data/VpnProfileSqlDataSource.java
@@ -299,31 +299,16 @@ public class VpnProfileSqlDataSource implements VpnProfileDataSource
 	@Override
 	public boolean updateVpnProfile(VpnProfile profile)
 	{
-		long id = profile.getId();
+		final UUID uuid = profile.getUUID();
 		ContentValues values = ContentValuesFromVpnProfile(profile);
-		return mDatabase.update(TABLE_VPNPROFILE, values, KEY_ID + " = " + id, null) > 0;
+		return mDatabase.update(TABLE_VPNPROFILE, values, KEY_UUID + " = ?", new String[]{uuid.toString()}) > 0;
 	}
 
 	@Override
 	public boolean deleteVpnProfile(VpnProfile profile)
 	{
-		long id = profile.getId();
-		return mDatabase.delete(TABLE_VPNPROFILE, KEY_ID + " = " + id, null) > 0;
-	}
-
-	@Override
-	public VpnProfile getVpnProfile(long id)
-	{
-		VpnProfile profile = null;
-		Cursor cursor = mDatabase.query(TABLE_VPNPROFILE, ALL_COLUMNS,
-		                                KEY_ID + "=" + id, null, null, null, null);
-		if (cursor.moveToFirst())
-		{
-			profile = VpnProfileFromCursor(cursor);
-			profile.setDataSource(this);
-		}
-		cursor.close();
-		return profile;
+		final UUID uuid = profile.getUUID();
+		return mDatabase.delete(TABLE_VPNPROFILE, KEY_UUID + " = ?", new String[]{uuid.toString()}) > 0;
 	}
 
 	@Override
@@ -331,7 +316,7 @@ public class VpnProfileSqlDataSource implements VpnProfileDataSource
 	{
 		VpnProfile profile = null;
 		Cursor cursor = mDatabase.query(TABLE_VPNPROFILE, ALL_COLUMNS,
-		                                KEY_UUID + "='" + uuid.toString() + "'", null, null, null, null);
+		                                KEY_UUID + " = ?", new String[]{uuid.toString()}, null, null, null);
 		if (cursor.moveToFirst())
 		{
 			profile = VpnProfileFromCursor(cursor);
@@ -362,7 +347,6 @@ public class VpnProfileSqlDataSource implements VpnProfileDataSource
 	private VpnProfile VpnProfileFromCursor(Cursor cursor)
 	{
 		VpnProfile profile = new VpnProfile();
-		profile.setId(cursor.getLong(cursor.getColumnIndexOrThrow(KEY_ID)));
 		profile.setUUID(UUID.fromString(cursor.getString(cursor.getColumnIndexOrThrow(KEY_UUID))));
 		profile.setName(cursor.getString(cursor.getColumnIndexOrThrow(KEY_NAME)));
 		profile.setGateway(cursor.getString(cursor.getColumnIndexOrThrow(KEY_GATEWAY)));

--- a/src/frontends/android/app/src/main/java/org/strongswan/android/data/VpnProfileSqlDataSource.java
+++ b/src/frontends/android/app/src/main/java/org/strongswan/android/data/VpnProfileSqlDataSource.java
@@ -339,24 +339,6 @@ public class VpnProfileSqlDataSource implements VpnProfileDataSource
 	}
 
 	@Override
-	public VpnProfile getVpnProfile(String uuid)
-	{
-		try
-		{
-			if (uuid != null)
-			{
-				return getVpnProfile(UUID.fromString(uuid));
-			}
-			return null;
-		}
-		catch (IllegalArgumentException e)
-		{
-			e.printStackTrace();
-			return null;
-		}
-	}
-
-	@Override
 	public List<VpnProfile> getAllVpnProfiles()
 	{
 		List<VpnProfile> vpnProfiles = new ArrayList<VpnProfile>();

--- a/src/frontends/android/app/src/main/java/org/strongswan/android/data/VpnType.java
+++ b/src/frontends/android/app/src/main/java/org/strongswan/android/data/VpnType.java
@@ -17,6 +17,10 @@
 package org.strongswan.android.data;
 
 import java.util.EnumSet;
+import java.util.Objects;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 public enum VpnType
 {
@@ -32,11 +36,17 @@ public enum VpnType
 	 */
 	public enum VpnTypeFeature
 	{
-		/** client certificate is required */
+		/**
+		 * client certificate is required
+		 */
 		CERTIFICATE,
-		/** username and password are required */
+		/**
+		 * username and password are required
+		 */
 		USER_PASS,
-		/** enable BYOD features */
+		/**
+		 * enable BYOD features
+		 */
 		BYOD;
 	}
 
@@ -58,6 +68,7 @@ public enum VpnType
 
 	/**
 	 * The identifier used to store this value in the database
+	 *
 	 * @return identifier
 	 */
 	public String getIdentifier()
@@ -81,11 +92,12 @@ public enum VpnType
 	 * @param identifier get the enum entry with this identifier
 	 * @return the enum entry, or the default if not found
 	 */
-	public static VpnType fromIdentifier(String identifier)
+	@NonNull
+	public static VpnType fromIdentifier(@Nullable String identifier)
 	{
 		for (VpnType type : VpnType.values())
 		{
-			if (identifier.equals(type.mIdentifier))
+			if (Objects.equals(identifier, type.mIdentifier))
 			{
 				return type;
 			}

--- a/src/frontends/android/app/src/main/java/org/strongswan/android/logic/CaCertificateInstaller.java
+++ b/src/frontends/android/app/src/main/java/org/strongswan/android/logic/CaCertificateInstaller.java
@@ -1,0 +1,74 @@
+package org.strongswan.android.logic;
+
+import android.app.admin.DevicePolicyManager;
+import android.content.Context;
+import android.util.Log;
+
+import org.strongswan.android.data.CaCertificate;
+import org.strongswan.android.utils.Certificates;
+
+import java.io.IOException;
+import java.security.KeyStore;
+import java.security.KeyStoreException;
+import java.security.NoSuchAlgorithmException;
+import java.security.cert.CertificateException;
+import java.security.cert.X509Certificate;
+
+import androidx.annotation.NonNull;
+
+public class CaCertificateInstaller
+{
+	private static final String TAG = CaCertificateInstaller.class.getSimpleName();
+
+	@NonNull
+	private final DevicePolicyManager policyManager;
+
+	public CaCertificateInstaller(@NonNull final Context context)
+	{
+		this.policyManager = (DevicePolicyManager)context.getSystemService(Context.DEVICE_POLICY_SERVICE);
+	}
+
+	private boolean installCaCert(@NonNull CaCertificate caCertificate)
+		throws CertificateException, IOException, KeyStoreException, NoSuchAlgorithmException
+	{
+		final X509Certificate certificate = Certificates.from(caCertificate);
+
+		KeyStore store = KeyStore.getInstance("LocalCertificateStore");
+		store.load(null, null);
+		store.setCertificateEntry(caCertificate.getAlias(), certificate);
+		caCertificate.setEffectiveAlias(store.getCertificateAlias(certificate));
+		return true;
+	}
+
+	private void uninstallCaCert(@NonNull CaCertificate caCertificate)
+		throws CertificateException, IOException
+	{
+		final X509Certificate certificate = Certificates.from(caCertificate);
+		policyManager.uninstallCaCert(null, certificate.getEncoded());
+	}
+
+	public synchronized boolean tryInstall(@NonNull CaCertificate caCertificate)
+	{
+		try
+		{
+			return installCaCert(caCertificate);
+		}
+		catch (final Exception e)
+		{
+			Log.e(TAG, "Could not install CA certificate " + caCertificate.getAlias(), e);
+			return false;
+		}
+	}
+
+	public synchronized void tryRemove(@NonNull CaCertificate caCertificate)
+	{
+		try
+		{
+			uninstallCaCert(caCertificate);
+		}
+		catch (final Exception e)
+		{
+			Log.e(TAG, "Could not remove CA certificate " + caCertificate.getAlias(), e);
+		}
+	}
+}

--- a/src/frontends/android/app/src/main/java/org/strongswan/android/logic/CaCertificateInstaller.java
+++ b/src/frontends/android/app/src/main/java/org/strongswan/android/logic/CaCertificateInstaller.java
@@ -31,18 +31,23 @@ public class CaCertificateInstaller
 	private boolean installCaCert(@NonNull CaCertificate caCertificate)
 		throws CertificateException, IOException, KeyStoreException, NoSuchAlgorithmException
 	{
+		Log.d(TAG, "Install CA certificate " + caCertificate);
 		final X509Certificate certificate = Certificates.from(caCertificate);
 
 		KeyStore store = KeyStore.getInstance("LocalCertificateStore");
 		store.load(null, null);
 		store.setCertificateEntry(caCertificate.getAlias(), certificate);
-		caCertificate.setEffectiveAlias(store.getCertificateAlias(certificate));
+		String alias = store.getCertificateAlias(certificate);
+
+		Log.w(TAG, "Set effective alias of certificate '" + caCertificate.getConfiguredAlias() + "' to '" + alias + "'");
+		caCertificate.setEffectiveAlias(alias);
 		return true;
 	}
 
 	private void uninstallCaCert(@NonNull CaCertificate caCertificate)
 		throws CertificateException, IOException
 	{
+		Log.d(TAG, "Remove CA certificate " + caCertificate);
 		final X509Certificate certificate = Certificates.from(caCertificate);
 		policyManager.uninstallCaCert(null, certificate.getEncoded());
 	}
@@ -55,7 +60,7 @@ public class CaCertificateInstaller
 		}
 		catch (final Exception e)
 		{
-			Log.e(TAG, "Could not install CA certificate " + caCertificate.getAlias(), e);
+			Log.e(TAG, "Could not install CA certificate " + caCertificate, e);
 			return false;
 		}
 	}
@@ -68,7 +73,7 @@ public class CaCertificateInstaller
 		}
 		catch (final Exception e)
 		{
-			Log.e(TAG, "Could not remove CA certificate " + caCertificate.getAlias(), e);
+			Log.e(TAG, "Could not remove CA certificate " + caCertificate, e);
 		}
 	}
 }

--- a/src/frontends/android/app/src/main/java/org/strongswan/android/logic/CaCertificateManager.java
+++ b/src/frontends/android/app/src/main/java/org/strongswan/android/logic/CaCertificateManager.java
@@ -58,9 +58,9 @@ public class CaCertificateManager
 			}
 			Log.d(TAG, "CA certificates changed " + diff);
 
-			for (final CaCertificate insert : diff.getInserts())
+			for (final CaCertificate delete : diff.getDeletes())
 			{
-				install(insert);
+				remove(delete);
 			}
 
 			for (final Pair<CaCertificate, CaCertificate> update : diff.getUpdates())
@@ -69,9 +69,9 @@ public class CaCertificateManager
 				install(update.second);
 			}
 
-			for (final CaCertificate delete : diff.getDeletes())
+			for (final CaCertificate insert : diff.getInserts())
 			{
-				remove(delete);
+				install(insert);
 			}
 
 			TrustedCertificateManager.getInstance().reset();

--- a/src/frontends/android/app/src/main/java/org/strongswan/android/logic/CaCertificateManager.java
+++ b/src/frontends/android/app/src/main/java/org/strongswan/android/logic/CaCertificateManager.java
@@ -1,0 +1,91 @@
+package org.strongswan.android.logic;
+
+import android.content.Context;
+import android.os.Handler;
+
+import org.strongswan.android.data.CaCertificate;
+import org.strongswan.android.data.CaCertificateRepository;
+import org.strongswan.android.data.DatabaseHelper;
+import org.strongswan.android.data.ManagedConfigurationService;
+import org.strongswan.android.utils.Difference;
+
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+
+import androidx.annotation.NonNull;
+import androidx.core.util.Pair;
+
+public class CaCertificateManager
+{
+	@NonNull
+	private final ExecutorService executorService;
+	@NonNull
+	private final Handler handler;
+
+	@NonNull
+	private final CaCertificateRepository caCertificateRepository;
+	@NonNull
+	private final CaCertificateInstaller caCertificateInstaller;
+
+	public CaCertificateManager(
+		@NonNull final Context context,
+		@NonNull final ExecutorService executorService,
+		@NonNull final Handler handler,
+		@NonNull final ManagedConfigurationService managedConfigurationService,
+		@NonNull final DatabaseHelper databaseHelper)
+	{
+		this.executorService = executorService;
+		this.handler = handler;
+
+		this.caCertificateRepository = new CaCertificateRepository(managedConfigurationService, databaseHelper);
+		this.caCertificateInstaller = new CaCertificateInstaller(context);
+	}
+
+	public void update(@NonNull final Runnable onUpdateCompleted)
+	{
+		executorService.execute(() -> {
+			final List<CaCertificate> configured = caCertificateRepository.getConfiguredCertificates();
+			final List<CaCertificate> installed = caCertificateRepository.getInstalledCertificates();
+
+			final Difference<CaCertificate> diff = Difference.between(installed, configured, CaCertificate::getVpnProfileUuid);
+			if (diff.isEmpty())
+			{
+				return;
+			}
+
+			for (final CaCertificate insert : diff.getInserts())
+			{
+				install(insert);
+			}
+
+			for (final Pair<CaCertificate, CaCertificate> update : diff.getUpdates())
+			{
+				remove(update.first);
+				install(update.second);
+			}
+
+			for (final CaCertificate delete : diff.getDeletes())
+			{
+				remove(delete);
+			}
+
+			TrustedCertificateManager.getInstance().reset();
+			TrustedCertificateManager.getInstance().load();
+			handler.post(onUpdateCompleted);
+		});
+	}
+
+	private void install(@NonNull final CaCertificate caCertificate)
+	{
+		if (caCertificateInstaller.tryInstall(caCertificate))
+		{
+			caCertificateRepository.addInstalledCertificate(caCertificate);
+		}
+	}
+
+	private void remove(@NonNull final CaCertificate caCertificate)
+	{
+		caCertificateInstaller.tryRemove(caCertificate);
+		caCertificateRepository.removeInstalledCertificate(caCertificate);
+	}
+}

--- a/src/frontends/android/app/src/main/java/org/strongswan/android/logic/CaCertificateManager.java
+++ b/src/frontends/android/app/src/main/java/org/strongswan/android/logic/CaCertificateManager.java
@@ -2,6 +2,7 @@ package org.strongswan.android.logic;
 
 import android.content.Context;
 import android.os.Handler;
+import android.util.Log;
 
 import org.strongswan.android.data.CaCertificate;
 import org.strongswan.android.data.CaCertificateRepository;
@@ -17,6 +18,8 @@ import androidx.core.util.Pair;
 
 public class CaCertificateManager
 {
+	private static final String TAG = CaCertificateManager.class.getSimpleName();
+
 	@NonNull
 	private final ExecutorService executorService;
 	@NonNull
@@ -50,8 +53,10 @@ public class CaCertificateManager
 			final Difference<CaCertificate> diff = Difference.between(installed, configured, CaCertificate::getVpnProfileUuid);
 			if (diff.isEmpty())
 			{
+				Log.d(TAG, "No CA certificates changed, nothing to do");
 				return;
 			}
+			Log.d(TAG, "CA certificates changed " + diff);
 
 			for (final CaCertificate insert : diff.getInserts())
 			{

--- a/src/frontends/android/app/src/main/java/org/strongswan/android/logic/CharonVpnService.java
+++ b/src/frontends/android/app/src/main/java/org/strongswan/android/logic/CharonVpnService.java
@@ -462,7 +462,7 @@ public class CharonVpnService extends VpnService implements Runnable, VpnStateSe
 				Intent intent = new Intent(getApplicationContext(), VpnProfileControlActivity.class);
 				intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
 				intent.setAction(VpnProfileControlActivity.START_PROFILE);
-				intent.putExtra(VpnProfileControlActivity.EXTRA_VPN_PROFILE_ID, profile.getUUID().toString());
+				intent.putExtra(VpnProfileControlActivity.EXTRA_VPN_PROFILE_UUID, profile.getUUID().toString());
 				int flags = PendingIntent.FLAG_UPDATE_CURRENT;
 				if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M)
 				{

--- a/src/frontends/android/app/src/main/java/org/strongswan/android/logic/CharonVpnService.java
+++ b/src/frontends/android/app/src/main/java/org/strongswan/android/logic/CharonVpnService.java
@@ -1037,9 +1037,8 @@ public class CharonVpnService extends VpnService implements Runnable, VpnStateSe
 			@Override
 			public synchronized void run()
 			{
-				try
+				try (FileInputStream plain = new FileInputStream(mFd.getFileDescriptor()))
 				{
-					FileInputStream plain = new FileInputStream(mFd.getFileDescriptor());
 					ByteBuffer packet = ByteBuffer.allocate(mCache.mMtu);
 					while (true)
 					{
@@ -1073,7 +1072,7 @@ public class CharonVpnService extends VpnService implements Runnable, VpnStateSe
 						}
 					}
 				}
-				catch (ClosedByInterruptException | InterruptedException e)
+				catch (final ClosedByInterruptException | InterruptedException e)
 				{
 					/* regular interruption */
 				}

--- a/src/frontends/android/app/src/main/java/org/strongswan/android/logic/CharonVpnService.java
+++ b/src/frontends/android/app/src/main/java/org/strongswan/android/logic/CharonVpnService.java
@@ -750,18 +750,19 @@ public class CharonVpnService extends VpnService implements Runnable, VpnStateSe
 	 * to call methods on KeyChain directly.
 	 *
 	 * @return list containing the certificates (first element is the user certificate)
-	 * @throws InterruptedException
-	 * @throws KeyChainException
 	 * @throws CertificateEncodingException
 	 */
-	private byte[][] getUserCertificate() throws KeyChainException, InterruptedException, CertificateEncodingException
+	private byte[][] getUserCertificate() throws CertificateEncodingException
 	{
-		ArrayList<byte[]> encodings = new ArrayList<byte[]>();
-		X509Certificate[] chain = KeyChain.getCertificateChain(getApplicationContext(), mCurrentUserCertificateAlias);
+		final UserCertificateLoader loader = new UserCertificateLoader(getApplicationContext());
+		X509Certificate[] chain = loader.loadCertificateChain(mCurrentUserCertificateAlias);
+
 		if (chain == null || chain.length == 0)
 		{
 			return null;
 		}
+
+		ArrayList<byte[]> encodings = new ArrayList<>();
 		for (X509Certificate cert : chain)
 		{
 			encodings.add(cert.getEncoded());

--- a/src/frontends/android/app/src/main/java/org/strongswan/android/logic/CharonVpnService.java
+++ b/src/frontends/android/app/src/main/java/org/strongswan/android/logic/CharonVpnService.java
@@ -1236,7 +1236,6 @@ public class CharonVpnService extends VpnService implements Runnable, VpnStateSe
 			}
 		}
 
-		@TargetApi(Build.VERSION_CODES.LOLLIPOP)
 		public void applyData(VpnService.Builder builder)
 		{
 			for (IPRange address : mAddresses)

--- a/src/frontends/android/app/src/main/java/org/strongswan/android/logic/CharonVpnService.java
+++ b/src/frontends/android/app/src/main/java/org/strongswan/android/logic/CharonVpnService.java
@@ -45,6 +45,7 @@ import org.strongswan.android.R;
 import org.strongswan.android.data.VpnProfile;
 import org.strongswan.android.data.VpnProfile.SelectedAppsHandling;
 import org.strongswan.android.data.VpnProfileDataSource;
+import org.strongswan.android.data.VpnProfileSource;
 import org.strongswan.android.data.VpnType.VpnTypeFeature;
 import org.strongswan.android.logic.VpnStateService.ErrorState;
 import org.strongswan.android.logic.VpnStateService.State;
@@ -196,7 +197,7 @@ public class CharonVpnService extends VpnService implements Runnable, VpnStateSe
 		/* handler used to do changes in the main UI thread */
 		mHandler = new Handler(getMainLooper());
 
-		mDataSource = new VpnProfileDataSource(this);
+		mDataSource = new VpnProfileSource(this);
 		mDataSource.open();
 		/* use a separate thread as main thread for charon */
 		mConnectionHandler = new Thread(this);

--- a/src/frontends/android/app/src/main/java/org/strongswan/android/logic/CharonVpnService.java
+++ b/src/frontends/android/app/src/main/java/org/strongswan/android/logic/CharonVpnService.java
@@ -101,14 +101,15 @@ public class CharonVpnService extends VpnService implements Runnable, VpnStateSe
 	private volatile boolean mTerminate;
 	private volatile boolean mIsDisconnecting;
 	private volatile boolean mShowNotification;
-	private BuilderAdapter mBuilderAdapter = new BuilderAdapter();
+	private final BuilderAdapter mBuilderAdapter = new BuilderAdapter();
 	private Handler mHandler;
 	private VpnStateService mService;
 	private final Object mServiceLock = new Object();
-	private final ServiceConnection mServiceConnection = new ServiceConnection() {
+	private final ServiceConnection mServiceConnection = new ServiceConnection()
+	{
 		@Override
 		public void onServiceDisconnected(ComponentName name)
-		{	/* since the service is local this is theoretically only called when the process is terminated */
+		{    /* since the service is local this is theoretically only called when the process is terminated */
 			synchronized (mServiceLock)
 			{
 				mService = null;
@@ -149,7 +150,7 @@ public class CharonVpnService extends VpnService implements Runnable, VpnStateSe
 			boolean retry = false;
 
 			if (VPN_SERVICE_ACTION.equals(intent.getAction()))
-			{	/* triggered when Always-on VPN is activated */
+			{    /* triggered when Always-on VPN is activated */
 				SharedPreferences pref = PreferenceManager.getDefaultSharedPreferences(this);
 				String uuid = pref.getString(Constants.PREF_DEFAULT_VPN_PROFILE, null);
 				if (uuid == null || uuid.equals(Constants.PREF_DEFAULT_VPN_PROFILE_MRU))
@@ -178,7 +179,7 @@ public class CharonVpnService extends VpnService implements Runnable, VpnStateSe
 				}
 			}
 			if (profile != null && !retry)
-			{	/* delete the log file if this is not an automatic retry */
+			{    /* delete the log file if this is not an automatic retry */
 				deleteFile(LOG_FILE);
 			}
 			setNextProfile(profile);
@@ -201,15 +202,15 @@ public class CharonVpnService extends VpnService implements Runnable, VpnStateSe
 		mConnectionHandler = new Thread(this);
 		/* the thread is started when the service is bound */
 		bindService(new Intent(this, VpnStateService.class),
-					mServiceConnection, Service.BIND_AUTO_CREATE);
+		            mServiceConnection, Service.BIND_AUTO_CREATE);
 
 		createNotificationChannel();
 	}
 
 	@Override
 	public void onRevoke()
-	{	/* the system revoked the rights grated with the initial prepare() call.
-		 * called when the user clicks disconnect in the system's VPN dialog */
+	{    /* the system revoked the rights grated with the initial prepare() call.
+	 * called when the user clicks disconnect in the system's VPN dialog */
 		setNextProfile(null);
 	}
 
@@ -290,13 +291,13 @@ public class CharonVpnService extends VpnService implements Runnable, VpnStateSe
 						addNotification();
 						mBuilderAdapter.setProfile(mCurrentProfile);
 						if (initializeCharon(mBuilderAdapter, mLogFile, mAppDir, mCurrentProfile.getVpnType().has(VpnTypeFeature.BYOD),
-											(mCurrentProfile.getFlags() & VpnProfile.FLAGS_IPv6_TRANSPORT) != 0))
+						                     (mCurrentProfile.getFlags() & VpnProfile.FLAGS_IPv6_TRANSPORT) != 0))
 						{
 							Log.i(TAG, "charon started");
 
 							if (mCurrentProfile.getVpnType().has(VpnTypeFeature.USER_PASS) &&
 								mCurrentProfile.getPassword() == null)
-							{	/* this can happen if Always-on VPN is enabled with an incomplete profile */
+							{    /* this can happen if Always-on VPN is enabled with an incomplete profile */
 								setError(ErrorState.PASSWORD_MISSING);
 								continue;
 							}
@@ -346,7 +347,7 @@ public class CharonVpnService extends VpnService implements Runnable, VpnStateSe
 	{
 		synchronized (this)
 		{
-			if (mNextProfile != null && Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP)
+			if (mNextProfile != null)
 			{
 				mBuilderAdapter.setProfile(mNextProfile);
 				mBuilderAdapter.establishBlocking();
@@ -361,7 +362,7 @@ public class CharonVpnService extends VpnService implements Runnable, VpnStateSe
 				Log.i(TAG, "charon stopped");
 				mCurrentProfile = null;
 				if (mNextProfile == null)
-				{	/* only do this if we are not connecting to another profile */
+				{    /* only do this if we are not connecting to another profile */
 					removeNotification();
 					mBuilderAdapter.closeBlocking();
 				}
@@ -411,7 +412,7 @@ public class CharonVpnService extends VpnService implements Runnable, VpnStateSe
 		{
 			NotificationChannel channel;
 			channel = new NotificationChannel(NOTIFICATION_CHANNEL, getString(R.string.permanent_notification_name),
-											  NotificationManager.IMPORTANCE_LOW);
+			                                  NotificationManager.IMPORTANCE_LOW);
 			channel.setDescription(getString(R.string.permanent_notification_description));
 			channel.setLockscreenVisibility(Notification.VISIBILITY_SECRET);
 			channel.setShowBadge(false);
@@ -437,10 +438,10 @@ public class CharonVpnService extends VpnService implements Runnable, VpnStateSe
 			name = profile.getName();
 		}
 		NotificationCompat.Builder builder = new NotificationCompat.Builder(this, NOTIFICATION_CHANNEL)
-				.setSmallIcon(R.drawable.ic_notification)
-				.setCategory(NotificationCompat.CATEGORY_SERVICE)
-				.setVisibility(publicVersion ? NotificationCompat.VISIBILITY_PUBLIC
-											 : NotificationCompat.VISIBILITY_PRIVATE);
+			.setSmallIcon(R.drawable.ic_notification)
+			.setCategory(NotificationCompat.CATEGORY_SERVICE)
+			.setVisibility(publicVersion ? NotificationCompat.VISIBILITY_PUBLIC
+			                             : NotificationCompat.VISIBILITY_PRIVATE);
 		int s = R.string.state_disabled;
 		if (error != ErrorState.NO_ERROR)
 		{
@@ -467,7 +468,7 @@ public class CharonVpnService extends VpnService implements Runnable, VpnStateSe
 					flags |= PendingIntent.FLAG_IMMUTABLE;
 				}
 				PendingIntent pending = PendingIntent.getActivity(getApplicationContext(), 0, intent,
-																  flags);
+				                                                  flags);
 				builder.addAction(R.drawable.ic_notification_connecting, getString(R.string.retry), pending);
 				add_action = true;
 			}
@@ -509,7 +510,7 @@ public class CharonVpnService extends VpnService implements Runnable, VpnStateSe
 				Intent intent = new Intent(getApplicationContext(), VpnProfileControlActivity.class);
 				intent.setAction(VpnProfileControlActivity.DISCONNECT);
 				PendingIntent pending = PendingIntent.getActivity(getApplicationContext(), 0, intent,
-																  flags);
+				                                                  flags);
 				builder.addAction(R.drawable.ic_notification_disconnect, getString(R.string.disconnect), pending);
 			}
 			if (error == ErrorState.NO_ERROR)
@@ -521,16 +522,17 @@ public class CharonVpnService extends VpnService implements Runnable, VpnStateSe
 
 		Intent intent = new Intent(getApplicationContext(), MainActivity.class);
 		PendingIntent pending = PendingIntent.getActivity(getApplicationContext(), 0, intent,
-														  flags);
+		                                                  flags);
 		builder.setContentIntent(pending);
 		return builder.build();
 	}
 
 	@Override
-	public void stateChanged() {
+	public void stateChanged()
+	{
 		if (mShowNotification)
 		{
-			NotificationManager manager = (NotificationManager) getSystemService(Context.NOTIFICATION_SERVICE);
+			NotificationManager manager = (NotificationManager)getSystemService(Context.NOTIFICATION_SERVICE);
 			manager.notify(VPN_STATE_NOTIFICATION_ID, buildNotification(false));
 		}
 	}
@@ -742,7 +744,7 @@ public class CharonVpnService extends VpnService implements Runnable, VpnStateSe
 	/**
 	 * Function called via JNI to get a list containing the DER encoded certificates
 	 * of the user selected certificate chain (beginning with the user certificate).
-	 *
+	 * <p>
 	 * Since this method is called from a thread of charon's thread pool we are safe
 	 * to call methods on KeyChain directly.
 	 *
@@ -768,7 +770,7 @@ public class CharonVpnService extends VpnService implements Runnable, VpnStateSe
 
 	/**
 	 * Function called via JNI to get the private key the user selected.
-	 *
+	 * <p>
 	 * Since this method is called from a thread of charon's thread pool we are safe
 	 * to call methods on KeyChain directly.
 	 *
@@ -813,7 +815,7 @@ public class CharonVpnService extends VpnService implements Runnable, VpnStateSe
 		private VpnService.Builder mBuilder;
 		private BuilderCache mCache;
 		private BuilderCache mEstablishedCache;
-		private PacketDropper mDropper = new PacketDropper();
+		private final PacketDropper mDropper = new PacketDropper();
 
 		public synchronized void setProfile(VpnProfile profile)
 		{
@@ -1042,7 +1044,7 @@ public class CharonVpnService extends VpnService implements Runnable, VpnStateSe
 					while (true)
 					{
 						if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N)
-						{	/* just read and ignore all data, regular read() is not interruptible */
+						{    /* just read and ignore all data, regular read() is not interruptible */
 							int len = plain.getChannel().read(packet);
 							packet.clear();
 							if (len < 0)
@@ -1051,7 +1053,7 @@ public class CharonVpnService extends VpnService implements Runnable, VpnStateSe
 							}
 						}
 						else
-						{	/* this is rather ugly but on older platforms not even the NIO version of read() is interruptible */
+						{    /* this is rather ugly but on older platforms not even the NIO version of read() is interruptible */
 							boolean wait = true;
 							if (plain.available() > 0)
 							{
@@ -1071,7 +1073,7 @@ public class CharonVpnService extends VpnService implements Runnable, VpnStateSe
 						}
 					}
 				}
-				catch (ClosedByInterruptException|InterruptedException e)
+				catch (ClosedByInterruptException | InterruptedException e)
 				{
 					/* regular interruption */
 				}
@@ -1250,7 +1252,7 @@ public class CharonVpnService extends VpnService implements Runnable, VpnStateSe
 			if ((mSplitTunneling & VpnProfile.SPLIT_TUNNELING_BLOCK_IPV4) == 0)
 			{
 				if (mIPv4Seen)
-				{	/* split tunneling is used depending on the routes and configuration */
+				{    /* split tunneling is used depending on the routes and configuration */
 					IPRangeSet ranges = new IPRangeSet();
 					if (mIncludedSubnetsv4.size() > 0)
 					{
@@ -1268,8 +1270,8 @@ public class CharonVpnService extends VpnService implements Runnable, VpnStateSe
 							builder.addRoute(subnet.getFrom(), subnet.getPrefix());
 						}
 						catch (IllegalArgumentException e)
-						{	/* some Android versions don't seem to like multicast addresses here,
-							 * ignore it for now */
+						{    /* some Android versions don't seem to like multicast addresses here,
+						 * ignore it for now */
 							if (!subnet.getFrom().isMulticastAddress())
 							{
 								throw e;
@@ -1277,14 +1279,14 @@ public class CharonVpnService extends VpnService implements Runnable, VpnStateSe
 						}
 					}
 				}
-				else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP)
-				{	/* allow traffic that would otherwise be blocked to bypass the VPN */
+				else
+				{    /* allow traffic that would otherwise be blocked to bypass the VPN */
 					builder.allowFamily(OsConstants.AF_INET);
 				}
 			}
 			else if (mIPv4Seen)
-			{	/* only needed if we've seen any addresses.  otherwise, traffic
-				 * is blocked by default (we also install no routes in that case) */
+			{    /* only needed if we've seen any addresses.  otherwise, traffic
+			 * is blocked by default (we also install no routes in that case) */
 				builder.addRoute("0.0.0.0", 0);
 			}
 			/* same thing for IPv6 */
@@ -1317,7 +1319,7 @@ public class CharonVpnService extends VpnService implements Runnable, VpnStateSe
 						}
 					}
 				}
-				else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP)
+				else
 				{
 					builder.allowFamily(OsConstants.AF_INET6);
 				}
@@ -1327,8 +1329,7 @@ public class CharonVpnService extends VpnService implements Runnable, VpnStateSe
 				builder.addRoute("::", 0);
 			}
 			/* apply selected applications */
-			if (mSelectedApps.size() > 0 &&
-				Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP)
+			if (mSelectedApps.size() > 0)
 			{
 				switch (mAppHandling)
 				{
@@ -1372,11 +1373,7 @@ public class CharonVpnService extends VpnService implements Runnable, VpnStateSe
 			{
 				return false;
 			}
-			else if (addr instanceof Inet6Address)
-			{
-				return true;
-			}
-			return false;
+			else return addr instanceof Inet6Address;
 		}
 	}
 

--- a/src/frontends/android/app/src/main/java/org/strongswan/android/logic/StrongSwanApplication.java
+++ b/src/frontends/android/app/src/main/java/org/strongswan/android/logic/StrongSwanApplication.java
@@ -17,24 +17,69 @@
 package org.strongswan.android.logic;
 
 import android.app.Application;
+import android.content.BroadcastReceiver;
 import android.content.Context;
+import android.content.Intent;
+import android.content.IntentFilter;
 import android.os.Handler;
 import android.os.Looper;
 
+import org.strongswan.android.data.ManagedConfigurationService;
+import org.strongswan.android.data.ManagedVpnProfile;
+import org.strongswan.android.data.VpnProfile;
 import org.strongswan.android.security.LocalCertificateKeyStoreProvider;
+import org.strongswan.android.utils.Constants;
 
 import java.security.Security;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
 import androidx.core.os.HandlerCompat;
+import androidx.lifecycle.Lifecycle;
+import androidx.lifecycle.LifecycleEventObserver;
+import androidx.lifecycle.LifecycleOwner;
+import androidx.lifecycle.ProcessLifecycleOwner;
+import androidx.localbroadcastmanager.content.LocalBroadcastManager;
 
-public class StrongSwanApplication extends Application
+public class StrongSwanApplication extends Application implements LifecycleEventObserver
 {
 	private static Context mContext;
+
 	private final ExecutorService mExecutorService = Executors.newFixedThreadPool(4);
 	private final Handler mMainHandler = HandlerCompat.createAsync(Looper.getMainLooper());
+
+	private ManagedConfigurationService mManagedConfigurationService;
+
+	private final BroadcastReceiver mRestrictionsReceiver = new BroadcastReceiver()
+	{
+		@Override
+		public void onReceive(Context context, Intent intent)
+		{
+			final List<ManagedVpnProfile> oldProfiles = mManagedConfigurationService.getManagedProfiles();
+			Set<String> uuids = new HashSet<>(oldProfiles.size());
+			for (final VpnProfile profile : oldProfiles)
+			{
+				uuids.add(profile.getUUID().toString());
+			}
+
+			mManagedConfigurationService.loadConfiguration();
+			mManagedConfigurationService.updateSettings();
+
+			final List<ManagedVpnProfile> newProfiles = mManagedConfigurationService.getManagedProfiles();
+			for (final VpnProfile profile : newProfiles)
+			{
+				uuids.add(profile.getUUID().toString());
+			}
+
+			Intent profilesChanged = new Intent(Constants.VPN_PROFILES_CHANGED);
+			profilesChanged.putExtra(Constants.VPN_PROFILES_MULTIPLE, uuids.toArray(new String[0]));
+			LocalBroadcastManager.getInstance(context).sendBroadcast(profilesChanged);
+		}
+	};
 
 	static
 	{
@@ -46,6 +91,9 @@ public class StrongSwanApplication extends Application
 	{
 		super.onCreate();
 		StrongSwanApplication.mContext = getApplicationContext();
+
+		mManagedConfigurationService = new ManagedConfigurationService(this);
+		ProcessLifecycleOwner.get().getLifecycle().addObserver(this);
 	}
 
 	/**
@@ -85,5 +133,29 @@ public class StrongSwanApplication extends Application
 	static
 	{
 		System.loadLibrary("androidbridge");
+	}
+
+	@Override
+	public void onStateChanged(final LifecycleOwner source, final Lifecycle.Event event)
+	{
+		if (event == Lifecycle.Event.ON_START)
+		{
+			registerManagedConfigurationReceiver();
+		}
+		else if (event == Lifecycle.Event.ON_STOP)
+		{
+			unregisterManagedConfigurationReceiver();
+		}
+	}
+
+	private void registerManagedConfigurationReceiver()
+	{
+		final IntentFilter restrictionsFilter = new IntentFilter(Intent.ACTION_APPLICATION_RESTRICTIONS_CHANGED);
+		registerReceiver(mRestrictionsReceiver, restrictionsFilter);
+	}
+
+	private void unregisterManagedConfigurationReceiver()
+	{
+		unregisterReceiver(mRestrictionsReceiver);
 	}
 }

--- a/src/frontends/android/app/src/main/java/org/strongswan/android/logic/StrongSwanApplication.java
+++ b/src/frontends/android/app/src/main/java/org/strongswan/android/logic/StrongSwanApplication.java
@@ -16,19 +16,17 @@
 
 package org.strongswan.android.logic;
 
+import android.app.Application;
+import android.content.Context;
+import android.os.Handler;
+import android.os.Looper;
+
+import org.strongswan.android.security.LocalCertificateKeyStoreProvider;
+
 import java.security.Security;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
-
-import org.strongswan.android.security.LocalCertificateKeyStoreProvider;
-import org.strongswan.android.ui.MainActivity;
-
-import android.app.Application;
-import android.content.Context;
-import android.os.Build;
-import android.os.Handler;
-import android.os.Looper;
 
 import androidx.core.os.HandlerCompat;
 
@@ -38,7 +36,8 @@ public class StrongSwanApplication extends Application
 	private final ExecutorService mExecutorService = Executors.newFixedThreadPool(4);
 	private final Handler mMainHandler = HandlerCompat.createAsync(Looper.getMainLooper());
 
-	static {
+	static
+	{
 		Security.addProvider(new LocalCertificateKeyStoreProvider());
 	}
 
@@ -51,6 +50,7 @@ public class StrongSwanApplication extends Application
 
 	/**
 	 * Returns the current application context
+	 *
 	 * @return context
 	 */
 	public static Context getContext()
@@ -60,6 +60,7 @@ public class StrongSwanApplication extends Application
 
 	/**
 	 * Returns a thread pool to run tasks in separate threads
+	 *
 	 * @return thread pool
 	 */
 	public Executor getExecutor()
@@ -69,6 +70,7 @@ public class StrongSwanApplication extends Application
 
 	/**
 	 * Returns a handler to execute stuff by the main thread.
+	 *
 	 * @return handler
 	 */
 	public Handler getHandler()
@@ -82,21 +84,6 @@ public class StrongSwanApplication extends Application
 	 */
 	static
 	{
-		if (Build.VERSION.SDK_INT < Build.VERSION_CODES.JELLY_BEAN_MR2)
-		{
-			System.loadLibrary("strongswan");
-
-			if (MainActivity.USE_BYOD)
-			{
-				System.loadLibrary("tpmtss");
-				System.loadLibrary("tncif");
-				System.loadLibrary("tnccs");
-				System.loadLibrary("imcv");
-			}
-
-			System.loadLibrary("charon");
-			System.loadLibrary("ipsec");
-		}
 		System.loadLibrary("androidbridge");
 	}
 }

--- a/src/frontends/android/app/src/main/java/org/strongswan/android/logic/StrongSwanApplication.java
+++ b/src/frontends/android/app/src/main/java/org/strongswan/android/logic/StrongSwanApplication.java
@@ -23,6 +23,7 @@ import android.content.Intent;
 import android.content.IntentFilter;
 import android.os.Handler;
 import android.os.Looper;
+import android.util.Log;
 
 import org.strongswan.android.data.DatabaseHelper;
 import org.strongswan.android.data.ManagedConfigurationService;
@@ -48,6 +49,8 @@ import androidx.localbroadcastmanager.content.LocalBroadcastManager;
 
 public class StrongSwanApplication extends Application implements LifecycleEventObserver
 {
+	private static final String TAG = StrongSwanApplication.class.getSimpleName();
+
 	private static Context mContext;
 
 	private final ExecutorService mExecutorService = Executors.newFixedThreadPool(4);
@@ -65,6 +68,8 @@ public class StrongSwanApplication extends Application implements LifecycleEvent
 		@Override
 		public void onReceive(Context context, Intent intent)
 		{
+			Log.d(TAG, "Managed configuration changed");
+
 			final List<ManagedVpnProfile> oldProfiles = mManagedConfigurationService.getManagedProfiles();
 			Set<String> uuids = new HashSet<>(oldProfiles.size());
 			for (final VpnProfile profile : oldProfiles)
@@ -83,8 +88,10 @@ public class StrongSwanApplication extends Application implements LifecycleEvent
 					uuids.add(profile.getUUID().toString());
 				}
 
-				Intent profilesChanged = new Intent(Constants.VPN_PROFILES_CHANGED);
+				final Intent profilesChanged = new Intent(Constants.VPN_PROFILES_CHANGED);
 				profilesChanged.putExtra(Constants.VPN_PROFILES_MULTIPLE, uuids.toArray(new String[0]));
+
+				Log.d(TAG, "Send profiles changed broadcast");
 				LocalBroadcastManager.getInstance(context).sendBroadcast(profilesChanged);
 			});
 		}

--- a/src/frontends/android/app/src/main/java/org/strongswan/android/logic/StrongSwanApplication.java
+++ b/src/frontends/android/app/src/main/java/org/strongswan/android/logic/StrongSwanApplication.java
@@ -24,6 +24,7 @@ import android.content.IntentFilter;
 import android.os.Handler;
 import android.os.Looper;
 
+import org.strongswan.android.data.DatabaseHelper;
 import org.strongswan.android.data.ManagedConfigurationService;
 import org.strongswan.android.data.ManagedVpnProfile;
 import org.strongswan.android.data.VpnProfile;
@@ -53,6 +54,8 @@ public class StrongSwanApplication extends Application implements LifecycleEvent
 	private final Handler mMainHandler = HandlerCompat.createAsync(Looper.getMainLooper());
 
 	private ManagedConfigurationService mManagedConfigurationService;
+
+	private DatabaseHelper mDatabaseHelper;
 
 	private final BroadcastReceiver mRestrictionsReceiver = new BroadcastReceiver()
 	{
@@ -92,8 +95,10 @@ public class StrongSwanApplication extends Application implements LifecycleEvent
 		super.onCreate();
 		StrongSwanApplication.mContext = getApplicationContext();
 
-		mManagedConfigurationService = new ManagedConfigurationService(this);
+		mManagedConfigurationService = new ManagedConfigurationService(mContext);
 		ProcessLifecycleOwner.get().getLifecycle().addObserver(this);
+
+		mDatabaseHelper = new DatabaseHelper(mContext);
 	}
 
 	/**
@@ -124,6 +129,14 @@ public class StrongSwanApplication extends Application implements LifecycleEvent
 	public Handler getHandler()
 	{
 		return mMainHandler;
+	}
+
+	/**
+	 * @return the application's database helper used to access its SQLite database
+	 */
+	public DatabaseHelper getDatabaseHelper()
+	{
+		return mDatabaseHelper;
 	}
 
 	/*

--- a/src/frontends/android/app/src/main/java/org/strongswan/android/logic/UserCertificateInstaller.java
+++ b/src/frontends/android/app/src/main/java/org/strongswan/android/logic/UserCertificateInstaller.java
@@ -1,0 +1,110 @@
+package org.strongswan.android.logic;
+
+import android.app.admin.DevicePolicyManager;
+import android.content.Context;
+import android.os.Build;
+import android.util.Log;
+
+import org.strongswan.android.data.UserCertificate;
+import org.strongswan.android.utils.KeyPair;
+import org.strongswan.android.utils.KeyPairs;
+
+import java.io.IOException;
+import java.security.KeyStoreException;
+import java.security.NoSuchAlgorithmException;
+import java.security.UnrecoverableKeyException;
+import java.security.cert.Certificate;
+import java.security.cert.CertificateException;
+
+import androidx.annotation.NonNull;
+
+public class UserCertificateInstaller
+{
+	private static final String TAG = UserCertificateInstaller.class.getSimpleName();
+
+	private final DevicePolicyManager policyManager;
+
+	public UserCertificateInstaller(final Context context)
+	{
+		this.policyManager = (DevicePolicyManager)context.getSystemService(Context.DEVICE_POLICY_SERVICE);
+	}
+
+	private boolean installKeyPair(@NonNull UserCertificate userCertificate, @NonNull KeyPair keyPair)
+	{
+		if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P)
+		{
+			int flags = DevicePolicyManager.INSTALLKEY_REQUEST_CREDENTIALS_ACCESS | DevicePolicyManager.INSTALLKEY_SET_USER_SELECTABLE;
+			return policyManager.installKeyPair(
+				null,
+				keyPair.privateKey,
+				new Certificate[]{keyPair.certificate},
+				userCertificate.getAlias(),
+				flags);
+		}
+		else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N)
+		{
+			return policyManager.installKeyPair(
+				null,
+				keyPair.privateKey,
+				new Certificate[]{keyPair.certificate},
+				userCertificate.getAlias(),
+				true);
+		}
+
+		// This effectively prevents the app from using its own certificate, so certificate based authentication can only really work on Android 6+
+		// The certificate chooser is currently never shown on devices that are enrolled
+		return policyManager.installKeyPair(
+			null,
+			keyPair.privateKey,
+			keyPair.certificate,
+			userCertificate.getAlias());
+	}
+
+	private boolean installKeyPair(@NonNull UserCertificate userCertificate)
+		throws UnrecoverableKeyException, CertificateException, IOException, KeyStoreException, NoSuchAlgorithmException
+	{
+		final KeyPair keyPair = KeyPairs.from(userCertificate);
+		if (keyPair == null)
+		{
+			return false;
+		}
+
+		return installKeyPair(userCertificate, keyPair);
+	}
+
+	private void removeKeyPair(@NonNull UserCertificate userCertificate)
+	{
+		if (Build.VERSION.SDK_INT < Build.VERSION_CODES.N)
+		{
+			Log.w(TAG, "Cannot remove key pair, unsupported on API level " + Build.VERSION.SDK_INT);
+			return;
+		}
+
+		policyManager.removeKeyPair(null, userCertificate.getAlias());
+	}
+
+	public synchronized boolean tryInstall(@NonNull UserCertificate userCertificate)
+	{
+		try
+		{
+			return installKeyPair(userCertificate);
+		}
+		catch (final Exception e)
+		{
+			Log.e(TAG, "Could not install key pair " + userCertificate.getAlias(), e);
+			return false;
+		}
+	}
+
+	public synchronized void tryRemove(@NonNull UserCertificate userCertificate)
+	{
+		try
+		{
+			removeKeyPair(userCertificate);
+		}
+		catch (final Exception e)
+		{
+			Log.e(TAG, "Could not remove key pair " + userCertificate.getAlias(), e);
+		}
+	}
+}

--- a/src/frontends/android/app/src/main/java/org/strongswan/android/logic/UserCertificateInstaller.java
+++ b/src/frontends/android/app/src/main/java/org/strongswan/android/logic/UserCertificateInstaller.java
@@ -69,6 +69,7 @@ public class UserCertificateInstaller
 			return false;
 		}
 
+		Log.d(TAG, "Install key pair " + userCertificate);
 		return installKeyPair(userCertificate, keyPair);
 	}
 
@@ -80,6 +81,7 @@ public class UserCertificateInstaller
 			return;
 		}
 
+		Log.d(TAG, "Remove key pair " + userCertificate);
 		policyManager.removeKeyPair(null, userCertificate.getAlias());
 	}
 
@@ -91,7 +93,7 @@ public class UserCertificateInstaller
 		}
 		catch (final Exception e)
 		{
-			Log.e(TAG, "Could not install key pair " + userCertificate.getAlias(), e);
+			Log.e(TAG, "Could not install key pair " + userCertificate, e);
 			return false;
 		}
 	}
@@ -104,7 +106,7 @@ public class UserCertificateInstaller
 		}
 		catch (final Exception e)
 		{
-			Log.e(TAG, "Could not remove key pair " + userCertificate.getAlias(), e);
+			Log.e(TAG, "Could not remove key pair " + userCertificate, e);
 		}
 	}
 }

--- a/src/frontends/android/app/src/main/java/org/strongswan/android/logic/UserCertificateLoader.java
+++ b/src/frontends/android/app/src/main/java/org/strongswan/android/logic/UserCertificateLoader.java
@@ -4,6 +4,7 @@ import android.content.Context;
 import android.os.Handler;
 import android.security.KeyChain;
 import android.security.KeyChainException;
+import android.util.Log;
 
 import org.strongswan.android.data.VpnProfile;
 
@@ -15,6 +16,8 @@ import androidx.annotation.Nullable;
 
 public class UserCertificateLoader
 {
+	private static final String TAG = UserCertificateLoader.class.getSimpleName();
+
 	@NonNull
 	private final StrongSwanApplication mApplication;
 
@@ -37,6 +40,7 @@ public class UserCertificateLoader
 		X509Certificate[] chain;
 		try
 		{
+			Log.d(TAG, "Load key chain '" + userCertificateAlias + "'");
 			chain = KeyChain.getCertificateChain(mApplication, userCertificateAlias);
 		}
 		catch (final InterruptedException e)

--- a/src/frontends/android/app/src/main/java/org/strongswan/android/logic/UserCertificateLoader.java
+++ b/src/frontends/android/app/src/main/java/org/strongswan/android/logic/UserCertificateLoader.java
@@ -1,0 +1,88 @@
+package org.strongswan.android.logic;
+
+import android.content.Context;
+import android.os.Handler;
+import android.security.KeyChain;
+import android.security.KeyChainException;
+
+import org.strongswan.android.data.VpnProfile;
+
+import java.security.cert.X509Certificate;
+import java.util.concurrent.Executor;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+public class UserCertificateLoader
+{
+	@NonNull
+	private final StrongSwanApplication mApplication;
+
+	@NonNull
+	private final Executor mExecutor;
+	@NonNull
+	private final Handler mHandler;
+
+	public UserCertificateLoader(@NonNull final Context context)
+	{
+		mApplication = (StrongSwanApplication)context.getApplicationContext();
+
+		mExecutor = mApplication.getExecutor();
+		mHandler = mApplication.getHandler();
+	}
+
+	@Nullable
+	public X509Certificate[] loadCertificateChain(@NonNull String userCertificateAlias)
+	{
+		X509Certificate[] chain;
+		try
+		{
+			chain = KeyChain.getCertificateChain(mApplication, userCertificateAlias);
+		}
+		catch (final InterruptedException e)
+		{
+			Thread.currentThread().interrupt();
+			chain = null;
+		}
+		catch (final KeyChainException e)
+		{
+			e.printStackTrace();
+			chain = null;
+		}
+
+		return chain;
+	}
+
+	@Nullable
+	private X509Certificate loadCertificate(@NonNull final VpnProfile vpnProfile)
+	{
+		X509Certificate[] chain = loadCertificateChain(vpnProfile.getUserCertificateAlias());
+		if (chain != null && chain.length > 0)
+		{
+			return chain[0];
+		}
+		return null;
+	}
+
+	public void loadCertificate(@NonNull final VpnProfile vpnProfile, @NonNull final UserCertificateLoaderCallback callback)
+	{
+		mExecutor.execute(() -> {
+			final X509Certificate certificate = loadCertificate(vpnProfile);
+			complete(certificate, callback);
+		});
+	}
+
+	protected void complete(@Nullable X509Certificate result, @NonNull UserCertificateLoaderCallback callback)
+	{
+		mHandler.post(() -> callback.onComplete(result));
+	}
+
+	/**
+	 * Callback interface for the user certificate loader.
+	 */
+	@FunctionalInterface
+	public interface UserCertificateLoaderCallback
+	{
+		void onComplete(@Nullable final X509Certificate result);
+	}
+}

--- a/src/frontends/android/app/src/main/java/org/strongswan/android/logic/UserCertificateManager.java
+++ b/src/frontends/android/app/src/main/java/org/strongswan/android/logic/UserCertificateManager.java
@@ -48,9 +48,9 @@ public class UserCertificateManager
 		}
 		Log.d(TAG, "Key pairs changed " + diff);
 
-		for (final UserCertificate insert : diff.getInserts())
+		for (final UserCertificate delete : diff.getDeletes())
 		{
-			install(insert);
+			remove(delete);
 		}
 
 		for (final Pair<UserCertificate, UserCertificate> update : diff.getUpdates())
@@ -59,9 +59,9 @@ public class UserCertificateManager
 			install(update.second);
 		}
 
-		for (final UserCertificate delete : diff.getDeletes())
+		for (final UserCertificate insert : diff.getInserts())
 		{
-			remove(delete);
+			install(insert);
 		}
 	}
 

--- a/src/frontends/android/app/src/main/java/org/strongswan/android/logic/UserCertificateManager.java
+++ b/src/frontends/android/app/src/main/java/org/strongswan/android/logic/UserCertificateManager.java
@@ -31,8 +31,8 @@ public class UserCertificateManager
 
 	public void update()
 	{
-		final List<UserCertificate> configured = userCertificateRepository.getConfiguredKeyStores();
-		final List<UserCertificate> installed = userCertificateRepository.getInstalledKeyStores();
+		final List<UserCertificate> configured = userCertificateRepository.getConfiguredCertificates();
+		final List<UserCertificate> installed = userCertificateRepository.getInstalledCertificates();
 
 		final Difference<UserCertificate> diff = Difference.between(installed, configured, UserCertificate::getVpnProfileUuid);
 		if (diff.isEmpty())
@@ -61,13 +61,13 @@ public class UserCertificateManager
 	{
 		if (userCertificateInstaller.tryInstall(userCertificate))
 		{
-			userCertificateRepository.addInstalledKeyStore(userCertificate);
+			userCertificateRepository.addInstalledCertificate(userCertificate);
 		}
 	}
 
 	private void remove(@NonNull final UserCertificate userCertificate)
 	{
 		userCertificateInstaller.tryRemove(userCertificate);
-		userCertificateRepository.removeInstalledKeyStore(userCertificate);
+		userCertificateRepository.removeInstalledCertificate(userCertificate);
 	}
 }

--- a/src/frontends/android/app/src/main/java/org/strongswan/android/logic/UserCertificateManager.java
+++ b/src/frontends/android/app/src/main/java/org/strongswan/android/logic/UserCertificateManager.java
@@ -1,0 +1,73 @@
+package org.strongswan.android.logic;
+
+import android.content.Context;
+
+import org.strongswan.android.data.DatabaseHelper;
+import org.strongswan.android.data.ManagedConfigurationService;
+import org.strongswan.android.data.UserCertificate;
+import org.strongswan.android.data.UserCertificateRepository;
+import org.strongswan.android.utils.Difference;
+
+import java.util.List;
+
+import androidx.annotation.NonNull;
+import androidx.core.util.Pair;
+
+public class UserCertificateManager
+{
+	@NonNull
+	private final UserCertificateRepository userCertificateRepository;
+	@NonNull
+	private final UserCertificateInstaller userCertificateInstaller;
+
+	public UserCertificateManager(
+		@NonNull final Context context,
+		@NonNull final ManagedConfigurationService managedConfigurationService,
+		@NonNull final DatabaseHelper databaseHelper)
+	{
+		this.userCertificateRepository = new UserCertificateRepository(managedConfigurationService, databaseHelper);
+		this.userCertificateInstaller = new UserCertificateInstaller(context);
+	}
+
+	public void update()
+	{
+		final List<UserCertificate> configured = userCertificateRepository.getConfiguredKeyStores();
+		final List<UserCertificate> installed = userCertificateRepository.getInstalledKeyStores();
+
+		final Difference<UserCertificate> diff = Difference.between(installed, configured, UserCertificate::getVpnProfileUuid);
+		if (diff.isEmpty())
+		{
+			return;
+		}
+
+		for (final UserCertificate insert : diff.getInserts())
+		{
+			install(insert);
+		}
+
+		for (final Pair<UserCertificate, UserCertificate> update : diff.getUpdates())
+		{
+			remove(update.first);
+			install(update.second);
+		}
+
+		for (final UserCertificate delete : diff.getDeletes())
+		{
+			remove(delete);
+		}
+	}
+
+	private void install(@NonNull final UserCertificate userCertificate)
+	{
+		if (userCertificateInstaller.tryInstall(userCertificate))
+		{
+			userCertificateRepository.addInstalledKeyStore(userCertificate);
+		}
+	}
+
+	private void remove(@NonNull final UserCertificate userCertificate)
+	{
+		userCertificateInstaller.tryRemove(userCertificate);
+		userCertificateRepository.removeInstalledKeyStore(userCertificate);
+	}
+}

--- a/src/frontends/android/app/src/main/java/org/strongswan/android/logic/UserCertificateManager.java
+++ b/src/frontends/android/app/src/main/java/org/strongswan/android/logic/UserCertificateManager.java
@@ -1,5 +1,6 @@
 package org.strongswan.android.logic;
 
+import android.app.admin.DevicePolicyManager;
 import android.content.Context;
 
 import org.strongswan.android.data.DatabaseHelper;
@@ -25,7 +26,9 @@ public class UserCertificateManager
 		@NonNull final ManagedConfigurationService managedConfigurationService,
 		@NonNull final DatabaseHelper databaseHelper)
 	{
-		this.userCertificateRepository = new UserCertificateRepository(managedConfigurationService, databaseHelper);
+		final DevicePolicyManager devicePolicyManager = (DevicePolicyManager)context.getSystemService(Context.DEVICE_POLICY_SERVICE);
+
+		this.userCertificateRepository = new UserCertificateRepository(managedConfigurationService, devicePolicyManager, databaseHelper);
 		this.userCertificateInstaller = new UserCertificateInstaller(context);
 	}
 

--- a/src/frontends/android/app/src/main/java/org/strongswan/android/logic/UserCertificateManager.java
+++ b/src/frontends/android/app/src/main/java/org/strongswan/android/logic/UserCertificateManager.java
@@ -2,6 +2,7 @@ package org.strongswan.android.logic;
 
 import android.app.admin.DevicePolicyManager;
 import android.content.Context;
+import android.util.Log;
 
 import org.strongswan.android.data.DatabaseHelper;
 import org.strongswan.android.data.ManagedConfigurationService;
@@ -16,6 +17,8 @@ import androidx.core.util.Pair;
 
 public class UserCertificateManager
 {
+	private static final String TAG = UserCertificateManager.class.getSimpleName();
+
 	@NonNull
 	private final UserCertificateRepository userCertificateRepository;
 	@NonNull
@@ -40,8 +43,10 @@ public class UserCertificateManager
 		final Difference<UserCertificate> diff = Difference.between(installed, configured, UserCertificate::getVpnProfileUuid);
 		if (diff.isEmpty())
 		{
+			Log.d(TAG, "No key pairs changed, nothing to do");
 			return;
 		}
+		Log.d(TAG, "Key pairs changed " + diff);
 
 		for (final UserCertificate insert : diff.getInserts())
 		{

--- a/src/frontends/android/app/src/main/java/org/strongswan/android/ui/MainActivity.java
+++ b/src/frontends/android/app/src/main/java/org/strongswan/android/ui/MainActivity.java
@@ -77,15 +77,7 @@ public class MainActivity extends AppCompatActivity implements OnVpnProfileSelec
 			TrustedCertificateManager.getInstance().load();
 		});
 
-		mManagedConfigurationService = new ManagedConfigurationService(this);
-	}
-
-	@Override
-	protected void onResume()
-	{
-		super.onResume();
-
-		mManagedConfigurationService.loadConfiguration();
+		mManagedConfigurationService = ((StrongSwanApplication)this.getApplicationContext()).getManagedConfigurationService();
 	}
 
 	@Override

--- a/src/frontends/android/app/src/main/java/org/strongswan/android/ui/MainActivity.java
+++ b/src/frontends/android/app/src/main/java/org/strongswan/android/ui/MainActivity.java
@@ -21,7 +21,6 @@ package org.strongswan.android.ui;
 import android.app.Dialog;
 import android.content.DialogInterface;
 import android.content.Intent;
-import android.os.Build;
 import android.os.Bundle;
 import android.text.format.Formatter;
 import android.view.Menu;
@@ -79,16 +78,6 @@ public class MainActivity extends AppCompatActivity implements OnVpnProfileSelec
 	public boolean onCreateOptionsMenu(Menu menu)
 	{
 		getMenuInflater().inflate(R.menu.main, menu);
-		return true;
-	}
-
-	@Override
-	public boolean onPrepareOptionsMenu(Menu menu)
-	{
-		if (Build.VERSION.SDK_INT < Build.VERSION_CODES.KITKAT)
-		{
-			menu.removeItem(R.id.menu_import_profile);
-		}
 		return true;
 	}
 
@@ -195,26 +184,26 @@ public class MainActivity extends AppCompatActivity implements OnVpnProfileSelec
 			size = Formatter.formatFileSize(getActivity(), s);
 
 			AlertDialog.Builder builder = new AlertDialog.Builder(getActivity())
-					.setTitle(R.string.clear_crl_cache_title)
-					.setNegativeButton(android.R.string.cancel, new DialogInterface.OnClickListener()
+				.setTitle(R.string.clear_crl_cache_title)
+				.setNegativeButton(android.R.string.cancel, new DialogInterface.OnClickListener()
+				{
+					@Override
+					public void onClick(DialogInterface dialog, int which)
 					{
-						@Override
-						public void onClick(DialogInterface dialog, int which)
-						{
-							dismiss();
-						}
-					})
-					.setPositiveButton(R.string.clear, new DialogInterface.OnClickListener()
+						dismiss();
+					}
+				})
+				.setPositiveButton(R.string.clear, new DialogInterface.OnClickListener()
+				{
+					@Override
+					public void onClick(DialogInterface dialog, int whichButton)
 					{
-						@Override
-						public void onClick(DialogInterface dialog, int whichButton)
+						for (String file : list)
 						{
-							for (String file : list)
-							{
-								getActivity().deleteFile(file);
-							}
+							getActivity().deleteFile(file);
 						}
-					});
+					}
+				});
 			builder.setMessage(getActivity().getResources().getQuantityString(R.plurals.clear_crl_cache_msg, list.size(), list.size(), size));
 			return builder.create();
 		}

--- a/src/frontends/android/app/src/main/java/org/strongswan/android/ui/MainActivity.java
+++ b/src/frontends/android/app/src/main/java/org/strongswan/android/ui/MainActivity.java
@@ -142,7 +142,7 @@ public class MainActivity extends AppCompatActivity implements OnVpnProfileSelec
 	{
 		Intent intent = new Intent(this, VpnProfileControlActivity.class);
 		intent.setAction(VpnProfileControlActivity.START_PROFILE);
-		intent.putExtra(VpnProfileControlActivity.EXTRA_VPN_PROFILE_ID, profile.getUUID().toString());
+		intent.putExtra(VpnProfileControlActivity.EXTRA_VPN_PROFILE_UUID, profile.getUUID().toString());
 		startActivity(intent);
 	}
 

--- a/src/frontends/android/app/src/main/java/org/strongswan/android/ui/MainActivity.java
+++ b/src/frontends/android/app/src/main/java/org/strongswan/android/ui/MainActivity.java
@@ -28,6 +28,8 @@ import android.view.MenuItem;
 import android.widget.Toast;
 
 import org.strongswan.android.R;
+import org.strongswan.android.data.ManagedConfiguration;
+import org.strongswan.android.data.ManagedConfigurationService;
 import org.strongswan.android.data.VpnProfile;
 import org.strongswan.android.logic.StrongSwanApplication;
 import org.strongswan.android.logic.TrustedCertificateManager;
@@ -57,6 +59,8 @@ public class MainActivity extends AppCompatActivity implements OnVpnProfileSelec
 
 	private static final String DIALOG_TAG = "Dialog";
 
+	private ManagedConfigurationService mManagedConfigurationService;
+
 	@Override
 	public void onCreate(Bundle savedInstanceState)
 	{
@@ -72,12 +76,35 @@ public class MainActivity extends AppCompatActivity implements OnVpnProfileSelec
 		((StrongSwanApplication)getApplication()).getExecutor().execute(() -> {
 			TrustedCertificateManager.getInstance().load();
 		});
+
+		mManagedConfigurationService = new ManagedConfigurationService(this);
+	}
+
+	@Override
+	protected void onResume()
+	{
+		super.onResume();
+
+		mManagedConfigurationService.loadConfiguration();
 	}
 
 	@Override
 	public boolean onCreateOptionsMenu(Menu menu)
 	{
 		getMenuInflater().inflate(R.menu.main, menu);
+		return true;
+	}
+
+	@Override
+	public boolean onPrepareOptionsMenu(Menu menu)
+	{
+		final MenuItem importProfile = menu.findItem(R.id.menu_import_profile);
+		if (importProfile != null)
+		{
+			final ManagedConfiguration managedConfiguration = mManagedConfigurationService.getManagedConfiguration();
+			importProfile.setVisible(managedConfiguration.isAllowProfileImport());
+			importProfile.setEnabled(managedConfiguration.isAllowProfileImport());
+		}
 		return true;
 	}
 

--- a/src/frontends/android/app/src/main/java/org/strongswan/android/ui/SelectedApplicationsListFragment.java
+++ b/src/frontends/android/app/src/main/java/org/strongswan/android/ui/SelectedApplicationsListFragment.java
@@ -60,9 +60,11 @@ public class SelectedApplicationsListFragment extends ListFragment implements Lo
 		super.onViewCreated(view, savedInstanceState);
 		setHasOptionsMenu(true);
 
-		getListView().setChoiceMode(ListView.CHOICE_MODE_MULTIPLE);
+		final boolean readOnly = getActivity().getIntent().getBooleanExtra(VpnProfileDataSource.KEY_READ_ONLY, false);
+		getListView().setChoiceMode(readOnly ? ListView.CHOICE_MODE_NONE : ListView.CHOICE_MODE_MULTIPLE);
 
 		mAdapter = new SelectedApplicationsAdapter(getActivity());
+		mAdapter.setReadOnly(readOnly);
 		setListAdapter(mAdapter);
 		setListShown(false);
 
@@ -101,6 +103,11 @@ public class SelectedApplicationsListFragment extends ListFragment implements Lo
 	@Override
 	public void onListItemClick(ListView l, View v, int position, long id)
 	{
+		if (mAdapter.isReadOnly())
+		{
+			return;
+		}
+
 		super.onListItemClick(l, v, position, id);
 		SelectedApplicationEntry item = (SelectedApplicationEntry)getListView().getItemAtPosition(position);
 		item.setSelected(!item.isSelected());
@@ -236,7 +243,7 @@ public class SelectedApplicationsListFragment extends ListFragment implements Lo
 		protected void onStartLoading()
 		{
 			if (mData != null)
-			{	/* if we have data ready, deliver it directly */
+			{   /* if we have data ready, deliver it directly */
 				deliverResult(mData);
 			}
 			if (takeContentChanged() || mData == null)
@@ -254,8 +261,8 @@ public class SelectedApplicationsListFragment extends ListFragment implements Lo
 			}
 			mData = data;
 			if (isStarted())
-			{	/* if it is started we deliver the data directly,
-				 * otherwise this is handled in onStartLoading */
+			{   /* if it is started we deliver the data directly,
+			 * otherwise this is handled in onStartLoading */
 				super.deliverResult(data);
 			}
 		}

--- a/src/frontends/android/app/src/main/java/org/strongswan/android/ui/SettingsFragment.java
+++ b/src/frontends/android/app/src/main/java/org/strongswan/android/ui/SettingsFragment.java
@@ -63,7 +63,7 @@ public class SettingsFragment extends PreferenceFragmentCompat implements Prefer
 		VpnProfileDataSource profiles = new VpnProfileSource(getActivity());
 		profiles.open();
 
-		List<VpnProfile> all = profiles.getAllVpnProfiles();
+		List<? extends VpnProfile> all = profiles.getAllVpnProfiles();
 		Collections.sort(all, new Comparator<VpnProfile>()
 		{
 			@Override

--- a/src/frontends/android/app/src/main/java/org/strongswan/android/ui/SettingsFragment.java
+++ b/src/frontends/android/app/src/main/java/org/strongswan/android/ui/SettingsFragment.java
@@ -30,6 +30,7 @@ import org.strongswan.android.data.ManagedConfigurationService;
 import org.strongswan.android.data.VpnProfile;
 import org.strongswan.android.data.VpnProfileDataSource;
 import org.strongswan.android.data.VpnProfileSource;
+import org.strongswan.android.logic.StrongSwanApplication;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -51,8 +52,7 @@ public class SettingsFragment extends PreferenceFragmentCompat implements Prefer
 	@Override
 	public void onCreatePreferences(Bundle bundle, String s)
 	{
-		mManagedConfigurationService = new ManagedConfigurationService(getContext());
-		mManagedConfigurationService.loadConfiguration();
+		mManagedConfigurationService = ((StrongSwanApplication)getContext().getApplicationContext()).getManagedConfigurationService();
 		mManagedConfigurationService.updateSettings();
 
 		setPreferencesFromResource(R.xml.settings, s);

--- a/src/frontends/android/app/src/main/java/org/strongswan/android/ui/SettingsFragment.java
+++ b/src/frontends/android/app/src/main/java/org/strongswan/android/ui/SettingsFragment.java
@@ -16,6 +16,9 @@
 
 package org.strongswan.android.ui;
 
+import static org.strongswan.android.utils.Constants.PREF_DEFAULT_VPN_PROFILE;
+import static org.strongswan.android.utils.Constants.PREF_DEFAULT_VPN_PROFILE_MRU;
+
 import android.content.SharedPreferences;
 import android.os.Build;
 import android.os.Bundle;
@@ -23,6 +26,7 @@ import android.os.Bundle;
 import org.strongswan.android.R;
 import org.strongswan.android.data.VpnProfile;
 import org.strongswan.android.data.VpnProfileDataSource;
+import org.strongswan.android.data.VpnProfileSource;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -34,9 +38,6 @@ import androidx.preference.Preference;
 import androidx.preference.PreferenceFragmentCompat;
 import androidx.preference.PreferenceManager;
 
-import static org.strongswan.android.utils.Constants.PREF_DEFAULT_VPN_PROFILE;
-import static org.strongswan.android.utils.Constants.PREF_DEFAULT_VPN_PROFILE_MRU;
-
 public class SettingsFragment extends PreferenceFragmentCompat implements Preference.OnPreferenceChangeListener
 {
 	private ListPreference mDefaultVPNProfile;
@@ -46,7 +47,7 @@ public class SettingsFragment extends PreferenceFragmentCompat implements Prefer
 	{
 		setPreferencesFromResource(R.xml.settings, s);
 
-		mDefaultVPNProfile = (ListPreference)findPreference(PREF_DEFAULT_VPN_PROFILE);
+		mDefaultVPNProfile = findPreference(PREF_DEFAULT_VPN_PROFILE);
 		mDefaultVPNProfile.setOnPreferenceChangeListener(this);
 		if (Build.VERSION.SDK_INT < Build.VERSION_CODES.N)
 		{
@@ -59,11 +60,12 @@ public class SettingsFragment extends PreferenceFragmentCompat implements Prefer
 	{
 		super.onResume();
 
-		VpnProfileDataSource profiles = new VpnProfileDataSource(getActivity());
+		VpnProfileDataSource profiles = new VpnProfileSource(getActivity());
 		profiles.open();
 
 		List<VpnProfile> all = profiles.getAllVpnProfiles();
-		Collections.sort(all, new Comparator<VpnProfile>() {
+		Collections.sort(all, new Comparator<VpnProfile>()
+		{
 			@Override
 			public int compare(VpnProfile lhs, VpnProfile rhs)
 			{
@@ -111,7 +113,7 @@ public class SettingsFragment extends PreferenceFragmentCompat implements Prefer
 
 	private void setCurrentProfileName(String uuid)
 	{
-		VpnProfileDataSource profiles = new VpnProfileDataSource(getActivity());
+		VpnProfileDataSource profiles = new VpnProfileSource(getActivity());
 		profiles.open();
 
 		if (!uuid.equals(PREF_DEFAULT_VPN_PROFILE_MRU))

--- a/src/frontends/android/app/src/main/java/org/strongswan/android/ui/TrustedCertificateImportActivity.java
+++ b/src/frontends/android/app/src/main/java/org/strongswan/android/ui/TrustedCertificateImportActivity.java
@@ -16,13 +16,11 @@
 
 package org.strongswan.android.ui;
 
-import android.annotation.TargetApi;
 import android.app.Dialog;
 import android.content.ActivityNotFoundException;
 import android.content.DialogInterface;
 import android.content.Intent;
 import android.net.Uri;
-import android.os.Build;
 import android.os.Bundle;
 import android.widget.Toast;
 
@@ -61,7 +59,6 @@ public class TrustedCertificateImportActivity extends AppCompatActivity
 		}
 	);
 
-	@TargetApi(Build.VERSION_CODES.KITKAT)
 	@Override
 	public void onCreate(Bundle savedInstanceState)
 	{

--- a/src/frontends/android/app/src/main/java/org/strongswan/android/ui/TrustedCertificateImportActivity.java
+++ b/src/frontends/android/app/src/main/java/org/strongswan/android/ui/TrustedCertificateImportActivity.java
@@ -68,7 +68,7 @@ public class TrustedCertificateImportActivity extends AppCompatActivity
 		super.onCreate(savedInstanceState);
 
 		if (savedInstanceState != null)
-		{	/* do nothing when we are restoring */
+		{    /* do nothing when we are restoring */
 			return;
 		}
 
@@ -78,7 +78,7 @@ public class TrustedCertificateImportActivity extends AppCompatActivity
 		{
 			importCertificate(intent.getData());
 		}
-		else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT)
+		else
 		{
 			Intent openIntent = new Intent(Intent.ACTION_OPEN_DOCUMENT);
 			openIntent.setType("*/*");
@@ -87,9 +87,8 @@ public class TrustedCertificateImportActivity extends AppCompatActivity
 				mOpenDocument.launch(openIntent);
 			}
 			catch (ActivityNotFoundException e)
-			{	/* some devices are unable to browse for files */
+			{    /* some devices are unable to browse for files */
 				finish();
-				return;
 			}
 		}
 	}

--- a/src/frontends/android/app/src/main/java/org/strongswan/android/ui/TrustedCertificatesActivity.java
+++ b/src/frontends/android/app/src/main/java/org/strongswan/android/ui/TrustedCertificatesActivity.java
@@ -17,7 +17,6 @@
 package org.strongswan.android.ui;
 
 import android.content.Intent;
-import android.os.Build;
 import android.os.Bundle;
 import android.view.Menu;
 import android.view.MenuItem;
@@ -73,10 +72,10 @@ public class TrustedCertificatesActivity extends AppCompatActivity implements Tr
 
 		mAdapter = new TrustedCertificatesPagerAdapter(this);
 
-		mPager = (ViewPager2)findViewById(R.id.viewpager);
+		mPager = findViewById(R.id.viewpager);
 		mPager.setAdapter(mAdapter);
 
-		TabLayout tabs = (TabLayout)findViewById(R.id.tabs);
+		TabLayout tabs = findViewById(R.id.tabs);
 		new TabLayoutMediator(tabs, mPager, (tab, position) -> {
 			tab.setText(mAdapter.getTitle(position));
 		}).attach();
@@ -88,16 +87,6 @@ public class TrustedCertificatesActivity extends AppCompatActivity implements Tr
 	public boolean onCreateOptionsMenu(Menu menu)
 	{
 		getMenuInflater().inflate(R.menu.certificates, menu);
-		return true;
-	}
-
-	@Override
-	public boolean onPrepareOptionsMenu(Menu menu)
-	{
-		if (Build.VERSION.SDK_INT < Build.VERSION_CODES.KITKAT)
-		{
-			menu.removeItem(R.id.menu_import_certificate);
-		}
 		return true;
 	}
 
@@ -164,7 +153,7 @@ public class TrustedCertificatesActivity extends AppCompatActivity implements Tr
 
 	public static class TrustedCertificatesPagerAdapter extends FragmentStateAdapter
 	{
-		private TrustedCertificatesTab mTabs[];
+		private final TrustedCertificatesTab[] mTabs;
 
 		public TrustedCertificatesPagerAdapter(@NonNull FragmentActivity fragmentActivity)
 		{

--- a/src/frontends/android/app/src/main/java/org/strongswan/android/ui/TrustedCertificatesActivity.java
+++ b/src/frontends/android/app/src/main/java/org/strongswan/android/ui/TrustedCertificatesActivity.java
@@ -25,6 +25,8 @@ import com.google.android.material.tabs.TabLayout;
 import com.google.android.material.tabs.TabLayoutMediator;
 
 import org.strongswan.android.R;
+import org.strongswan.android.data.ManagedConfiguration;
+import org.strongswan.android.data.ManagedConfigurationService;
 import org.strongswan.android.data.VpnProfileDataSource;
 import org.strongswan.android.logic.TrustedCertificateManager;
 import org.strongswan.android.logic.TrustedCertificateManager.TrustedCertificateSource;
@@ -50,6 +52,8 @@ public class TrustedCertificatesActivity extends AppCompatActivity implements Tr
 	private TrustedCertificatesPagerAdapter mAdapter;
 	private ViewPager2 mPager;
 	private boolean mSelect;
+
+	private ManagedConfigurationService mManagedConfigurationService;
 
 	private final ActivityResultLauncher<Intent> mImportCertificate = registerForActivityResult(
 		new ActivityResultContracts.StartActivityForResult(),
@@ -81,12 +85,34 @@ public class TrustedCertificatesActivity extends AppCompatActivity implements Tr
 		}).attach();
 
 		mSelect = SELECT_CERTIFICATE.equals(getIntent().getAction());
+		mManagedConfigurationService = new ManagedConfigurationService(this);
+	}
+
+	@Override
+	protected void onResume()
+	{
+		super.onResume();
+
+		mManagedConfigurationService.loadConfiguration();
 	}
 
 	@Override
 	public boolean onCreateOptionsMenu(Menu menu)
 	{
 		getMenuInflater().inflate(R.menu.certificates, menu);
+		return true;
+	}
+
+	@Override
+	public boolean onPrepareOptionsMenu(Menu menu)
+	{
+		final MenuItem importCertificate = menu.findItem(R.id.menu_import_certificate);
+		if (importCertificate != null)
+		{
+			final ManagedConfiguration managedConfiguration = mManagedConfigurationService.getManagedConfiguration();
+			importCertificate.setVisible(managedConfiguration.isAllowCertificateImport());
+			importCertificate.setEnabled(managedConfiguration.isAllowCertificateImport());
+		}
 		return true;
 	}
 

--- a/src/frontends/android/app/src/main/java/org/strongswan/android/ui/TrustedCertificatesActivity.java
+++ b/src/frontends/android/app/src/main/java/org/strongswan/android/ui/TrustedCertificatesActivity.java
@@ -28,6 +28,7 @@ import org.strongswan.android.R;
 import org.strongswan.android.data.ManagedConfiguration;
 import org.strongswan.android.data.ManagedConfigurationService;
 import org.strongswan.android.data.VpnProfileDataSource;
+import org.strongswan.android.logic.StrongSwanApplication;
 import org.strongswan.android.logic.TrustedCertificateManager;
 import org.strongswan.android.logic.TrustedCertificateManager.TrustedCertificateSource;
 import org.strongswan.android.security.TrustedCertificateEntry;
@@ -85,15 +86,7 @@ public class TrustedCertificatesActivity extends AppCompatActivity implements Tr
 		}).attach();
 
 		mSelect = SELECT_CERTIFICATE.equals(getIntent().getAction());
-		mManagedConfigurationService = new ManagedConfigurationService(this);
-	}
-
-	@Override
-	protected void onResume()
-	{
-		super.onResume();
-
-		mManagedConfigurationService.loadConfiguration();
+		mManagedConfigurationService = ((StrongSwanApplication)this.getApplicationContext()).getManagedConfigurationService();
 	}
 
 	@Override

--- a/src/frontends/android/app/src/main/java/org/strongswan/android/ui/VpnProfileControlActivity.java
+++ b/src/frontends/android/app/src/main/java/org/strongswan/android/ui/VpnProfileControlActivity.java
@@ -64,7 +64,7 @@ public class VpnProfileControlActivity extends AppCompatActivity
 {
 	public static final String START_PROFILE = "org.strongswan.android.action.START_PROFILE";
 	public static final String DISCONNECT = "org.strongswan.android.action.DISCONNECT";
-	public static final String EXTRA_VPN_PROFILE_ID = "org.strongswan.android.VPN_PROFILE_ID";
+	public static final String EXTRA_VPN_PROFILE_UUID = "org.strongswan.android.VPN_PROFILE_UUID";
 
 	private static final String WAITING_FOR_RESULT = "WAITING_FOR_RESULT";
 	private static final String PROFILE_NAME = "PROFILE_NAME";
@@ -377,18 +377,10 @@ public class VpnProfileControlActivity extends AppCompatActivity
 
 		VpnProfileDataSource dataSource = new VpnProfileSource(this);
 		dataSource.open();
-		String profileUUID = intent.getStringExtra(EXTRA_VPN_PROFILE_ID);
+		String profileUUID = intent.getStringExtra(EXTRA_VPN_PROFILE_UUID);
 		if (profileUUID != null)
 		{
 			profile = dataSource.getVpnProfile(profileUUID);
-		}
-		else
-		{
-			long profileId = intent.getLongExtra(EXTRA_VPN_PROFILE_ID, 0);
-			if (profileId > 0)
-			{
-				profile = dataSource.getVpnProfile(profileId);
-			}
 		}
 		dataSource.close();
 
@@ -414,7 +406,7 @@ public class VpnProfileControlActivity extends AppCompatActivity
 
 		removeFragmentByTag(DIALOG_TAG);
 
-		String profileUUID = intent.getStringExtra(EXTRA_VPN_PROFILE_ID);
+		String profileUUID = intent.getStringExtra(EXTRA_VPN_PROFILE_UUID);
 		if (profileUUID != null)
 		{
 			VpnProfileDataSource dataSource = new VpnProfileSource(this);

--- a/src/frontends/android/app/src/main/java/org/strongswan/android/ui/VpnProfileControlActivity.java
+++ b/src/frontends/android/app/src/main/java/org/strongswan/android/ui/VpnProfileControlActivity.java
@@ -42,12 +42,12 @@ import android.widget.Toast;
 import org.strongswan.android.R;
 import org.strongswan.android.data.VpnProfile;
 import org.strongswan.android.data.VpnProfileDataSource;
+import org.strongswan.android.data.VpnProfileSource;
 import org.strongswan.android.data.VpnType.VpnTypeFeature;
 import org.strongswan.android.logic.VpnStateService;
 import org.strongswan.android.logic.VpnStateService.State;
 import org.strongswan.android.utils.Constants;
 
-import androidx.activity.result.ActivityResultCallback;
 import androidx.activity.result.ActivityResultLauncher;
 import androidx.activity.result.contract.ActivityResultContracts;
 import androidx.annotation.NonNull;
@@ -101,7 +101,7 @@ public class VpnProfileControlActivity extends AppCompatActivity
 				onVpnServicePrepared();
 			}
 			else
-			{	/* this happens if the always-on VPN feature is activated by a different app or the user declined */
+			{    /* this happens if the always-on VPN feature is activated by a different app or the user declined */
 				VpnNotSupportedError.showWithMessage(this, R.string.vpn_not_supported_no_permission);
 			}
 		}
@@ -136,7 +136,7 @@ public class VpnProfileControlActivity extends AppCompatActivity
 			mWaitingForResult = savedInstanceState.getBoolean(WAITING_FOR_RESULT, false);
 		}
 		this.bindService(new Intent(this, VpnStateService.class),
-						 mServiceConnection, Service.BIND_AUTO_CREATE);
+		                 mServiceConnection, Service.BIND_AUTO_CREATE);
 	}
 
 	@Override
@@ -225,7 +225,7 @@ public class VpnProfileControlActivity extends AppCompatActivity
 			}
 		}
 		else
-		{	/* user already granted permission to use VpnService */
+		{    /* user already granted permission to use VpnService */
 			onVpnServicePrepared();
 		}
 	}
@@ -257,6 +257,7 @@ public class VpnProfileControlActivity extends AppCompatActivity
 	/**
 	 * Check if we have permission to display notifications to the user, if necessary,
 	 * ask the user to allow this.
+	 *
 	 * @return true if profile can be initiated immediately
 	 */
 	private boolean checkNotificationPermission()
@@ -274,6 +275,7 @@ public class VpnProfileControlActivity extends AppCompatActivity
 	/**
 	 * Check if we are on the system's power whitelist, if necessary, or ask the user
 	 * to add us.
+	 *
 	 * @return true if profile can be initiated immediately
 	 */
 	private boolean checkPowerWhitelist()
@@ -286,9 +288,9 @@ public class VpnProfileControlActivity extends AppCompatActivity
 				!pref.getBoolean(Constants.PREF_IGNORE_POWER_WHITELIST, false))
 			{
 				if (getSupportFragmentManager().isStateSaved())
-				{	/* we might get called via service connection and manual onActivityResult()
-					 * call when the activity is not active anymore and fragment transactions
-					 * would cause an illegalStateException */
+				{    /* we might get called via service connection and manual onActivityResult()
+				 * call when the activity is not active anymore and fragment transactions
+				 * would cause an illegalStateException */
 					return false;
 				}
 				PowerWhitelistRequired whitelist = new PowerWhitelistRequired();
@@ -311,7 +313,7 @@ public class VpnProfileControlActivity extends AppCompatActivity
 			return false;
 		}
 		if (mService.getErrorState() != VpnStateService.ErrorState.NO_ERROR)
-		{	/* allow reconnecting (even to a different profile) without confirmation if there is an error */
+		{    /* allow reconnecting (even to a different profile) without confirmation if there is an error */
 			return false;
 		}
 		return (mService.getState() == State.CONNECTED || mService.getState() == State.CONNECTING);
@@ -373,7 +375,7 @@ public class VpnProfileControlActivity extends AppCompatActivity
 	{
 		VpnProfile profile = null;
 
-		VpnProfileDataSource dataSource = new VpnProfileDataSource(this);
+		VpnProfileDataSource dataSource = new VpnProfileSource(this);
 		dataSource.open();
 		String profileUUID = intent.getStringExtra(EXTRA_VPN_PROFILE_ID);
 		if (profileUUID != null)
@@ -415,7 +417,7 @@ public class VpnProfileControlActivity extends AppCompatActivity
 		String profileUUID = intent.getStringExtra(EXTRA_VPN_PROFILE_ID);
 		if (profileUUID != null)
 		{
-			VpnProfileDataSource dataSource = new VpnProfileDataSource(this);
+			VpnProfileDataSource dataSource = new VpnProfileSource(this);
 			dataSource.open();
 			profile = dataSource.getVpnProfile(profileUUID);
 			dataSource.close();
@@ -427,7 +429,7 @@ public class VpnProfileControlActivity extends AppCompatActivity
 				mService.getState() == State.CONNECTING)
 			{
 				if (profile != null && profile.equals(mService.getProfile()))
-				{	/* allow explicit termination without confirmation */
+				{    /* allow explicit termination without confirmation */
 					mService.disconnect();
 					finish();
 					return;
@@ -583,9 +585,9 @@ public class VpnProfileControlActivity extends AppCompatActivity
 			final Bundle profileInfo = getArguments();
 			LayoutInflater inflater = getActivity().getLayoutInflater();
 			View view = inflater.inflate(R.layout.login_dialog, null);
-			EditText username = (EditText)view.findViewById(R.id.username);
+			EditText username = view.findViewById(R.id.username);
 			username.setText(profileInfo.getString(VpnProfileDataSource.KEY_USERNAME));
-			final EditText password = (EditText)view.findViewById(R.id.password);
+			final EditText password = view.findViewById(R.id.password);
 
 			AlertDialog.Builder adb = new AlertDialog.Builder(getActivity());
 			adb.setView(view);
@@ -634,7 +636,7 @@ public class VpnProfileControlActivity extends AppCompatActivity
 					VpnProfileControlActivity activity = (VpnProfileControlActivity)getActivity();
 					activity.mWaitingForResult = true;
 					Intent intent = new Intent(Settings.ACTION_REQUEST_IGNORE_BATTERY_OPTIMIZATIONS,
-											   Uri.parse("package:" + activity.getPackageName()));
+					                           Uri.parse("package:" + activity.getPackageName()));
 					activity.mAddToPowerWhitelist.launch(intent);
 				}).create();
 		}

--- a/src/frontends/android/app/src/main/java/org/strongswan/android/ui/VpnProfileDetailActivity.java
+++ b/src/frontends/android/app/src/main/java/org/strongswan/android/ui/VpnProfileDetailActivity.java
@@ -19,11 +19,9 @@
 package org.strongswan.android.ui;
 
 import android.app.Dialog;
-import android.content.Context;
 import android.content.DialogInterface;
 import android.content.Intent;
 import android.os.Bundle;
-import android.os.Handler;
 import android.security.KeyChain;
 import android.security.KeyChainAliasCallback;
 import android.security.KeyChainException;
@@ -59,7 +57,6 @@ import org.strongswan.android.data.VpnProfileDataSource;
 import org.strongswan.android.data.VpnProfileSource;
 import org.strongswan.android.data.VpnType;
 import org.strongswan.android.data.VpnType.VpnTypeFeature;
-import org.strongswan.android.logic.StrongSwanApplication;
 import org.strongswan.android.logic.TrustedCertificateManager;
 import org.strongswan.android.logic.UserCertificateLoader;
 import org.strongswan.android.security.TrustedCertificateEntry;
@@ -75,7 +72,6 @@ import java.util.ArrayList;
 import java.util.SortedSet;
 import java.util.TreeSet;
 import java.util.UUID;
-import java.util.concurrent.Executor;
 
 import androidx.activity.result.ActivityResultLauncher;
 import androidx.activity.result.contract.ActivityResultContracts;
@@ -896,6 +892,14 @@ public class VpnProfileDetailActivity extends AppCompatActivity
 
 		mCheckAuto.setEnabled(!readOnly);
 		mSelectSelectedAppsHandling.setEnabled(!readOnly);
+
+		findViewById(R.id.install_user_certificate).setEnabled(!readOnly);
+
+		if (readOnly)
+		{
+			mSelectCert.setOnClickListener(null);
+			mSelectUserCert.setOnClickListener(null);
+		}
 	}
 
 	/**

--- a/src/frontends/android/app/src/main/java/org/strongswan/android/ui/VpnProfileDetailActivity.java
+++ b/src/frontends/android/app/src/main/java/org/strongswan/android/ui/VpnProfileDetailActivity.java
@@ -88,7 +88,7 @@ import androidx.localbroadcastmanager.content.LocalBroadcastManager;
 public class VpnProfileDetailActivity extends AppCompatActivity
 {
 	private VpnProfileDataSource mDataSource;
-	private Long mId;
+	private String mUuid;
 	private TrustedCertificateEntry mCertEntry;
 	private String mUserCertLoading;
 	private CertificateIdentitiesAdapter mSelectUserIdAdapter;
@@ -384,11 +384,11 @@ public class VpnProfileDetailActivity extends AppCompatActivity
 			}
 		});
 
-		mId = savedInstanceState == null ? null : savedInstanceState.getLong(VpnProfileDataSource.KEY_ID);
-		if (mId == null)
+		mUuid = savedInstanceState == null ? null : savedInstanceState.getString(VpnProfileDataSource.KEY_UUID);
+		if (mUuid == null)
 		{
 			Bundle extras = getIntent().getExtras();
-			mId = extras == null ? null : extras.getLong(VpnProfileDataSource.KEY_ID);
+			mUuid = extras == null ? null : extras.getString(VpnProfileDataSource.KEY_UUID);
 		}
 
 		loadProfileData(savedInstanceState);
@@ -410,9 +410,9 @@ public class VpnProfileDetailActivity extends AppCompatActivity
 	protected void onSaveInstanceState(Bundle outState)
 	{
 		super.onSaveInstanceState(outState);
-		if (mId != null)
+		if (mUuid != null)
 		{
-			outState.putLong(VpnProfileDataSource.KEY_ID, mId);
+			outState.putString(VpnProfileDataSource.KEY_UUID, mUuid);
 		}
 		if (mUserCertEntry != null)
 		{
@@ -619,10 +619,10 @@ public class VpnProfileDetailActivity extends AppCompatActivity
 				mDataSource.insertProfile(mProfile);
 			}
 			Intent intent = new Intent(Constants.VPN_PROFILES_CHANGED);
-			intent.putExtra(Constants.VPN_PROFILES_SINGLE, mProfile.getId());
+			intent.putExtra(Constants.VPN_PROFILES_SINGLE, mProfile.getUUID().toString());
 			LocalBroadcastManager.getInstance(this).sendBroadcast(intent);
 
-			setResult(RESULT_OK, new Intent().putExtra(VpnProfileDataSource.KEY_ID, mProfile.getId()));
+			setResult(RESULT_OK, new Intent().putExtra(VpnProfileDataSource.KEY_UUID, mProfile.getUUID().toString()));
 			finish();
 		}
 	}
@@ -757,13 +757,15 @@ public class VpnProfileDetailActivity extends AppCompatActivity
 	 */
 	private void loadProfileData(Bundle savedInstanceState)
 	{
-		String useralias = null, local_id = null, alias = null;
+		String useralias = null;
+		String local_id = null;
+		String alias = null;
 		Integer flags = null;
 
 		getSupportActionBar().setTitle(R.string.add_profile);
-		if (mId != null && mId != 0)
+		if (mUuid != null)
 		{
-			mProfile = mDataSource.getVpnProfile(mId);
+			mProfile = mDataSource.getVpnProfile(mUuid);
 			if (mProfile != null)
 			{
 				mName.setText(mProfile.getName());
@@ -797,7 +799,7 @@ public class VpnProfileDetailActivity extends AppCompatActivity
 			else
 			{
 				Log.e(VpnProfileDetailActivity.class.getSimpleName(),
-				      "VPN profile with id " + mId + " not found");
+				      "VPN profile with UUID " + mUuid + " not found");
 				finish();
 			}
 		}

--- a/src/frontends/android/app/src/main/java/org/strongswan/android/ui/VpnProfileDetailActivity.java
+++ b/src/frontends/android/app/src/main/java/org/strongswan/android/ui/VpnProfileDetailActivity.java
@@ -97,6 +97,7 @@ public class VpnProfileDetailActivity extends AppCompatActivity
 	private SelectedAppsHandling mSelectedAppsHandling = SelectedAppsHandling.SELECTED_APPS_DISABLE;
 	private SortedSet<String> mSelectedApps = new TreeSet<>();
 	private VpnProfile mProfile;
+	private View mManagedProfile;
 	private MultiAutoCompleteTextView mName;
 	private TextInputLayoutHelper mNameWrap;
 	private EditText mGateway;
@@ -193,6 +194,8 @@ public class VpnProfileDetailActivity extends AppCompatActivity
 		mDataSource.open();
 
 		setContentView(R.layout.profile_detail_view);
+
+		mManagedProfile = findViewById(R.id.managed_profile);
 
 		mName = findViewById(R.id.name);
 		mNameWrap = findViewById(R.id.name_wrap);
@@ -855,6 +858,15 @@ public class VpnProfileDetailActivity extends AppCompatActivity
 
 	private void setReadOnly(final boolean readOnly)
 	{
+		if (readOnly)
+		{
+			mManagedProfile.setVisibility(View.VISIBLE);
+		}
+		else
+		{
+			mManagedProfile.setVisibility(View.GONE);
+		}
+
 		mName.setEnabled(!readOnly);
 		mGateway.setEnabled(!readOnly);
 		mUsername.setEnabled(!readOnly);

--- a/src/frontends/android/app/src/main/java/org/strongswan/android/ui/VpnProfileDetailActivity.java
+++ b/src/frontends/android/app/src/main/java/org/strongswan/android/ui/VpnProfileDetailActivity.java
@@ -56,6 +56,7 @@ import org.strongswan.android.R;
 import org.strongswan.android.data.VpnProfile;
 import org.strongswan.android.data.VpnProfile.SelectedAppsHandling;
 import org.strongswan.android.data.VpnProfileDataSource;
+import org.strongswan.android.data.VpnProfileSource;
 import org.strongswan.android.data.VpnType;
 import org.strongswan.android.data.VpnType.VpnTypeFeature;
 import org.strongswan.android.logic.StrongSwanApplication;
@@ -188,7 +189,7 @@ public class VpnProfileDetailActivity extends AppCompatActivity
 		/* the title is set when we load the profile, if any */
 		getSupportActionBar().setDisplayHomeAsUpEnabled(true);
 
-		mDataSource = new VpnProfileDataSource(this);
+		mDataSource = new VpnProfileSource(this);
 		mDataSource.open();
 
 		setContentView(R.layout.profile_detail_view);

--- a/src/frontends/android/app/src/main/java/org/strongswan/android/ui/VpnProfileDetailActivity.java
+++ b/src/frontends/android/app/src/main/java/org/strongswan/android/ui/VpnProfileDetailActivity.java
@@ -787,6 +787,8 @@ public class VpnProfileDetailActivity extends AppCompatActivity
 				local_id = mProfile.getLocalId();
 				alias = mProfile.getCertificateAlias();
 				getSupportActionBar().setTitle(mProfile.getName());
+
+				setReadOnly(mProfile.isReadOnly());
 			}
 			else
 			{
@@ -849,6 +851,36 @@ public class VpnProfileDetailActivity extends AppCompatActivity
 			ArrayList<String> selectedApps = savedInstanceState.getStringArrayList(VpnProfileDataSource.KEY_SELECTED_APPS_LIST);
 			mSelectedApps = new TreeSet<>(selectedApps);
 		}
+	}
+
+	private void setReadOnly(final boolean readOnly)
+	{
+		mName.setEnabled(!readOnly);
+		mGateway.setEnabled(!readOnly);
+		mUsername.setEnabled(!readOnly);
+		mRemoteId.setEnabled(!readOnly);
+		mLocalId.setEnabled(!readOnly);
+		mMTU.setEnabled(!readOnly);
+		mPort.setEnabled(!readOnly);
+		mNATKeepalive.setEnabled(!readOnly);
+		mIncludedSubnets.setEnabled(!readOnly);
+		mExcludedSubnets.setEnabled(!readOnly);
+		mBlockIPv4.setEnabled(!readOnly);
+		mBlockIPv6.setEnabled(!readOnly);
+		mIkeProposal.setEnabled(!readOnly);
+		mEspProposal.setEnabled(!readOnly);
+		mDnsServers.setEnabled(!readOnly);
+
+		mSelectVpnType.setEnabled(!readOnly);
+		mCertReq.setEnabled(!readOnly);
+		mUseCrl.setEnabled(!readOnly);
+		mUseOcsp.setEnabled(!readOnly);
+		mStrictRevocation.setEnabled(!readOnly);
+		mRsaPss.setEnabled(!readOnly);
+		mIPv6Transport.setEnabled(!readOnly);
+
+		mCheckAuto.setEnabled(!readOnly);
+		mSelectSelectedAppsHandling.setEnabled(!readOnly);
 	}
 
 	/**

--- a/src/frontends/android/app/src/main/java/org/strongswan/android/ui/VpnProfileDetailActivity.java
+++ b/src/frontends/android/app/src/main/java/org/strongswan/android/ui/VpnProfileDetailActivity.java
@@ -379,6 +379,7 @@ public class VpnProfileDetailActivity extends AppCompatActivity
 			{
 				Intent intent = new Intent(VpnProfileDetailActivity.this, SelectedApplicationsActivity.class);
 				intent.putExtra(VpnProfileDataSource.KEY_SELECTED_APPS_LIST, new ArrayList<>(mSelectedApps));
+				intent.putExtra(VpnProfileDataSource.KEY_READ_ONLY, mProfile.isReadOnly());
 				mSelectApplications.launch(intent);
 			}
 		});

--- a/src/frontends/android/app/src/main/java/org/strongswan/android/ui/VpnProfileDetailActivity.java
+++ b/src/frontends/android/app/src/main/java/org/strongswan/android/ui/VpnProfileDetailActivity.java
@@ -22,7 +22,6 @@ import android.app.Dialog;
 import android.content.Context;
 import android.content.DialogInterface;
 import android.content.Intent;
-import android.os.Build;
 import android.os.Bundle;
 import android.os.Handler;
 import android.security.KeyChain;
@@ -44,7 +43,6 @@ import android.view.ViewGroup;
 import android.widget.AdapterView;
 import android.widget.AdapterView.OnItemSelectedListener;
 import android.widget.ArrayAdapter;
-import android.widget.Button;
 import android.widget.CheckBox;
 import android.widget.CompoundButton;
 import android.widget.CompoundButton.OnCheckedChangeListener;
@@ -195,64 +193,64 @@ public class VpnProfileDetailActivity extends AppCompatActivity
 
 		setContentView(R.layout.profile_detail_view);
 
-		mName = (MultiAutoCompleteTextView)findViewById(R.id.name);
-		mNameWrap = (TextInputLayoutHelper)findViewById(R.id.name_wrap);
-		mGateway = (EditText)findViewById(R.id.gateway);
-		mGatewayWrap = (TextInputLayoutHelper) findViewById(R.id.gateway_wrap);
-		mSelectVpnType = (Spinner)findViewById(R.id.vpn_type);
-		mTncNotice = (RelativeLayout)findViewById(R.id.tnc_notice);
+		mName = findViewById(R.id.name);
+		mNameWrap = findViewById(R.id.name_wrap);
+		mGateway = findViewById(R.id.gateway);
+		mGatewayWrap = findViewById(R.id.gateway_wrap);
+		mSelectVpnType = findViewById(R.id.vpn_type);
+		mTncNotice = findViewById(R.id.tnc_notice);
 
-		mUsernamePassword = (ViewGroup)findViewById(R.id.username_password_group);
-		mUsername = (EditText)findViewById(R.id.username);
-		mUsernameWrap = (TextInputLayoutHelper) findViewById(R.id.username_wrap);
-		mPassword = (EditText)findViewById(R.id.password);
+		mUsernamePassword = findViewById(R.id.username_password_group);
+		mUsername = findViewById(R.id.username);
+		mUsernameWrap = findViewById(R.id.username_wrap);
+		mPassword = findViewById(R.id.password);
 
-		mUserCertificate = (ViewGroup)findViewById(R.id.user_certificate_group);
-		mSelectUserCert = (RelativeLayout)findViewById(R.id.select_user_certificate);
+		mUserCertificate = findViewById(R.id.user_certificate_group);
+		mSelectUserCert = findViewById(R.id.select_user_certificate);
 
-		mCheckAuto = (CheckBox)findViewById(R.id.ca_auto);
-		mSelectCert = (RelativeLayout)findViewById(R.id.select_certificate);
+		mCheckAuto = findViewById(R.id.ca_auto);
+		mSelectCert = findViewById(R.id.select_certificate);
 
-		mShowAdvanced = (CheckBox)findViewById(R.id.show_advanced);
-		mAdvancedSettings = (ViewGroup)findViewById(R.id.advanced_settings);
+		mShowAdvanced = findViewById(R.id.show_advanced);
+		mAdvancedSettings = findViewById(R.id.advanced_settings);
 
-		mRemoteId = (MultiAutoCompleteTextView)findViewById(R.id.remote_id);
-		mRemoteIdWrap = (TextInputLayoutHelper) findViewById(R.id.remote_id_wrap);
+		mRemoteId = findViewById(R.id.remote_id);
+		mRemoteIdWrap = findViewById(R.id.remote_id_wrap);
 		mLocalId = findViewById(R.id.local_id);
 		mLocalIdWrap = findViewById(R.id.local_id_wrap);
 		mDnsServers = findViewById(R.id.dns_servers);
 		mDnsServersWrap = findViewById(R.id.dns_servers_wrap);
-		mMTU = (EditText)findViewById(R.id.mtu);
-		mMTUWrap = (TextInputLayoutHelper) findViewById(R.id.mtu_wrap);
-		mPort = (EditText)findViewById(R.id.port);
-		mPortWrap = (TextInputLayoutHelper) findViewById(R.id.port_wrap);
-		mNATKeepalive = (EditText)findViewById(R.id.nat_keepalive);
-		mNATKeepaliveWrap = (TextInputLayoutHelper) findViewById(R.id.nat_keepalive_wrap);
+		mMTU = findViewById(R.id.mtu);
+		mMTUWrap = findViewById(R.id.mtu_wrap);
+		mPort = findViewById(R.id.port);
+		mPortWrap = findViewById(R.id.port_wrap);
+		mNATKeepalive = findViewById(R.id.nat_keepalive);
+		mNATKeepaliveWrap = findViewById(R.id.nat_keepalive_wrap);
 		mCertReq = findViewById(R.id.cert_req);
 		mUseCrl = findViewById(R.id.use_crl);
 		mUseOcsp = findViewById(R.id.use_ocsp);
-		mStrictRevocation= findViewById(R.id.strict_revocation);
-		mRsaPss= findViewById(R.id.rsa_pss);
-		mIPv6Transport= findViewById(R.id.ipv6_transport);
-		mIncludedSubnets = (EditText)findViewById(R.id.included_subnets);
-		mIncludedSubnetsWrap = (TextInputLayoutHelper)findViewById(R.id.included_subnets_wrap);
-		mExcludedSubnets = (EditText)findViewById(R.id.excluded_subnets);
-		mExcludedSubnetsWrap = (TextInputLayoutHelper)findViewById(R.id.excluded_subnets_wrap);
-		mBlockIPv4 = (CheckBox)findViewById(R.id.split_tunneling_v4);
-		mBlockIPv6 = (CheckBox)findViewById(R.id.split_tunneling_v6);
+		mStrictRevocation = findViewById(R.id.strict_revocation);
+		mRsaPss = findViewById(R.id.rsa_pss);
+		mIPv6Transport = findViewById(R.id.ipv6_transport);
+		mIncludedSubnets = findViewById(R.id.included_subnets);
+		mIncludedSubnetsWrap = findViewById(R.id.included_subnets_wrap);
+		mExcludedSubnets = findViewById(R.id.excluded_subnets);
+		mExcludedSubnetsWrap = findViewById(R.id.excluded_subnets_wrap);
+		mBlockIPv4 = findViewById(R.id.split_tunneling_v4);
+		mBlockIPv6 = findViewById(R.id.split_tunneling_v6);
 
-		mSelectSelectedAppsHandling = (Spinner)findViewById(R.id.apps_handling);
-		mSelectApps = (RelativeLayout)findViewById(R.id.select_applications);
+		mSelectSelectedAppsHandling = findViewById(R.id.apps_handling);
+		mSelectApps = findViewById(R.id.select_applications);
 
-		mIkeProposal = (EditText)findViewById(R.id.ike_proposal);
-		mIkeProposalWrap = (TextInputLayoutHelper)findViewById(R.id.ike_proposal_wrap);
-		mEspProposal = (EditText)findViewById(R.id.esp_proposal);
-		mEspProposalWrap = (TextInputLayoutHelper)findViewById(R.id.esp_proposal_wrap);
+		mIkeProposal = findViewById(R.id.ike_proposal);
+		mIkeProposalWrap = findViewById(R.id.ike_proposal_wrap);
+		mEspProposal = findViewById(R.id.esp_proposal);
+		mEspProposalWrap = findViewById(R.id.esp_proposal_wrap);
 		/* make the link clickable */
 		((TextView)findViewById(R.id.proposal_intro)).setMovementMethod(LinkMovementMethod.getInstance());
 
-		mProfileIdLabel = (TextView)findViewById(R.id.profile_id_label);
-		mProfileId = (TextView)findViewById(R.id.profile_id);
+		mProfileIdLabel = findViewById(R.id.profile_id_label);
+		mProfileId = findViewById(R.id.profile_id);
 
 		final SpaceTokenizer spaceTokenizer = new SpaceTokenizer();
 		mName.setTokenizer(spaceTokenizer);
@@ -262,14 +260,8 @@ public class VpnProfileDetailActivity extends AppCompatActivity
 		mName.setAdapter(gatewayAdapter);
 		mRemoteId.setAdapter(gatewayAdapter);
 
-		if (Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP)
+		mGateway.addTextChangedListener(new TextWatcher()
 		{
-			findViewById(R.id.apps).setVisibility(View.GONE);
-			mSelectSelectedAppsHandling.setVisibility(View.GONE);
-			mSelectApps.setVisibility(View.GONE);
-		}
-
-		mGateway.addTextChangedListener(new TextWatcher() {
 			@Override
 			public void beforeTextChanged(CharSequence s, int start, int count, int after) {}
 
@@ -294,7 +286,8 @@ public class VpnProfileDetailActivity extends AppCompatActivity
 			}
 		});
 
-		mSelectVpnType.setOnItemSelectedListener(new OnItemSelectedListener() {
+		mSelectVpnType.setOnItemSelectedListener(new OnItemSelectedListener()
+		{
 			@Override
 			public void onItemSelected(AdapterView<?> parent, View view, int position, long id)
 			{
@@ -304,7 +297,7 @@ public class VpnProfileDetailActivity extends AppCompatActivity
 
 			@Override
 			public void onNothingSelected(AdapterView<?> parent)
-			{	/* should not happen */
+			{    /* should not happen */
 				mVpnType = VpnType.IKEV2_EAP;
 				updateCredentialView();
 			}
@@ -312,7 +305,8 @@ public class VpnProfileDetailActivity extends AppCompatActivity
 
 		((TextView)mTncNotice.findViewById(android.R.id.text1)).setText(R.string.tnc_notice_title);
 		((TextView)mTncNotice.findViewById(android.R.id.text2)).setText(R.string.tnc_notice_subtitle);
-		mTncNotice.setOnClickListener(new OnClickListener() {
+		mTncNotice.setOnClickListener(new OnClickListener()
+		{
 			@Override
 			public void onClick(View v)
 			{
@@ -321,14 +315,15 @@ public class VpnProfileDetailActivity extends AppCompatActivity
 		});
 
 		mSelectUserCert.setOnClickListener(new SelectUserCertOnClickListener());
-		((Button)findViewById(R.id.install_user_certificate)).setOnClickListener(v -> {
+		findViewById(R.id.install_user_certificate).setOnClickListener(v -> {
 			Intent intent = KeyChain.createInstallIntent();
 			mInstallPKCS12.launch(intent);
 		});
 		mSelectUserIdAdapter = new CertificateIdentitiesAdapter(this);
 		mLocalId.setAdapter(mSelectUserIdAdapter);
 
-		mCheckAuto.setOnCheckedChangeListener(new OnCheckedChangeListener() {
+		mCheckAuto.setOnCheckedChangeListener(new OnCheckedChangeListener()
+		{
 			@Override
 			public void onCheckedChanged(CompoundButton buttonView, boolean isChecked)
 			{
@@ -336,7 +331,8 @@ public class VpnProfileDetailActivity extends AppCompatActivity
 			}
 		});
 
-		mSelectCert.setOnClickListener(new OnClickListener() {
+		mSelectCert.setOnClickListener(new OnClickListener()
+		{
 			@Override
 			public void onClick(View v)
 			{
@@ -346,7 +342,8 @@ public class VpnProfileDetailActivity extends AppCompatActivity
 			}
 		});
 
-		mShowAdvanced.setOnCheckedChangeListener(new OnCheckedChangeListener() {
+		mShowAdvanced.setOnCheckedChangeListener(new OnCheckedChangeListener()
+		{
 			@Override
 			public void onCheckedChanged(CompoundButton buttonView, boolean isChecked)
 			{
@@ -354,7 +351,8 @@ public class VpnProfileDetailActivity extends AppCompatActivity
 			}
 		});
 
-		mSelectSelectedAppsHandling.setOnItemSelectedListener(new OnItemSelectedListener() {
+		mSelectSelectedAppsHandling.setOnItemSelectedListener(new OnItemSelectedListener()
+		{
 			@Override
 			public void onItemSelected(AdapterView<?> parent, View view, int position, long id)
 			{
@@ -364,13 +362,14 @@ public class VpnProfileDetailActivity extends AppCompatActivity
 
 			@Override
 			public void onNothingSelected(AdapterView<?> parent)
-			{	/* should not happen */
+			{    /* should not happen */
 				mSelectedAppsHandling = SelectedAppsHandling.SELECTED_APPS_DISABLE;
 				updateAppsSelector();
 			}
 		});
 
-		mSelectApps.setOnClickListener(new OnClickListener() {
+		mSelectApps.setOnClickListener(new OnClickListener()
+		{
 			@Override
 			public void onClick(View v)
 			{
@@ -464,7 +463,7 @@ public class VpnProfileDetailActivity extends AppCompatActivity
 				((TextView)mSelectUserCert.findViewById(android.R.id.text2)).setText(R.string.loading);
 			}
 			else if (mUserCertEntry != null)
-			{	/* clear any errors and set the new data */
+			{   /* clear any errors and set the new data */
 				((TextView)mSelectUserCert.findViewById(android.R.id.text1)).setError(null);
 				((TextView)mSelectUserCert.findViewById(android.R.id.text1)).setText(mUserCertEntry.getAlias());
 				((TextView)mSelectUserCert.findViewById(android.R.id.text2)).setText(mUserCertEntry.getCertificate().getSubjectDN().toString());
@@ -489,7 +488,8 @@ public class VpnProfileDetailActivity extends AppCompatActivity
 		AlertDialog.Builder adb = new AlertDialog.Builder(VpnProfileDetailActivity.this);
 		adb.setTitle(R.string.alert_text_nocertfound_title);
 		adb.setMessage(R.string.alert_text_nocertfound);
-		adb.setPositiveButton(android.R.string.ok, new DialogInterface.OnClickListener() {
+		adb.setPositiveButton(android.R.string.ok, new DialogInterface.OnClickListener()
+		{
 			@Override
 			public void onClick(DialogInterface dialog, int id)
 			{
@@ -573,12 +573,12 @@ public class VpnProfileDetailActivity extends AppCompatActivity
 		{
 			Integer st = mProfile.getSplitTunneling(), flags = mProfile.getFlags();
 			show = mProfile.getRemoteId() != null || mProfile.getMTU() != null ||
-				   mProfile.getPort() != null || mProfile.getNATKeepAlive() != null ||
-				   (flags != null && flags != 0) || (st != null && st != 0) ||
-				   mProfile.getIncludedSubnets() != null || mProfile.getExcludedSubnets() != null ||
-				   mProfile.getSelectedAppsHandling() != SelectedAppsHandling.SELECTED_APPS_DISABLE ||
-				   mProfile.getIkeProposal() != null || mProfile.getEspProposal() != null ||
-				   mProfile.getDnsServers() != null || mProfile.getLocalId() != null;
+				mProfile.getPort() != null || mProfile.getNATKeepAlive() != null ||
+				(flags != null && flags != 0) || (st != null && st != 0) ||
+				mProfile.getIncludedSubnets() != null || mProfile.getExcludedSubnets() != null ||
+				mProfile.getSelectedAppsHandling() != SelectedAppsHandling.SELECTED_APPS_DISABLE ||
+				mProfile.getIkeProposal() != null || mProfile.getEspProposal() != null ||
+				mProfile.getDnsServers() != null || mProfile.getLocalId() != null;
 		}
 		mShowAdvanced.setVisibility(!show ? View.VISIBLE : View.GONE);
 		mAdvancedSettings.setVisibility(show ? View.VISIBLE : View.GONE);
@@ -624,6 +624,7 @@ public class VpnProfileDetailActivity extends AppCompatActivity
 
 	/**
 	 * Verify the user input and display error messages.
+	 *
 	 * @return true if the input is valid
 	 */
 	private boolean verifyInput()
@@ -643,7 +644,7 @@ public class VpnProfileDetailActivity extends AppCompatActivity
 			}
 		}
 		if (mVpnType.has(VpnTypeFeature.CERTIFICATE) && mUserCertEntry == null)
-		{	/* let's show an error icon */
+		{    /* let's show an error icon */
 			((TextView)mSelectUserCert.findViewById(android.R.id.text1)).setError("");
 			valid = false;
 		}
@@ -675,7 +676,7 @@ public class VpnProfileDetailActivity extends AppCompatActivity
 		if (!validateInteger(mNATKeepalive, Constants.NAT_KEEPALIVE_MIN, Constants.NAT_KEEPALIVE_MAX))
 		{
 			mNATKeepaliveWrap.setError(String.format(getString(R.string.alert_text_out_of_range),
-													 Constants.NAT_KEEPALIVE_MIN, Constants.NAT_KEEPALIVE_MAX));
+			                                         Constants.NAT_KEEPALIVE_MIN, Constants.NAT_KEEPALIVE_MAX));
 			valid = false;
 		}
 		if (!validateProposal(mIkeProposal, true))
@@ -789,7 +790,7 @@ public class VpnProfileDetailActivity extends AppCompatActivity
 			else
 			{
 				Log.e(VpnProfileDetailActivity.class.getSimpleName(),
-					  "VPN profile with id " + mId + " not found");
+				      "VPN profile with id " + mId + " not found");
 				finish();
 			}
 		}
@@ -808,14 +809,14 @@ public class VpnProfileDetailActivity extends AppCompatActivity
 		{
 			mUserCertLoading = useralias;
 			UserCertificateLoader loader = new UserCertificateLoader(((StrongSwanApplication)getApplication()).getExecutor(),
-																	 ((StrongSwanApplication)getApplication()).getHandler());
+			                                                         ((StrongSwanApplication)getApplication()).getHandler());
 			loader.loadCertifiate(this, useralias, result -> {
 				if (result != null)
 				{
 					mUserCertEntry = new TrustedCertificateEntry(mUserCertLoading, result);
 				}
 				else
-				{	/* previously selected certificate is not here anymore */
+				{    /* previously selected certificate is not here anymore */
 					((TextView)mSelectUserCert.findViewById(android.R.id.text1)).setError("");
 					mUserCertEntry = null;
 				}
@@ -835,7 +836,7 @@ public class VpnProfileDetailActivity extends AppCompatActivity
 				mCertEntry = new TrustedCertificateEntry(alias, certificate);
 			}
 			else
-			{	/* previously selected certificate is not here anymore */
+			{    /* previously selected certificate is not here anymore */
 				showCertificateAlert();
 				mCertEntry = null;
 			}
@@ -964,12 +965,13 @@ public class VpnProfileDetailActivity extends AppCompatActivity
 		public void alias(final String alias)
 		{
 			if (alias != null)
-			{	/* otherwise the dialog was canceled, the request denied */
+			{    /* otherwise the dialog was canceled, the request denied */
 				try
 				{
 					final X509Certificate[] chain = KeyChain.getCertificateChain(VpnProfileDetailActivity.this, alias);
 					/* alias() is not called from our main thread */
-					runOnUiThread(new Runnable() {
+					runOnUiThread(new Runnable()
+					{
 						@Override
 						public void run()
 						{
@@ -992,7 +994,8 @@ public class VpnProfileDetailActivity extends AppCompatActivity
 	/**
 	 * Callback interface for the user certificate loader.
 	 */
-	private interface UserCertificateLoaderCallback {
+	private interface UserCertificateLoaderCallback
+	{
 		void onComplete(X509Certificate result);
 	}
 
@@ -1050,7 +1053,8 @@ public class VpnProfileDetailActivity extends AppCompatActivity
 			return new AlertDialog.Builder(getActivity())
 				.setTitle(R.string.tnc_notice_title)
 				.setMessage(HtmlCompat.fromHtml(getString(R.string.tnc_notice_details), HtmlCompat.FROM_HTML_MODE_LEGACY))
-				.setPositiveButton(android.R.string.ok, new DialogInterface.OnClickListener() {
+				.setPositiveButton(android.R.string.ok, new DialogInterface.OnClickListener()
+				{
 					@Override
 					public void onClick(DialogInterface dialog, int id)
 					{
@@ -1111,7 +1115,7 @@ public class VpnProfileDetailActivity extends AppCompatActivity
 				if (text instanceof Spanned)
 				{
 					SpannableString sp = new SpannableString(text + " ");
-					TextUtils.copySpansFrom((Spanned) text, 0, text.length(), Object.class, sp, 0);
+					TextUtils.copySpansFrom((Spanned)text, 0, text.length(), Object.class, sp, 0);
 					return sp;
 				}
 				else

--- a/src/frontends/android/app/src/main/java/org/strongswan/android/ui/VpnProfileImportActivity.java
+++ b/src/frontends/android/app/src/main/java/org/strongswan/android/ui/VpnProfileImportActivity.java
@@ -45,6 +45,7 @@ import org.strongswan.android.R;
 import org.strongswan.android.data.VpnProfile;
 import org.strongswan.android.data.VpnProfile.SelectedAppsHandling;
 import org.strongswan.android.data.VpnProfileDataSource;
+import org.strongswan.android.data.VpnProfileSource;
 import org.strongswan.android.data.VpnType;
 import org.strongswan.android.data.VpnType.VpnTypeFeature;
 import org.strongswan.android.logic.TrustedCertificateManager;
@@ -184,7 +185,7 @@ public class VpnProfileImportActivity extends AppCompatActivity
 		getSupportActionBar().setHomeAsUpIndicator(R.drawable.ic_close_white_24dp);
 		getSupportActionBar().setDisplayHomeAsUpEnabled(true);
 
-		mDataSource = new VpnProfileDataSource(this);
+		mDataSource = new VpnProfileSource(this);
 		mDataSource.open();
 
 		setContentView(R.layout.profile_import_view);

--- a/src/frontends/android/app/src/main/java/org/strongswan/android/ui/VpnProfileImportActivity.java
+++ b/src/frontends/android/app/src/main/java/org/strongswan/android/ui/VpnProfileImportActivity.java
@@ -675,7 +675,7 @@ public class VpnProfileImportActivity extends AppCompatActivity
 			updateProfileData();
 			if (mExisting != null)
 			{
-				mProfile.setId(mExisting.getId());
+				mProfile.setUUID(mExisting.getUUID());
 				mDataSource.updateVpnProfile(mProfile);
 			}
 			else
@@ -697,14 +697,14 @@ public class VpnProfileImportActivity extends AppCompatActivity
 				}
 			}
 			Intent intent = new Intent(Constants.VPN_PROFILES_CHANGED);
-			intent.putExtra(Constants.VPN_PROFILES_SINGLE, mProfile.getId());
+			intent.putExtra(Constants.VPN_PROFILES_SINGLE, mProfile.getUUID().toString());
 			LocalBroadcastManager.getInstance(this).sendBroadcast(intent);
 
 			intent = new Intent(this, MainActivity.class);
 			intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
 			startActivity(intent);
 
-			setResult(RESULT_OK, new Intent().putExtra(VpnProfileDataSource.KEY_ID, mProfile.getId()));
+			setResult(RESULT_OK, new Intent().putExtra(VpnProfileDataSource.KEY_UUID, mProfile.getUUID().toString()));
 			finish();
 		}
 	}

--- a/src/frontends/android/app/src/main/java/org/strongswan/android/ui/VpnProfileImportActivity.java
+++ b/src/frontends/android/app/src/main/java/org/strongswan/android/ui/VpnProfileImportActivity.java
@@ -21,7 +21,6 @@ import android.content.ContentResolver;
 import android.content.Context;
 import android.content.Intent;
 import android.net.Uri;
-import android.os.Build;
 import android.os.Bundle;
 import android.security.KeyChain;
 import android.security.KeyChainAliasCallback;
@@ -116,7 +115,7 @@ public class VpnProfileImportActivity extends AppCompatActivity
 		new ActivityResultContracts.StartActivityForResult(),
 		result -> {
 			if (result.getResultCode() == RESULT_OK)
-			{	/* no need to import twice */
+			{   /* no need to import twice */
 				mImportUserCert.setEnabled(false);
 				mSelectUserCert.performClick();
 			}
@@ -135,12 +134,12 @@ public class VpnProfileImportActivity extends AppCompatActivity
 		}
 	);
 
-	private LoaderManager.LoaderCallbacks<ProfileLoadResult> mProfileLoaderCallbacks = new LoaderManager.LoaderCallbacks<ProfileLoadResult>()
+	private final LoaderManager.LoaderCallbacks<ProfileLoadResult> mProfileLoaderCallbacks = new LoaderManager.LoaderCallbacks<ProfileLoadResult>()
 	{
 		@Override
 		public Loader<ProfileLoadResult> onCreateLoader(int id, Bundle args)
 		{
-			return new ProfileLoader(VpnProfileImportActivity.this, (Uri)args.getParcelable(PROFILE_URI));
+			return new ProfileLoader(VpnProfileImportActivity.this, args.getParcelable(PROFILE_URI));
 		}
 
 		@Override
@@ -156,7 +155,7 @@ public class VpnProfileImportActivity extends AppCompatActivity
 		}
 	};
 
-	private LoaderManager.LoaderCallbacks<TrustedCertificateEntry> mUserCertificateLoaderCallbacks = new LoaderManager.LoaderCallbacks<TrustedCertificateEntry>()
+	private final LoaderManager.LoaderCallbacks<TrustedCertificateEntry> mUserCertificateLoaderCallbacks = new LoaderManager.LoaderCallbacks<TrustedCertificateEntry>()
 	{
 		@Override
 		public Loader<TrustedCertificateEntry> onCreateLoader(int id, Bundle args)
@@ -191,23 +190,23 @@ public class VpnProfileImportActivity extends AppCompatActivity
 		setContentView(R.layout.profile_import_view);
 
 		mProgressBar = findViewById(R.id.progress_bar);
-		mExistsWarning = (TextView)findViewById(R.id.exists_warning);
-		mBasicDataGroup = (ViewGroup)findViewById(R.id.basic_data_group);
-		mName = (TextView)findViewById(R.id.name);
-		mGateway = (TextView)findViewById(R.id.gateway);
-		mSelectVpnType = (TextView)findViewById(R.id.vpn_type);
+		mExistsWarning = findViewById(R.id.exists_warning);
+		mBasicDataGroup = findViewById(R.id.basic_data_group);
+		mName = findViewById(R.id.name);
+		mGateway = findViewById(R.id.gateway);
+		mSelectVpnType = findViewById(R.id.vpn_type);
 
-		mUsernamePassword = (ViewGroup)findViewById(R.id.username_password_group);
-		mUsername = (EditText)findViewById(R.id.username);
-		mUsernameWrap = (TextInputLayoutHelper) findViewById(R.id.username_wrap);
-		mPassword = (EditText)findViewById(R.id.password);
+		mUsernamePassword = findViewById(R.id.username_password_group);
+		mUsername = findViewById(R.id.username);
+		mUsernameWrap = findViewById(R.id.username_wrap);
+		mPassword = findViewById(R.id.password);
 
-		mUserCertificate = (ViewGroup)findViewById(R.id.user_certificate_group);
-		mSelectUserCert = (RelativeLayout)findViewById(R.id.select_user_certificate);
-		mImportUserCert = (Button)findViewById(R.id.import_user_certificate);
+		mUserCertificate = findViewById(R.id.user_certificate_group);
+		mSelectUserCert = findViewById(R.id.select_user_certificate);
+		mImportUserCert = findViewById(R.id.import_user_certificate);
 
-		mRemoteCertificate = (ViewGroup)findViewById(R.id.remote_certificate_group);
-		mRemoteCert = (RelativeLayout)findViewById(R.id.remote_certificate);
+		mRemoteCertificate = findViewById(R.id.remote_certificate_group);
+		mRemoteCert = findViewById(R.id.remote_certificate);
 
 		mExistsWarning.setVisibility(View.GONE);
 		mBasicDataGroup.setVisibility(View.GONE);
@@ -216,7 +215,8 @@ public class VpnProfileImportActivity extends AppCompatActivity
 		mRemoteCertificate.setVisibility(View.GONE);
 
 		mSelectUserCert.setOnClickListener(new SelectUserCertOnClickListener());
-		mImportUserCert.setOnClickListener(new View.OnClickListener() {
+		mImportUserCert.setOnClickListener(new View.OnClickListener()
+		{
 			@Override
 			public void onClick(View v)
 			{
@@ -233,7 +233,7 @@ public class VpnProfileImportActivity extends AppCompatActivity
 		{
 			loadProfile(getIntent().getData());
 		}
-		else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT)
+		else
 		{
 			Intent openIntent = new Intent(Intent.ACTION_OPEN_DOCUMENT);
 			openIntent.setType("*/*");
@@ -242,7 +242,7 @@ public class VpnProfileImportActivity extends AppCompatActivity
 				mOpenDocument.launch(openIntent);
 			}
 			catch (ActivityNotFoundException e)
-			{	/* some devices are unable to browse for files */
+			{   /* some devices are unable to browse for files */
 				finish();
 				return;
 			}
@@ -396,7 +396,7 @@ public class VpnProfileImportActivity extends AppCompatActivity
 		mImportUserCert.setVisibility(mProfile.PKCS12 != null ? View.VISIBLE : View.GONE);
 
 		if (mProfile.getVpnType().has(VpnTypeFeature.CERTIFICATE))
-		{	/* try to load an existing certificate with the default name */
+		{   /* try to load an existing certificate with the default name */
 			if (mUserCertLoading == null)
 			{
 				mUserCertLoading = getString(R.string.profile_cert_alias, mProfile.getName());
@@ -441,7 +441,7 @@ public class VpnProfileImportActivity extends AppCompatActivity
 			((TextView)mSelectUserCert.findViewById(android.R.id.text2)).setText(R.string.loading);
 		}
 		else if (mUserCertEntry != null)
-		{	/* clear any errors and set the new data */
+		{   /* clear any errors and set the new data */
 			((TextView)mSelectUserCert.findViewById(android.R.id.text1)).setError(null);
 			((TextView)mSelectUserCert.findViewById(android.R.id.text1)).setText(mUserCertEntry.getAlias());
 			((TextView)mSelectUserCert.findViewById(android.R.id.text2)).setText(mUserCertEntry.getCertificate().getSubjectDN().toString());
@@ -535,9 +535,9 @@ public class VpnProfileImportActivity extends AppCompatActivity
 		if (split != null)
 		{
 			String included = getSubnets(split, "subnets");
-			profile.setIncludedSubnets(included != null ? included : null);
+			profile.setIncludedSubnets(included);
 			String excluded = getSubnets(split, "excluded");
-			profile.setExcludedSubnets(excluded != null ? excluded : null);
+			profile.setExcludedSubnets(excluded);
 			int st = 0;
 			st |= split.optBoolean("block-ipv4") ? VpnProfile.SPLIT_TUNNELING_BLOCK_IPV4 : 0;
 			st |= split.optBoolean("block-ipv6") ? VpnProfile.SPLIT_TUNNELING_BLOCK_IPV6 : 0;
@@ -586,7 +586,7 @@ public class VpnProfileImportActivity extends AppCompatActivity
 		if (arr != null)
 		{
 			for (int i = 0; i < arr.length(); i++)
-			{	/* replace all spaces, e.g. in "192.168.1.1 - 192.168.1.10" */
+			{   /* replace all spaces, e.g. in "192.168.1.1 - 192.168.1.10" */
 				subnets.add(arr.getString(i).replace(" ", ""));
 			}
 		}
@@ -605,7 +605,7 @@ public class VpnProfileImportActivity extends AppCompatActivity
 			if (ranges == null)
 			{
 				throw new JSONException(getString(R.string.profile_import_failed_value,
-												  "split-tunneling." + key));
+				                                  "split-tunneling." + key));
 			}
 			return ranges.toString();
 		}
@@ -684,7 +684,7 @@ public class VpnProfileImportActivity extends AppCompatActivity
 			if (mCertEntry != null)
 			{
 				try
-				{	/* store the CA/server certificate */
+				{   /* store the CA/server certificate */
 					KeyStore store = KeyStore.getInstance("LocalCertificateStore");
 					store.load(null, null);
 					store.setCertificateEntry(null, mCertEntry.getCertificate());
@@ -710,6 +710,7 @@ public class VpnProfileImportActivity extends AppCompatActivity
 
 	/**
 	 * Verify the user input and display error messages.
+	 *
 	 * @return true if the input is valid
 	 */
 	private boolean verifyInput()
@@ -724,7 +725,7 @@ public class VpnProfileImportActivity extends AppCompatActivity
 			}
 		}
 		if (mProfile.getVpnType().has(VpnTypeFeature.CERTIFICATE) && mUserCertEntry == null)
-		{	/* let's show an error icon */
+		{   /* let's show an error icon */
 			((TextView)mSelectUserCert.findViewById(android.R.id.text1)).setError("");
 			valid = false;
 		}
@@ -804,7 +805,7 @@ public class VpnProfileImportActivity extends AppCompatActivity
 					result.Profile = streamToString(in);
 				}
 				catch (OutOfMemoryError e)
-				{	/* just use a generic exception */
+				{   /* just use a generic exception */
 					result.ThrownException = new RuntimeException();
 				}
 			}
@@ -815,7 +816,7 @@ public class VpnProfileImportActivity extends AppCompatActivity
 		protected void onStartLoading()
 		{
 			if (mData != null)
-			{	/* if we have data ready, deliver it directly */
+			{   /* if we have data ready, deliver it directly */
 				deliverResult(mData);
 			}
 			if (takeContentChanged() || mData == null)
@@ -833,8 +834,8 @@ public class VpnProfileImportActivity extends AppCompatActivity
 			}
 			mData = data;
 			if (isStarted())
-			{	/* if it is started we deliver the data directly,
-				 * otherwise this is handled in onStartLoading */
+			{   /* if it is started we deliver the data directly,
+			 * otherwise this is handled in onStartLoading */
 				super.deliverResult(data);
 			}
 		}
@@ -899,14 +900,15 @@ public class VpnProfileImportActivity extends AppCompatActivity
 		public void alias(final String alias)
 		{
 			/* alias() is not called from our main thread */
-			runOnUiThread(new Runnable() {
+			runOnUiThread(new Runnable()
+			{
 				@Override
 				public void run()
 				{
 					mUserCertLoading = alias;
 					updateUserCertView();
 					if (alias != null)
-					{	/* otherwise the dialog was canceled, the request denied */
+					{   /* otherwise the dialog was canceled, the request denied */
 						LoaderManager.getInstance(VpnProfileImportActivity.this).restartLoader(USER_CERT_LOADER, null, mUserCertificateLoaderCallbacks);
 					}
 				}
@@ -953,7 +955,7 @@ public class VpnProfileImportActivity extends AppCompatActivity
 		protected void onStartLoading()
 		{
 			if (mData != null)
-			{	/* if we have data ready, deliver it directly */
+			{   /* if we have data ready, deliver it directly */
 				deliverResult(mData);
 			}
 			if (takeContentChanged() || mData == null)
@@ -971,8 +973,8 @@ public class VpnProfileImportActivity extends AppCompatActivity
 			}
 			mData = data;
 			if (isStarted())
-			{	/* if it is started we deliver the data directly,
-				 * otherwise this is handled in onStartLoading */
+			{   /* if it is started we deliver the data directly,
+			 * otherwise this is handled in onStartLoading */
 				super.deliverResult(data);
 			}
 		}

--- a/src/frontends/android/app/src/main/java/org/strongswan/android/ui/VpnProfileListFragment.java
+++ b/src/frontends/android/app/src/main/java/org/strongswan/android/ui/VpnProfileListFragment.java
@@ -49,6 +49,7 @@ import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Set;
 import java.util.UUID;
 
 import androidx.fragment.app.Fragment;
@@ -63,7 +64,7 @@ public class VpnProfileListFragment extends Fragment
 	private VpnProfileAdapter mListAdapter;
 	private ListView mListView;
 	private OnVpnProfileSelectedListener mListener;
-	private HashSet<Integer> mSelected;
+	private Set<Integer> mSelected;
 	private boolean mReadOnly;
 
 	private final BroadcastReceiver mProfilesChanged = new BroadcastReceiver()
@@ -235,18 +236,27 @@ public class VpnProfileListFragment extends Fragment
 	{
 		private MenuItem mEditProfile;
 		private MenuItem mCopyProfile;
+		private MenuItem mDeleteProfile;
+
+		private boolean mCanEdit;
+		private boolean mCanCopy;
+		private boolean mCanDelete;
+
+		private int mReadOnlyCount;
 
 		@Override
 		public boolean onPrepareActionMode(ActionMode mode, Menu menu)
 		{
-			mEditProfile.setEnabled(mSelected.size() == 1);
-			mCopyProfile.setEnabled(mEditProfile.isEnabled());
+			mEditProfile.setEnabled(mCanEdit);
+			mCopyProfile.setEnabled(mCanCopy);
+			mDeleteProfile.setEnabled(mCanDelete);
 			return true;
 		}
 
 		@Override
 		public void onDestroyActionMode(ActionMode mode)
 		{
+			mReadOnlyCount = 0;
 			mSelected.clear();
 		}
 
@@ -257,6 +267,7 @@ public class VpnProfileListFragment extends Fragment
 			inflater.inflate(R.menu.profile_list_context, menu);
 			mEditProfile = menu.findItem(R.id.edit_profile);
 			mCopyProfile = menu.findItem(R.id.copy_profile);
+			mDeleteProfile = menu.findItem(R.id.delete_profile);
 			mode.setTitle(R.string.select_profiles);
 			return true;
 		}
@@ -325,13 +336,17 @@ public class VpnProfileListFragment extends Fragment
 		public void onItemCheckedStateChanged(ActionMode mode, int position,
 		                                      long id, boolean checked)
 		{
+			VpnProfile profile = (VpnProfile)mListView.getItemAtPosition(position);
+
 			if (checked)
 			{
 				mSelected.add(position);
+				mReadOnlyCount += (profile.isReadOnly()) ? 1 : 0;
 			}
 			else
 			{
 				mSelected.remove(position);
+				mReadOnlyCount -= (profile.isReadOnly()) ? 1 : 0;
 			}
 			final int checkedCount = mSelected.size();
 			switch (checkedCount)
@@ -346,6 +361,11 @@ public class VpnProfileListFragment extends Fragment
 					mode.setSubtitle(String.format(getString(R.string.x_profiles_selected), checkedCount));
 					break;
 			}
+
+			mCanEdit = checkedCount == 1;
+			mCanCopy = checkedCount == 1 && mReadOnlyCount == 0;
+			mCanDelete = checkedCount > 0 && mReadOnlyCount == 0;
+
 			mode.invalidate();
 		}
 	};

--- a/src/frontends/android/app/src/main/java/org/strongswan/android/ui/VpnProfileListFragment.java
+++ b/src/frontends/android/app/src/main/java/org/strongswan/android/ui/VpnProfileListFragment.java
@@ -166,7 +166,7 @@ public class VpnProfileListFragment extends Fragment
 		mDataSource.open();
 
 		/* cached list of profiles used as backend for the ListView */
-		mVpnProfiles = mDataSource.getAllVpnProfiles();
+		mVpnProfiles = (List<VpnProfile>)mDataSource.getAllVpnProfiles();
 
 		mListAdapter = new VpnProfileAdapter(getActivity(), R.layout.profile_list_item, mVpnProfiles);
 

--- a/src/frontends/android/app/src/main/java/org/strongswan/android/ui/VpnProfileListFragment.java
+++ b/src/frontends/android/app/src/main/java/org/strongswan/android/ui/VpnProfileListFragment.java
@@ -44,6 +44,7 @@ import org.strongswan.android.data.ManagedConfigurationService;
 import org.strongswan.android.data.VpnProfile;
 import org.strongswan.android.data.VpnProfileDataSource;
 import org.strongswan.android.data.VpnProfileSource;
+import org.strongswan.android.logic.StrongSwanApplication;
 import org.strongswan.android.ui.adapter.VpnProfileAdapter;
 import org.strongswan.android.utils.Constants;
 
@@ -179,7 +180,7 @@ public class VpnProfileListFragment extends Fragment
 		mDataSource = new VpnProfileSource(this.getActivity());
 		mDataSource.open();
 
-		mManagedConfigurationService = new ManagedConfigurationService(getContext());
+		mManagedConfigurationService = ((StrongSwanApplication)getContext().getApplicationContext()).getManagedConfigurationService();
 
 		/* cached list of profiles used as backend for the ListView */
 		mVpnProfiles = (List<VpnProfile>)mDataSource.getAllVpnProfiles();
@@ -195,14 +196,6 @@ public class VpnProfileListFragment extends Fragment
 	{
 		super.onSaveInstanceState(outState);
 		outState.putIntegerArrayList(SELECTED_KEY, new ArrayList<>(mSelected));
-	}
-
-	@Override
-	public void onResume()
-	{
-		super.onResume();
-
-		mManagedConfigurationService.loadConfiguration();
 	}
 
 	@Override

--- a/src/frontends/android/app/src/main/java/org/strongswan/android/ui/VpnProfileListFragment.java
+++ b/src/frontends/android/app/src/main/java/org/strongswan/android/ui/VpnProfileListFragment.java
@@ -51,6 +51,7 @@ import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 import java.util.UUID;
 
@@ -76,11 +77,11 @@ public class VpnProfileListFragment extends Fragment
 		@Override
 		public void onReceive(Context context, Intent intent)
 		{
-			long id;
-			long[] ids;
-			if ((id = intent.getLongExtra(Constants.VPN_PROFILES_SINGLE, 0)) > 0)
+			String uuid;
+			String[] uuids;
+			if ((uuid = intent.getStringExtra(Constants.VPN_PROFILES_SINGLE)) != null)
 			{
-				VpnProfile profile = mDataSource.getVpnProfile(id);
+				VpnProfile profile = mDataSource.getVpnProfile(uuid);
 				if (profile != null)
 				{   /* in case this was an edit, we remove it first */
 					mVpnProfiles.remove(profile);
@@ -88,15 +89,15 @@ public class VpnProfileListFragment extends Fragment
 					mListAdapter.notifyDataSetChanged();
 				}
 			}
-			else if ((ids = intent.getLongArrayExtra(Constants.VPN_PROFILES_MULTIPLE)) != null)
+			else if ((uuids = intent.getStringArrayExtra(Constants.VPN_PROFILES_MULTIPLE)) != null)
 			{
-				for (long i : ids)
+				for (String id : uuids)
 				{
 					Iterator<VpnProfile> profiles = mVpnProfiles.iterator();
 					while (profiles.hasNext())
 					{
 						VpnProfile profile = profiles.next();
-						if (profile.getId() == i)
+						if (Objects.equals(profile.getUUID().toString(), id))
 						{
 							profiles.remove();
 							break;
@@ -309,7 +310,7 @@ public class VpnProfileListFragment extends Fragment
 					int position = mSelected.iterator().next();
 					VpnProfile profile = (VpnProfile)mListView.getItemAtPosition(position);
 					Intent connectionIntent = new Intent(getActivity(), VpnProfileDetailActivity.class);
-					connectionIntent.putExtra(VpnProfileDataSource.KEY_ID, profile.getId());
+					connectionIntent.putExtra(VpnProfileDataSource.KEY_UUID, profile.getUUID().toString());
 					startActivity(connectionIntent);
 					break;
 				}
@@ -323,11 +324,11 @@ public class VpnProfileListFragment extends Fragment
 					mDataSource.insertProfile(profile);
 
 					Intent intent = new Intent(Constants.VPN_PROFILES_CHANGED);
-					intent.putExtra(Constants.VPN_PROFILES_SINGLE, profile.getId());
+					intent.putExtra(Constants.VPN_PROFILES_SINGLE, profile.getUUID().toString());
 					LocalBroadcastManager.getInstance(getActivity()).sendBroadcast(intent);
 
 					Intent connectionIntent = new Intent(getActivity(), VpnProfileDetailActivity.class);
-					connectionIntent.putExtra(VpnProfileDataSource.KEY_ID, profile.getId());
+					connectionIntent.putExtra(VpnProfileDataSource.KEY_UUID, profile.getUUID().toString());
 					startActivity(connectionIntent);
 					break;
 				}
@@ -338,15 +339,15 @@ public class VpnProfileListFragment extends Fragment
 					{
 						profiles.add((VpnProfile)mListView.getItemAtPosition(position));
 					}
-					long[] ids = new long[profiles.size()];
+					String[] uuids = new String[profiles.size()];
 					for (int i = 0; i < profiles.size(); i++)
 					{
 						VpnProfile profile = profiles.get(i);
-						ids[i] = profile.getId();
+						uuids[i] = profile.getUUID().toString();
 						mDataSource.deleteVpnProfile(profile);
 					}
 					Intent intent = new Intent(Constants.VPN_PROFILES_CHANGED);
-					intent.putExtra(Constants.VPN_PROFILES_MULTIPLE, ids);
+					intent.putExtra(Constants.VPN_PROFILES_MULTIPLE, uuids);
 					LocalBroadcastManager.getInstance(getActivity()).sendBroadcast(intent);
 					Toast.makeText(VpnProfileListFragment.this.getActivity(),
 					               R.string.profiles_deleted, Toast.LENGTH_SHORT).show();

--- a/src/frontends/android/app/src/main/java/org/strongswan/android/ui/VpnProfileListFragment.java
+++ b/src/frontends/android/app/src/main/java/org/strongswan/android/ui/VpnProfileListFragment.java
@@ -41,6 +41,7 @@ import android.widget.Toast;
 import org.strongswan.android.R;
 import org.strongswan.android.data.VpnProfile;
 import org.strongswan.android.data.VpnProfileDataSource;
+import org.strongswan.android.data.VpnProfileSource;
 import org.strongswan.android.ui.adapter.VpnProfileAdapter;
 import org.strongswan.android.utils.Constants;
 
@@ -65,17 +66,18 @@ public class VpnProfileListFragment extends Fragment
 	private HashSet<Integer> mSelected;
 	private boolean mReadOnly;
 
-	private BroadcastReceiver mProfilesChanged = new BroadcastReceiver()
+	private final BroadcastReceiver mProfilesChanged = new BroadcastReceiver()
 	{
 		@Override
 		public void onReceive(Context context, Intent intent)
 		{
-			long id, ids[];
+			long id;
+			long[] ids;
 			if ((id = intent.getLongExtra(Constants.VPN_PROFILES_SINGLE, 0)) > 0)
 			{
 				VpnProfile profile = mDataSource.getVpnProfile(id);
 				if (profile != null)
-				{	/* in case this was an edit, we remove it first */
+				{   /* in case this was an edit, we remove it first */
 					mVpnProfiles.remove(profile);
 					mVpnProfiles.add(profile);
 					mListAdapter.notifyDataSetChanged();
@@ -104,7 +106,8 @@ public class VpnProfileListFragment extends Fragment
 	/**
 	 * The activity containing this fragment should implement this interface
 	 */
-	public interface OnVpnProfileSelectedListener {
+	public interface OnVpnProfileSelectedListener
+	{
 		void onVpnProfileSelected(VpnProfile profile);
 	}
 
@@ -119,7 +122,7 @@ public class VpnProfileListFragment extends Fragment
 
 	@Override
 	public View onCreateView(LayoutInflater inflater, ViewGroup container,
-							 Bundle savedInstanceState)
+	                         Bundle savedInstanceState)
 	{
 		View view = inflater.inflate(R.layout.profile_list_fragment, null);
 
@@ -159,7 +162,7 @@ public class VpnProfileListFragment extends Fragment
 			mSelected = selected != null ? new HashSet<>(selected) : new HashSet<>();
 		}
 
-		mDataSource = new VpnProfileDataSource(this.getActivity());
+		mDataSource = new VpnProfileSource(this.getActivity());
 		mDataSource.open();
 
 		/* cached list of profiles used as backend for the ListView */
@@ -206,19 +209,18 @@ public class VpnProfileListFragment extends Fragment
 	@Override
 	public boolean onOptionsItemSelected(MenuItem item)
 	{
-		switch (item.getItemId())
+		if (item.getItemId() == R.id.add_profile)
 		{
-			case R.id.add_profile:
-				Intent connectionIntent = new Intent(getActivity(),
-													 VpnProfileDetailActivity.class);
-				startActivity(connectionIntent);
-				return true;
-			default:
-				return super.onOptionsItemSelected(item);
+			Intent connectionIntent = new Intent(getActivity(),
+			                                     VpnProfileDetailActivity.class);
+			startActivity(connectionIntent);
+			return true;
 		}
+		return super.onOptionsItemSelected(item);
 	}
 
-	private final OnItemClickListener mVpnProfileClicked = new OnItemClickListener() {
+	private final OnItemClickListener mVpnProfileClicked = new OnItemClickListener()
+	{
 		@Override
 		public void onItemClick(AdapterView<?> a, View v, int position, long id)
 		{
@@ -229,7 +231,8 @@ public class VpnProfileListFragment extends Fragment
 		}
 	};
 
-	private final MultiChoiceModeListener mVpnProfileSelected = new MultiChoiceModeListener() {
+	private final MultiChoiceModeListener mVpnProfileSelected = new MultiChoiceModeListener()
+	{
 		private MenuItem mEditProfile;
 		private MenuItem mCopyProfile;
 
@@ -297,7 +300,7 @@ public class VpnProfileListFragment extends Fragment
 					{
 						profiles.add((VpnProfile)mListView.getItemAtPosition(position));
 					}
-					long ids[] = new long[profiles.size()];
+					long[] ids = new long[profiles.size()];
 					for (int i = 0; i < profiles.size(); i++)
 					{
 						VpnProfile profile = profiles.get(i);
@@ -308,7 +311,7 @@ public class VpnProfileListFragment extends Fragment
 					intent.putExtra(Constants.VPN_PROFILES_MULTIPLE, ids);
 					LocalBroadcastManager.getInstance(getActivity()).sendBroadcast(intent);
 					Toast.makeText(VpnProfileListFragment.this.getActivity(),
-								   R.string.profiles_deleted, Toast.LENGTH_SHORT).show();
+					               R.string.profiles_deleted, Toast.LENGTH_SHORT).show();
 					break;
 				}
 				default:
@@ -320,7 +323,7 @@ public class VpnProfileListFragment extends Fragment
 
 		@Override
 		public void onItemCheckedStateChanged(ActionMode mode, int position,
-											  long id, boolean checked)
+		                                      long id, boolean checked)
 		{
 			if (checked)
 			{

--- a/src/frontends/android/app/src/main/java/org/strongswan/android/ui/VpnProfileListFragment.java
+++ b/src/frontends/android/app/src/main/java/org/strongswan/android/ui/VpnProfileListFragment.java
@@ -91,17 +91,24 @@ public class VpnProfileListFragment extends Fragment
 			}
 			else if ((uuids = intent.getStringArrayExtra(Constants.VPN_PROFILES_MULTIPLE)) != null)
 			{
-				for (String id : uuids)
+				for (final String id : uuids)
 				{
-					Iterator<VpnProfile> profiles = mVpnProfiles.iterator();
-					while (profiles.hasNext())
+					final Iterator<VpnProfile> iterator = mVpnProfiles.iterator();
+					while (iterator.hasNext())
 					{
-						VpnProfile profile = profiles.next();
+						final VpnProfile profile = iterator.next();
 						if (Objects.equals(profile.getUUID().toString(), id))
 						{
-							profiles.remove();
+							/* in case this was an edit, we remove it first */
+							iterator.remove();
 							break;
 						}
+					}
+
+					VpnProfile profile = mDataSource.getVpnProfile(id);
+					if (profile != null)
+					{
+						mVpnProfiles.add(profile);
 					}
 				}
 				mListAdapter.notifyDataSetChanged();

--- a/src/frontends/android/app/src/main/java/org/strongswan/android/ui/VpnProfileSelectActivity.java
+++ b/src/frontends/android/app/src/main/java/org/strongswan/android/ui/VpnProfileSelectActivity.java
@@ -45,7 +45,7 @@ public class VpnProfileSelectActivity extends AppCompatActivity implements OnVpn
 	public void onVpnProfileSelected(VpnProfile profile)
 	{
 		Intent shortcut = new Intent(VpnProfileControlActivity.START_PROFILE);
-		shortcut.putExtra(VpnProfileControlActivity.EXTRA_VPN_PROFILE_ID, profile.getUUID().toString());
+		shortcut.putExtra(VpnProfileControlActivity.EXTRA_VPN_PROFILE_UUID, profile.getUUID().toString());
 
 		ShortcutInfoCompat.Builder builder = new ShortcutInfoCompat.Builder(this, profile.getUUID().toString());
 		builder.setIntent(shortcut);

--- a/src/frontends/android/app/src/main/java/org/strongswan/android/ui/VpnTileService.java
+++ b/src/frontends/android/app/src/main/java/org/strongswan/android/ui/VpnTileService.java
@@ -32,6 +32,7 @@ import android.service.quicksettings.TileService;
 import org.strongswan.android.R;
 import org.strongswan.android.data.VpnProfile;
 import org.strongswan.android.data.VpnProfileDataSource;
+import org.strongswan.android.data.VpnProfileSource;
 import org.strongswan.android.data.VpnType;
 import org.strongswan.android.logic.VpnStateService;
 import org.strongswan.android.utils.Constants;
@@ -71,9 +72,9 @@ public class VpnTileService extends TileService implements VpnStateService.VpnSt
 
 		Context context = getApplicationContext();
 		context.bindService(new Intent(context, VpnStateService.class),
-							mServiceConnection, Service.BIND_AUTO_CREATE);
+		                    mServiceConnection, Service.BIND_AUTO_CREATE);
 
-		mDataSource = new VpnProfileDataSource(this);
+		mDataSource = new VpnProfileSource(this);
 		mDataSource.open();
 	}
 
@@ -175,7 +176,7 @@ public class VpnTileService extends TileService implements VpnStateService.VpnSt
 				intent.putExtra(VpnProfileControlActivity.EXTRA_VPN_PROFILE_ID, profile.getUUID().toString());
 				if (profile.getVpnType().has(VpnType.VpnTypeFeature.USER_PASS) &&
 					profile.getPassword() == null)
-				{	/* the user will have to enter the password, so collapse the drawer */
+				{   /* the user will have to enter the password, so collapse the drawer */
 					startActivityAndCollapse(intent);
 				}
 				else

--- a/src/frontends/android/app/src/main/java/org/strongswan/android/ui/VpnTileService.java
+++ b/src/frontends/android/app/src/main/java/org/strongswan/android/ui/VpnTileService.java
@@ -140,7 +140,7 @@ public class VpnTileService extends TileService implements VpnStateService.VpnSt
 			}
 			else if (mDataSource != null)
 			{   /* always get the plain profile without cached password */
-				profile = mDataSource.getVpnProfile(profile.getId());
+				profile = mDataSource.getVpnProfile(profile.getUUID());
 			}
 			/* reconnect the profile in case of an error */
 			if (mService.getErrorState() == VpnStateService.ErrorState.NO_ERROR)
@@ -173,7 +173,7 @@ public class VpnTileService extends TileService implements VpnStateService.VpnSt
 				Intent intent = new Intent(this, VpnProfileControlActivity.class);
 				intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
 				intent.setAction(VpnProfileControlActivity.START_PROFILE);
-				intent.putExtra(VpnProfileControlActivity.EXTRA_VPN_PROFILE_ID, profile.getUUID().toString());
+				intent.putExtra(VpnProfileControlActivity.EXTRA_VPN_PROFILE_UUID, profile.getUUID().toString());
 				if (profile.getVpnType().has(VpnType.VpnTypeFeature.USER_PASS) &&
 					profile.getPassword() == null)
 				{   /* the user will have to enter the password, so collapse the drawer */

--- a/src/frontends/android/app/src/main/java/org/strongswan/android/ui/adapter/SelectedApplicationsAdapter.java
+++ b/src/frontends/android/app/src/main/java/org/strongswan/android/ui/adapter/SelectedApplicationsAdapter.java
@@ -35,11 +35,12 @@ import java.util.List;
 
 public class SelectedApplicationsAdapter extends BaseAdapter implements Filterable
 {
-	private Context mContext;
+	private final Context mContext;
 	private final Object mLock = new Object();
-	private List<SelectedApplicationEntry> mData;
+	private final List<SelectedApplicationEntry> mData;
 	private List<SelectedApplicationEntry> mDataFiltered;
 	private SelectedApplicationsFilter mFilter;
+	private boolean mReadOnly;
 
 	public SelectedApplicationsAdapter(Context context)
 	{
@@ -100,9 +101,10 @@ public class SelectedApplicationsAdapter extends BaseAdapter implements Filterab
 		SelectedApplicationEntry item = getItem(position);
 		CheckableLinearLayout checkable = (CheckableLinearLayout)view;
 		checkable.setChecked(item.isSelected());
-		ImageView icon = (ImageView)view.findViewById(R.id.app_icon);
+		checkable.setEnabled(!mReadOnly);
+		ImageView icon = view.findViewById(R.id.app_icon);
 		icon.setImageDrawable(item.getIcon());
-		TextView text = (TextView)view.findViewById(R.id.app_name);
+		TextView text = view.findViewById(R.id.app_name);
 		text.setText(item.toString());
 		return view;
 	}
@@ -115,6 +117,16 @@ public class SelectedApplicationsAdapter extends BaseAdapter implements Filterab
 			mFilter = new SelectedApplicationsFilter();
 		}
 		return mFilter;
+	}
+
+	public boolean isReadOnly()
+	{
+		return mReadOnly;
+	}
+
+	public void setReadOnly(final boolean readOnly)
+	{
+		this.mReadOnly = readOnly;
 	}
 
 	private class SelectedApplicationsFilter extends Filter

--- a/src/frontends/android/app/src/main/java/org/strongswan/android/ui/adapter/VpnProfileAdapter.java
+++ b/src/frontends/android/app/src/main/java/org/strongswan/android/ui/adapter/VpnProfileAdapter.java
@@ -39,7 +39,7 @@ public class VpnProfileAdapter extends ArrayAdapter<VpnProfile>
 	private final List<VpnProfile> items;
 
 	public VpnProfileAdapter(Context context, int resource,
-							 List<VpnProfile> items)
+	                         List<VpnProfile> items)
 	{
 		super(context, resource, items);
 		this.resource = resource;
@@ -61,18 +61,20 @@ public class VpnProfileAdapter extends ArrayAdapter<VpnProfile>
 			vpnProfileView = inflater.inflate(resource, null);
 		}
 		VpnProfile profile = getItem(position);
-		TextView tv = (TextView)vpnProfileView.findViewById(R.id.profile_item_name);
+		TextView tv = vpnProfileView.findViewById(R.id.profile_item_name);
 		tv.setText(profile.getName());
-		tv = (TextView)vpnProfileView.findViewById(R.id.profile_item_gateway);
+		tv = vpnProfileView.findViewById(R.id.profile_item_managed);
+		tv.setVisibility(profile.isReadOnly() ? View.VISIBLE : View.GONE);
+		tv = vpnProfileView.findViewById(R.id.profile_item_gateway);
 		tv.setText(getContext().getString(R.string.profile_gateway_label) + ": " + profile.getGateway());
-		tv = (TextView)vpnProfileView.findViewById(R.id.profile_item_username);
+		tv = vpnProfileView.findViewById(R.id.profile_item_username);
 		if (profile.getVpnType().has(VpnTypeFeature.USER_PASS))
-		{	/* if the view is reused we make sure it is visible */
+		{    /* if the view is reused we make sure it is visible */
 			tv.setVisibility(View.VISIBLE);
 			tv.setText(getContext().getString(R.string.profile_username_label) + ": " + profile.getUsername());
 		}
 		else if (profile.getVpnType().has(VpnTypeFeature.CERTIFICATE) &&
-				 profile.getLocalId() != null)
+			profile.getLocalId() != null)
 		{
 			tv.setVisibility(View.VISIBLE);
 			tv.setText(getContext().getString(R.string.profile_local_id_label) + ": " + profile.getLocalId());
@@ -81,7 +83,7 @@ public class VpnProfileAdapter extends ArrayAdapter<VpnProfile>
 		{
 			tv.setVisibility(View.GONE);
 		}
-		tv = (TextView)vpnProfileView.findViewById(R.id.profile_item_certificate);
+		tv = vpnProfileView.findViewById(R.id.profile_item_certificate);
 		if (profile.getVpnType().has(VpnTypeFeature.CERTIFICATE))
 		{
 			tv.setText(getContext().getString(R.string.profile_user_certificate_label) + ": " + profile.getUserCertificateAlias());
@@ -103,7 +105,8 @@ public class VpnProfileAdapter extends ArrayAdapter<VpnProfile>
 
 	private void sortItems()
 	{
-		Collections.sort(this.items, new Comparator<VpnProfile>() {
+		Collections.sort(this.items, new Comparator<VpnProfile>()
+		{
 			@Override
 			public int compare(VpnProfile lhs, VpnProfile rhs)
 			{

--- a/src/frontends/android/app/src/main/java/org/strongswan/android/utils/Certificates.java
+++ b/src/frontends/android/app/src/main/java/org/strongswan/android/utils/Certificates.java
@@ -1,0 +1,29 @@
+
+package org.strongswan.android.utils;
+
+import org.strongswan.android.data.CaCertificate;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.security.cert.CertificateException;
+import java.security.cert.CertificateFactory;
+import java.security.cert.X509Certificate;
+
+import androidx.annotation.NonNull;
+
+public class Certificates
+{
+	@NonNull
+	public static X509Certificate from(@NonNull final CaCertificate certificate) throws IOException, CertificateException
+	{
+		final byte[] bytes = android.util.Base64.decode(certificate.getData(), android.util.Base64.DEFAULT);
+
+		try (final ByteArrayInputStream stream = new ByteArrayInputStream(bytes))
+		{
+			final CertificateFactory certificateFactory = CertificateFactory.getInstance("X.509");
+			return (X509Certificate)certificateFactory.generateCertificate(stream);
+		}
+	}
+
+	private Certificates() {}
+}

--- a/src/frontends/android/app/src/main/java/org/strongswan/android/utils/Difference.java
+++ b/src/frontends/android/app/src/main/java/org/strongswan/android/utils/Difference.java
@@ -1,0 +1,128 @@
+package org.strongswan.android.utils;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+import androidx.annotation.NonNull;
+import androidx.arch.core.util.Function;
+import androidx.core.util.Pair;
+
+public class Difference<T>
+{
+	@NonNull
+	private final List<T> inserts;
+	@NonNull
+	private final List<Pair<T, T>> updates;
+	@NonNull
+	private final List<T> deletes;
+
+	@NonNull
+	public static <K, V> Difference<V> between(
+		@NonNull final List<V> existing,
+		@NonNull final List<V> modified,
+		@NonNull final Function<V, K> getKey)
+	{
+		final Map<K, V> existingMap = mapOf(existing, getKey);
+		final Map<K, V> modifiedMap = mapOf(modified, getKey);
+
+		final List<V> inserts = notIn(existingMap, getKey, modified);
+		final List<V> deletes = notIn(modifiedMap, getKey, existing);
+		final List<Pair<V, V>> updates = changeBetween(existingMap, modifiedMap);
+
+		return new Difference<>(inserts, updates, deletes);
+	}
+
+	@NonNull
+	private static <K, V> Map<K, V> mapOf(
+		@NonNull final List<V> list,
+		@NonNull final Function<V, K> getKey)
+	{
+		final Map<K, V> map = new HashMap<>(list.size());
+
+		for (final V entry : list)
+		{
+			final K key = getKey.apply(entry);
+			map.put(key, entry);
+		}
+
+		return map;
+	}
+
+	@NonNull
+	private static <K, V> List<V> notIn(
+		@NonNull final Map<K, V> map,
+		@NonNull final Function<V, K> getKey,
+		@NonNull final List<V> list)
+	{
+		final List<V> filtered = new ArrayList<>(list.size());
+
+		for (final V value : list)
+		{
+			final K key = getKey.apply(value);
+			if (!map.containsKey(key))
+			{
+				filtered.add(value);
+			}
+		}
+
+		return filtered;
+	}
+
+	@NonNull
+	private static <K, V> List<Pair<V, V>> changeBetween(
+		@NonNull final Map<K, V> existingMap,
+		@NonNull final Map<K, V> modifiedMap)
+	{
+		final List<Pair<V, V>> changes = new ArrayList<>(modifiedMap.size());
+
+		for (final Map.Entry<K, V> entry : modifiedMap.entrySet())
+		{
+			final V existingValue = existingMap.get(entry.getKey());
+			final V modifiedValue = entry.getValue();
+
+			if (existingValue != null && !Objects.equals(existingValue, modifiedValue))
+			{
+				final Pair<V, V> change = Pair.create(existingValue, modifiedValue);
+				changes.add(change);
+			}
+		}
+
+		return changes;
+	}
+
+	public Difference(
+		@NonNull List<T> inserts,
+		@NonNull List<Pair<T, T>> updates,
+		@NonNull List<T> deletes)
+	{
+		this.inserts = inserts;
+		this.updates = updates;
+		this.deletes = deletes;
+	}
+
+	@NonNull
+	public List<T> getInserts()
+	{
+		return inserts;
+	}
+
+	@NonNull
+	public List<Pair<T, T>> getUpdates()
+	{
+		return updates;
+	}
+
+	@NonNull
+	public List<T> getDeletes()
+	{
+		return deletes;
+	}
+
+	public boolean isEmpty()
+	{
+		return inserts.isEmpty() && updates.isEmpty() && deletes.isEmpty();
+	}
+}

--- a/src/frontends/android/app/src/main/java/org/strongswan/android/utils/Difference.java
+++ b/src/frontends/android/app/src/main/java/org/strongswan/android/utils/Difference.java
@@ -125,4 +125,11 @@ public class Difference<T>
 	{
 		return inserts.isEmpty() && updates.isEmpty() && deletes.isEmpty();
 	}
+
+	@NonNull
+	@Override
+	public String toString()
+	{
+		return "Difference {" + inserts + ", " + updates + ", " + deletes + "}";
+	}
 }

--- a/src/frontends/android/app/src/main/java/org/strongswan/android/utils/KeyPair.java
+++ b/src/frontends/android/app/src/main/java/org/strongswan/android/utils/KeyPair.java
@@ -1,0 +1,60 @@
+package org.strongswan.android.utils;
+
+import java.security.PrivateKey;
+import java.security.cert.Certificate;
+import java.util.Objects;
+
+import androidx.annotation.NonNull;
+
+/**
+ * Represents a key pair, which consists of a certificate (i.e. public key) and its corresponding
+ * private key.
+ */
+public class KeyPair
+{
+	@NonNull
+	public final Certificate certificate;
+	@NonNull
+	public final PrivateKey privateKey;
+
+	/**
+	 * Constructor for a {@link KeyPair}.
+	 *
+	 * @param certificate the certificate of the key pair.
+	 * @param privateKey the private key of the key pair.
+	 */
+	public KeyPair(@NonNull Certificate certificate, @NonNull PrivateKey privateKey)
+	{
+		this.certificate = certificate;
+		this.privateKey = privateKey;
+	}
+
+	@Override
+	public boolean equals(Object o)
+	{
+		if (this == o)
+		{
+			return true;
+		}
+		if (o == null || getClass() != o.getClass())
+		{
+			return false;
+		}
+		final KeyPair that = (KeyPair)o;
+		return Objects.equals(certificate, that.certificate)
+			&& Objects.equals(privateKey, that.privateKey);
+	}
+
+	@Override
+	public int hashCode()
+	{
+		return Objects.hash(certificate, privateKey);
+	}
+
+	@NonNull
+	@Override
+	public String toString()
+	{
+		return "KeyPair{" + certificate + ", " + privateKey + "}";
+	}
+}

--- a/src/frontends/android/app/src/main/java/org/strongswan/android/utils/KeyPairs.java
+++ b/src/frontends/android/app/src/main/java/org/strongswan/android/utils/KeyPairs.java
@@ -1,5 +1,7 @@
 package org.strongswan.android.utils;
 
+import android.util.Log;
+
 import org.strongswan.android.data.UserCertificate;
 
 import java.io.ByteArrayInputStream;
@@ -19,6 +21,8 @@ import androidx.annotation.Nullable;
 
 public class KeyPairs
 {
+	private static final String TAG = KeyPairs.class.getSimpleName();
+
 	private static final String KEYSTORE_INSTANCE = "PKCS12";
 
 	@NonNull
@@ -67,6 +71,7 @@ public class KeyPairs
 			final KeyPair fallbackKeyPair = getKeyPair(keyStore, alias, passwordChars);
 			if (fallbackKeyPair != null)
 			{
+				Log.w(TAG, "Set effective alias of key pair '" + userCertificate.getConfiguredAlias() + "' to '" + alias + "'");
 				userCertificate.setEffectiveAlias(alias);
 				return fallbackKeyPair;
 			}

--- a/src/frontends/android/app/src/main/java/org/strongswan/android/utils/KeyPairs.java
+++ b/src/frontends/android/app/src/main/java/org/strongswan/android/utils/KeyPairs.java
@@ -1,0 +1,96 @@
+package org.strongswan.android.utils;
+
+import org.strongswan.android.data.UserCertificate;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.security.Key;
+import java.security.KeyStore;
+import java.security.KeyStoreException;
+import java.security.NoSuchAlgorithmException;
+import java.security.PrivateKey;
+import java.security.UnrecoverableKeyException;
+import java.security.cert.Certificate;
+import java.security.cert.CertificateException;
+import java.util.Enumeration;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+public class KeyPairs
+{
+	private static final String KEYSTORE_INSTANCE = "PKCS12";
+
+	@NonNull
+	private static KeyStore toKeyStore(@NonNull byte[] bytes, @NonNull char[] password)
+		throws IOException, KeyStoreException, CertificateException, NoSuchAlgorithmException
+	{
+		try (final ByteArrayInputStream stream = new ByteArrayInputStream(bytes))
+		{
+			final KeyStore keyStore = KeyStore.getInstance(KEYSTORE_INSTANCE);
+			keyStore.load(stream, password);
+			return keyStore;
+		}
+	}
+
+	@Nullable
+	private static KeyPair getKeyPair(
+		@NonNull final KeyStore keyStore,
+		@NonNull final String alias,
+		@NonNull final char[] passwordChars)
+		throws KeyStoreException, NoSuchAlgorithmException, UnrecoverableKeyException
+	{
+		final Certificate certificate = keyStore.getCertificate(alias);
+		if (certificate == null)
+		{
+			return null;
+		}
+
+		final Key key = keyStore.getKey(alias, passwordChars);
+		return new KeyPair(certificate, (PrivateKey)key);
+	}
+
+	@Nullable
+	private static KeyPair getKeyPair(@NonNull KeyStore keyStore, @NonNull UserCertificate userCertificate, @NonNull char[] passwordChars)
+		throws KeyStoreException, NoSuchAlgorithmException, UnrecoverableKeyException
+	{
+		final KeyPair keyPair = getKeyPair(keyStore, userCertificate.getConfiguredAlias(), passwordChars);
+		if (keyPair != null)
+		{
+			return keyPair;
+		}
+
+		final Enumeration<String> aliases = keyStore.aliases();
+		while (aliases.hasMoreElements())
+		{
+			final String alias = aliases.nextElement();
+			final KeyPair fallbackKeyPair = getKeyPair(keyStore, alias, passwordChars);
+			if (fallbackKeyPair != null)
+			{
+				userCertificate.setEffectiveAlias(alias);
+				return fallbackKeyPair;
+			}
+		}
+
+		return null;
+	}
+
+	@Nullable
+	public static KeyPair from(@NonNull final UserCertificate userCertificate)
+		throws IOException, KeyStoreException, CertificateException, NoSuchAlgorithmException, UnrecoverableKeyException
+	{
+		final String password = userCertificate.getPrivateKeyPassword();
+		if (password == null)
+		{
+			return null;
+		}
+
+		final byte[] bytes = android.util.Base64.decode(userCertificate.getData(), android.util.Base64.DEFAULT);
+		final char[] passwordChars = password.toCharArray();
+
+		final KeyStore keyStore = toKeyStore(bytes, passwordChars);
+		return getKeyPair(keyStore, userCertificate, passwordChars);
+	}
+
+	private KeyPairs() {}
+}

--- a/src/frontends/android/app/src/main/res/layout/profile_detail_view.xml
+++ b/src/frontends/android/app/src/main/res/layout/profile_detail_view.xml
@@ -16,541 +16,565 @@
     or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
     for more details.
 -->
-<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
-            xmlns:app="http://schemas.android.com/apk/res-auto"
-            android:layout_width="match_parent"
-            android:layout_height="match_parent" >
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
 
-    <LinearLayout
+    <TextView
+        android:id="@+id/managed_profile"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:orientation="vertical"
+        android:background="@drawable/error_background"
         android:padding="10dp"
-        android:animateLayoutChanges="true" >
+        android:text="@string/alert_text_vpn_profile_read_only"
+        android:textColor="@color/error_text"
+        android:textSize="15sp"
+        android:textStyle="bold"
+        android:visibility="gone"
+        app:layout_constraintTop_toTopOf="parent"
+        tools:visibility="visible" />
 
-        <org.strongswan.android.ui.widget.TextInputLayoutHelper
-            android:id="@+id/gateway_wrap"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="6dp"
-            android:hint="@string/profile_gateway_label"
-            app:helper_text="@string/profile_gateway_hint" >
-
-            <com.google.android.material.textfield.TextInputEditText
-                android:id="@+id/gateway"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:singleLine="true"
-                android:inputType="textNoSuggestions" />
-
-        </org.strongswan.android.ui.widget.TextInputLayoutHelper>
-
-        <TextView
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginLeft="4dp"
-            android:textSize="12sp"
-            android:text="@string/profile_vpn_type_label" />
-
-        <Spinner
-            android:id="@+id/vpn_type"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:spinnerMode="dropdown"
-            android:entries="@array/vpn_types" />
-
-        <include
-            android:id="@+id/tnc_notice"
-            layout="@layout/two_line_button"
-            android:visibility="gone" />
+    <ScrollView
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/managed_profile">
 
         <LinearLayout
-            android:id="@+id/username_password_group"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:orientation="vertical" >
+            android:animateLayoutChanges="true"
+            android:orientation="vertical"
+            android:padding="10dp">
 
             <org.strongswan.android.ui.widget.TextInputLayoutHelper
-                android:id="@+id/username_wrap"
+                android:id="@+id/gateway_wrap"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layout_marginTop="4dp"
-                android:hint="@string/profile_username_label" >
+                android:layout_marginTop="6dp"
+                android:hint="@string/profile_gateway_label"
+                app:helper_text="@string/profile_gateway_hint">
 
                 <com.google.android.material.textfield.TextInputEditText
-                    android:id="@+id/username"
+                    android:id="@+id/gateway"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:singleLine="true"
-                    android:inputType="textNoSuggestions" />
-
-            </org.strongswan.android.ui.widget.TextInputLayoutHelper>
-
-            <org.strongswan.android.ui.widget.TextInputLayoutHelper
-                android:id="@+id/password_wrap"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="4dp"
-                android:hint="@string/profile_password_label"
-                app:helper_text="@string/profile_password_hint" >
-
-                <com.google.android.material.textfield.TextInputEditText
-                    android:id="@+id/password"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:singleLine="true"
-                    android:inputType="textPassword|textNoSuggestions" />
-
-            </org.strongswan.android.ui.widget.TextInputLayoutHelper>
-
-        </LinearLayout>
-
-        <LinearLayout
-            android:id="@+id/user_certificate_group"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginBottom="4dp"
-            android:orientation="vertical" >
-
-            <TextView
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="4dp"
-                android:layout_marginLeft="4dp"
-                android:textSize="12sp"
-                android:text="@string/profile_user_certificate_label" />
-
-            <include
-                android:id="@+id/select_user_certificate"
-                layout="@layout/two_line_button" />
-
-            <Button
-                android:id="@+id/install_user_certificate"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_marginLeft="4dp"
-                android:layout_marginRight="4dp"
-                android:text="@string/profile_user_certificate_install" />
-
-        </LinearLayout>
-
-        <TextView
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginLeft="4dp"
-            android:textSize="12sp"
-            android:text="@string/profile_ca_label" />
-
-        <CheckBox
-            android:id="@+id/ca_auto"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="4dp"
-            android:text="@string/profile_ca_auto_label" />
-
-        <include
-            android:id="@+id/select_certificate"
-            layout="@layout/two_line_button" />
-
-        <org.strongswan.android.ui.widget.TextInputLayoutHelper
-            android:id="@+id/name_wrap"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="8dp"
-            android:hint="@string/profile_name_label"
-            app:helper_text="@string/profile_name_hint" >
-
-            <MultiAutoCompleteTextView
-                android:id="@+id/name"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:singleLine="true"
-                android:inputType="textNoSuggestions"
-                android:completionThreshold="1" />
-
-        </org.strongswan.android.ui.widget.TextInputLayoutHelper>
-
-        <CheckBox
-            android:id="@+id/show_advanced"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:text="@string/profile_show_advanced_label" />
-
-        <LinearLayout
-            android:id="@+id/advanced_settings"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:orientation="vertical" >
-
-            <TextView
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="10dp"
-                android:layout_marginLeft="4dp"
-                android:textSize="20sp"
-                android:text="@string/profile_advanced_label" />
-
-            <org.strongswan.android.ui.widget.TextInputLayoutHelper
-                android:id="@+id/remote_id_wrap"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="10dp"
-                android:hint="@string/profile_remote_id_label"
-                app:helper_text="@string/profile_remote_id_hint" >
-
-                <MultiAutoCompleteTextView
-                    android:id="@+id/remote_id"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:singleLine="true"
                     android:inputType="textNoSuggestions"
-                    android:completionThreshold="1" />
+                    android:singleLine="true" />
 
             </org.strongswan.android.ui.widget.TextInputLayoutHelper>
 
-            <org.strongswan.android.ui.widget.TextInputLayoutHelper
-                android:id="@+id/local_id_wrap"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:hint="@string/profile_local_id_label"
-                app:helper_text="@string/profile_local_id_hint_user" >
-
-                <MultiAutoCompleteTextView
-                    android:id="@+id/local_id"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:singleLine="true"
-                    android:inputType="textNoSuggestions"
-                    android:completionThreshold="0" />
-
-            </org.strongswan.android.ui.widget.TextInputLayoutHelper>
-
-            <org.strongswan.android.ui.widget.TextInputLayoutHelper
-                android:id="@+id/dns_servers_wrap"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:hint="@string/profile_dns_servers_label"
-                app:helper_text="@string/profile_dns_servers_hint" >
-
-                <com.google.android.material.textfield.TextInputEditText
-                    android:id="@+id/dns_servers"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:singleLine="true"
-                    android:inputType="textNoSuggestions" />
-
-            </org.strongswan.android.ui.widget.TextInputLayoutHelper>
-
-            <org.strongswan.android.ui.widget.TextInputLayoutHelper
-                android:id="@+id/mtu_wrap"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:hint="@string/profile_mtu_label"
-                app:helper_text="@string/profile_mtu_hint" >
-
-                <com.google.android.material.textfield.TextInputEditText
-                    android:id="@+id/mtu"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:singleLine="true"
-                    android:inputType="number|textNoSuggestions" />
-
-            </org.strongswan.android.ui.widget.TextInputLayoutHelper>
-
-            <org.strongswan.android.ui.widget.TextInputLayoutHelper
-                android:id="@+id/port_wrap"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:hint="@string/profile_port_label"
-                app:helper_text="@string/profile_port_hint" >
-
-                <com.google.android.material.textfield.TextInputEditText
-                    android:id="@+id/port"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:singleLine="true"
-                    android:inputType="number|textNoSuggestions" />
-
-            </org.strongswan.android.ui.widget.TextInputLayoutHelper>
-
-            <org.strongswan.android.ui.widget.TextInputLayoutHelper
-                android:id="@+id/nat_keepalive_wrap"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:hint="@string/profile_nat_keepalive_label"
-                app:helper_text="@string/profile_nat_keepalive_hint" >
-
-                <com.google.android.material.textfield.TextInputEditText
-                    android:id="@+id/nat_keepalive"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:singleLine="true"
-                    android:inputType="number|textNoSuggestions" />
-
-            </org.strongswan.android.ui.widget.TextInputLayoutHelper>
-
-            <androidx.appcompat.widget.SwitchCompat
-                android:id="@+id/cert_req"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_marginLeft="4dp"
-                android:layout_marginStart="4dp"
-                android:text="@string/profile_cert_req_label" />
-
             <TextView
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layout_marginBottom="10dp"
                 android:layout_marginLeft="4dp"
-                android:layout_marginStart="4dp"
-                android:textSize="12sp"
-                android:text="@string/profile_cert_req_hint" />
-
-            <androidx.appcompat.widget.SwitchCompat
-                android:id="@+id/use_ocsp"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_marginLeft="4dp"
-                android:layout_marginStart="4dp"
-                android:text="@string/profile_use_ocsp_label" />
-
-            <TextView
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_marginBottom="10dp"
-                android:layout_marginLeft="4dp"
-                android:layout_marginStart="4dp"
-                android:textSize="12sp"
-                android:text="@string/profile_use_ocsp_hint" />
-
-            <androidx.appcompat.widget.SwitchCompat
-                android:id="@+id/use_crl"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_marginLeft="4dp"
-                android:layout_marginStart="4dp"
-                android:text="@string/profile_use_crl_label" />
-
-            <TextView
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_marginBottom="10dp"
-                android:layout_marginLeft="4dp"
-                android:layout_marginStart="4dp"
-                android:textSize="12sp"
-                android:text="@string/profile_use_crl_hint" />
-
-            <androidx.appcompat.widget.SwitchCompat
-                android:id="@+id/strict_revocation"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_marginLeft="4dp"
-                android:layout_marginStart="4dp"
-                android:text="@string/profile_strict_revocation_label" />
-
-            <TextView
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_marginBottom="10dp"
-                android:layout_marginLeft="4dp"
-                android:layout_marginStart="4dp"
-                android:textSize="12sp"
-                android:text="@string/profile_strict_revocation_hint" />
-
-            <androidx.appcompat.widget.SwitchCompat
-                android:id="@+id/rsa_pss"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_marginLeft="4dp"
-                android:layout_marginStart="4dp"
-                android:text="@string/profile_rsa_pss_label" />
-
-            <TextView
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_marginBottom="10dp"
-                android:layout_marginLeft="4dp"
-                android:layout_marginStart="4dp"
-                android:textSize="12sp"
-                android:text="@string/profile_rsa_pss_hint" />
-
-            <androidx.appcompat.widget.SwitchCompat
-                android:id="@+id/ipv6_transport"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_marginLeft="4dp"
-                android:layout_marginStart="4dp"
-                android:text="@string/profile_ipv6_transport_label" />
-
-            <TextView
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_marginBottom="10dp"
-                android:layout_marginLeft="4dp"
-                android:layout_marginStart="4dp"
-                android:textSize="12sp"
-                android:text="@string/profile_ipv6_transport_hint" />
-
-            <TextView
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="10dp"
-                android:layout_marginBottom="10dp"
-                android:layout_marginLeft="4dp"
-                android:layout_marginStart="4dp"
-                android:textSize="20sp"
-                android:text="@string/profile_split_tunneling_label" />
-
-            <TextView
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="10dp"
-                android:layout_marginBottom="10dp"
-                android:layout_marginLeft="4dp"
-                android:textSize="12sp"
-                android:text="@string/profile_split_tunneling_intro" />
-
-            <org.strongswan.android.ui.widget.TextInputLayoutHelper
-                android:id="@+id/included_subnets_wrap"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:hint="@string/profile_included_subnets_label"
-                app:helper_text="@string/profile_included_subnets_hint" >
-
-                <com.google.android.material.textfield.TextInputEditText
-                    android:id="@+id/included_subnets"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:singleLine="true"
-                    android:inputType="textNoSuggestions" />
-
-            </org.strongswan.android.ui.widget.TextInputLayoutHelper>
-
-            <org.strongswan.android.ui.widget.TextInputLayoutHelper
-                android:id="@+id/excluded_subnets_wrap"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:hint="@string/profile_excluded_subnets_label"
-                app:helper_text="@string/profile_excluded_subnets_hint" >
-
-                <com.google.android.material.textfield.TextInputEditText
-                    android:id="@+id/excluded_subnets"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:singleLine="true"
-                    android:inputType="textNoSuggestions" />
-
-            </org.strongswan.android.ui.widget.TextInputLayoutHelper>
-
-            <CheckBox
-                android:id="@+id/split_tunneling_v4"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:text="@string/profile_split_tunnelingv4_title" />
-
-            <CheckBox
-                android:id="@+id/split_tunneling_v6"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:text="@string/profile_split_tunnelingv6_title" />
-
-            <TextView
-                android:id="@+id/apps"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="20dp"
-                android:layout_marginBottom="10dp"
-                android:layout_marginLeft="4dp"
-                android:layout_marginStart="4dp"
-                android:textSize="20sp"
-                android:text="@string/profile_select_apps_label" />
+                android:text="@string/profile_vpn_type_label"
+                android:textSize="12sp" />
 
             <Spinner
-                android:id="@+id/apps_handling"
+                android:id="@+id/vpn_type"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:spinnerMode="dropdown"
-                android:entries="@array/apps_handling" />
+                android:entries="@array/vpn_types"
+                android:spinnerMode="dropdown" />
 
             <include
-                android:id="@+id/select_applications"
+                android:id="@+id/tnc_notice"
+                layout="@layout/two_line_button"
+                android:visibility="gone" />
+
+            <LinearLayout
+                android:id="@+id/username_password_group"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="vertical">
+
+                <org.strongswan.android.ui.widget.TextInputLayoutHelper
+                    android:id="@+id/username_wrap"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="4dp"
+                    android:hint="@string/profile_username_label">
+
+                    <com.google.android.material.textfield.TextInputEditText
+                        android:id="@+id/username"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:inputType="textNoSuggestions"
+                        android:singleLine="true" />
+
+                </org.strongswan.android.ui.widget.TextInputLayoutHelper>
+
+                <org.strongswan.android.ui.widget.TextInputLayoutHelper
+                    android:id="@+id/password_wrap"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="4dp"
+                    android:hint="@string/profile_password_label"
+                    app:helper_text="@string/profile_password_hint">
+
+                    <com.google.android.material.textfield.TextInputEditText
+                        android:id="@+id/password"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:inputType="textPassword|textNoSuggestions"
+                        android:singleLine="true" />
+
+                </org.strongswan.android.ui.widget.TextInputLayoutHelper>
+
+            </LinearLayout>
+
+            <LinearLayout
+                android:id="@+id/user_certificate_group"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginBottom="4dp"
+                android:orientation="vertical">
+
+                <TextView
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginLeft="4dp"
+                    android:layout_marginTop="4dp"
+                    android:text="@string/profile_user_certificate_label"
+                    android:textSize="12sp" />
+
+                <include
+                    android:id="@+id/select_user_certificate"
+                    layout="@layout/two_line_button" />
+
+                <Button
+                    android:id="@+id/install_user_certificate"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginLeft="4dp"
+                    android:layout_marginRight="4dp"
+                    android:text="@string/profile_user_certificate_install" />
+
+            </LinearLayout>
+
+            <TextView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginLeft="4dp"
+                android:text="@string/profile_ca_label"
+                android:textSize="12sp" />
+
+            <CheckBox
+                android:id="@+id/ca_auto"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="4dp"
+                android:text="@string/profile_ca_auto_label" />
+
+            <include
+                android:id="@+id/select_certificate"
                 layout="@layout/two_line_button" />
 
-            <TextView
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="10dp"
-                android:layout_marginBottom="10dp"
-                android:layout_marginLeft="4dp"
-                android:layout_marginStart="4dp"
-                android:textSize="20sp"
-                android:text="@string/profile_proposals_label" />
-
-            <TextView
-                android:id="@+id/proposal_intro"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="10dp"
-                android:layout_marginBottom="10dp"
-                android:layout_marginLeft="4dp"
-                android:textSize="12sp"
-                android:text="@string/profile_proposals_intro" />
-
             <org.strongswan.android.ui.widget.TextInputLayoutHelper
-                android:id="@+id/ike_proposal_wrap"
+                android:id="@+id/name_wrap"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:hint="@string/profile_proposals_ike_label"
-                app:helper_text="@string/profile_proposals_ike_hint" >
+                android:layout_marginTop="8dp"
+                android:hint="@string/profile_name_label"
+                app:helper_text="@string/profile_name_hint">
 
-                <com.google.android.material.textfield.TextInputEditText
-                    android:id="@+id/ike_proposal"
+                <MultiAutoCompleteTextView
+                    android:id="@+id/name"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:singleLine="true"
-                    android:inputType="textNoSuggestions" />
+                    android:completionThreshold="1"
+                    android:inputType="textNoSuggestions"
+                    android:singleLine="true" />
 
             </org.strongswan.android.ui.widget.TextInputLayoutHelper>
 
-            <org.strongswan.android.ui.widget.TextInputLayoutHelper
-                android:id="@+id/esp_proposal_wrap"
+            <CheckBox
+                android:id="@+id/show_advanced"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:hint="@string/profile_proposals_esp_label"
-                app:helper_text="@string/profile_proposals_esp_hint" >
+                android:text="@string/profile_show_advanced_label" />
 
-                <com.google.android.material.textfield.TextInputEditText
-                    android:id="@+id/esp_proposal"
+            <LinearLayout
+                android:id="@+id/advanced_settings"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="vertical">
+
+                <TextView
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:singleLine="true"
-                    android:inputType="textNoSuggestions" />
+                    android:layout_marginLeft="4dp"
+                    android:layout_marginTop="10dp"
+                    android:text="@string/profile_advanced_label"
+                    android:textSize="20sp" />
 
-            </org.strongswan.android.ui.widget.TextInputLayoutHelper>
+                <org.strongswan.android.ui.widget.TextInputLayoutHelper
+                    android:id="@+id/remote_id_wrap"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="10dp"
+                    android:hint="@string/profile_remote_id_label"
+                    app:helper_text="@string/profile_remote_id_hint">
 
-            <TextView
-                android:id="@+id/profile_id_label"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="10dp"
-                android:layout_marginBottom="10dp"
-                android:layout_marginLeft="4dp"
-                android:layout_marginStart="4dp"
-                android:textSize="16sp"
-                android:text="@string/profile_profile_id" />
+                    <MultiAutoCompleteTextView
+                        android:id="@+id/remote_id"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:completionThreshold="1"
+                        android:inputType="textNoSuggestions"
+                        android:singleLine="true" />
 
-            <TextView
-                android:id="@+id/profile_id"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="10dp"
-                android:layout_marginBottom="10dp"
-                android:layout_marginLeft="4dp"
-                android:textSize="12sp"
-                android:textIsSelectable="true" />
+                </org.strongswan.android.ui.widget.TextInputLayoutHelper>
+
+                <org.strongswan.android.ui.widget.TextInputLayoutHelper
+                    android:id="@+id/local_id_wrap"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:hint="@string/profile_local_id_label"
+                    app:helper_text="@string/profile_local_id_hint_user">
+
+                    <MultiAutoCompleteTextView
+                        android:id="@+id/local_id"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:completionThreshold="0"
+                        android:inputType="textNoSuggestions"
+                        android:singleLine="true" />
+
+                </org.strongswan.android.ui.widget.TextInputLayoutHelper>
+
+                <org.strongswan.android.ui.widget.TextInputLayoutHelper
+                    android:id="@+id/dns_servers_wrap"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:hint="@string/profile_dns_servers_label"
+                    app:helper_text="@string/profile_dns_servers_hint">
+
+                    <com.google.android.material.textfield.TextInputEditText
+                        android:id="@+id/dns_servers"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:inputType="textNoSuggestions"
+                        android:singleLine="true" />
+
+                </org.strongswan.android.ui.widget.TextInputLayoutHelper>
+
+                <org.strongswan.android.ui.widget.TextInputLayoutHelper
+                    android:id="@+id/mtu_wrap"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:hint="@string/profile_mtu_label"
+                    app:helper_text="@string/profile_mtu_hint">
+
+                    <com.google.android.material.textfield.TextInputEditText
+                        android:id="@+id/mtu"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:inputType="number|textNoSuggestions"
+                        android:singleLine="true" />
+
+                </org.strongswan.android.ui.widget.TextInputLayoutHelper>
+
+                <org.strongswan.android.ui.widget.TextInputLayoutHelper
+                    android:id="@+id/port_wrap"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:hint="@string/profile_port_label"
+                    app:helper_text="@string/profile_port_hint">
+
+                    <com.google.android.material.textfield.TextInputEditText
+                        android:id="@+id/port"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:inputType="number|textNoSuggestions"
+                        android:singleLine="true" />
+
+                </org.strongswan.android.ui.widget.TextInputLayoutHelper>
+
+                <org.strongswan.android.ui.widget.TextInputLayoutHelper
+                    android:id="@+id/nat_keepalive_wrap"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:hint="@string/profile_nat_keepalive_label"
+                    app:helper_text="@string/profile_nat_keepalive_hint">
+
+                    <com.google.android.material.textfield.TextInputEditText
+                        android:id="@+id/nat_keepalive"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:inputType="number|textNoSuggestions"
+                        android:singleLine="true" />
+
+                </org.strongswan.android.ui.widget.TextInputLayoutHelper>
+
+                <androidx.appcompat.widget.SwitchCompat
+                    android:id="@+id/cert_req"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="4dp"
+                    android:layout_marginLeft="4dp"
+                    android:text="@string/profile_cert_req_label" />
+
+                <TextView
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="4dp"
+                    android:layout_marginLeft="4dp"
+                    android:layout_marginBottom="10dp"
+                    android:text="@string/profile_cert_req_hint"
+                    android:textSize="12sp" />
+
+                <androidx.appcompat.widget.SwitchCompat
+                    android:id="@+id/use_ocsp"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="4dp"
+                    android:layout_marginLeft="4dp"
+                    android:text="@string/profile_use_ocsp_label" />
+
+                <TextView
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="4dp"
+                    android:layout_marginLeft="4dp"
+                    android:layout_marginBottom="10dp"
+                    android:text="@string/profile_use_ocsp_hint"
+                    android:textSize="12sp" />
+
+                <androidx.appcompat.widget.SwitchCompat
+                    android:id="@+id/use_crl"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="4dp"
+                    android:layout_marginLeft="4dp"
+                    android:text="@string/profile_use_crl_label" />
+
+                <TextView
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="4dp"
+                    android:layout_marginLeft="4dp"
+                    android:layout_marginBottom="10dp"
+                    android:text="@string/profile_use_crl_hint"
+                    android:textSize="12sp" />
+
+                <androidx.appcompat.widget.SwitchCompat
+                    android:id="@+id/strict_revocation"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="4dp"
+                    android:layout_marginLeft="4dp"
+                    android:text="@string/profile_strict_revocation_label" />
+
+                <TextView
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="4dp"
+                    android:layout_marginLeft="4dp"
+                    android:layout_marginBottom="10dp"
+                    android:text="@string/profile_strict_revocation_hint"
+                    android:textSize="12sp" />
+
+                <androidx.appcompat.widget.SwitchCompat
+                    android:id="@+id/rsa_pss"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="4dp"
+                    android:layout_marginLeft="4dp"
+                    android:text="@string/profile_rsa_pss_label" />
+
+                <TextView
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="4dp"
+                    android:layout_marginLeft="4dp"
+                    android:layout_marginBottom="10dp"
+                    android:text="@string/profile_rsa_pss_hint"
+                    android:textSize="12sp" />
+
+                <androidx.appcompat.widget.SwitchCompat
+                    android:id="@+id/ipv6_transport"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="4dp"
+                    android:layout_marginLeft="4dp"
+                    android:text="@string/profile_ipv6_transport_label" />
+
+                <TextView
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="4dp"
+                    android:layout_marginLeft="4dp"
+                    android:layout_marginBottom="10dp"
+                    android:text="@string/profile_ipv6_transport_hint"
+                    android:textSize="12sp" />
+
+                <TextView
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="4dp"
+                    android:layout_marginLeft="4dp"
+                    android:layout_marginTop="10dp"
+                    android:layout_marginBottom="10dp"
+                    android:text="@string/profile_split_tunneling_label"
+                    android:textSize="20sp" />
+
+                <TextView
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginLeft="4dp"
+                    android:layout_marginTop="10dp"
+                    android:layout_marginBottom="10dp"
+                    android:text="@string/profile_split_tunneling_intro"
+                    android:textSize="12sp" />
+
+                <org.strongswan.android.ui.widget.TextInputLayoutHelper
+                    android:id="@+id/included_subnets_wrap"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:hint="@string/profile_included_subnets_label"
+                    app:helper_text="@string/profile_included_subnets_hint">
+
+                    <com.google.android.material.textfield.TextInputEditText
+                        android:id="@+id/included_subnets"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:inputType="textNoSuggestions"
+                        android:singleLine="true" />
+
+                </org.strongswan.android.ui.widget.TextInputLayoutHelper>
+
+                <org.strongswan.android.ui.widget.TextInputLayoutHelper
+                    android:id="@+id/excluded_subnets_wrap"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:hint="@string/profile_excluded_subnets_label"
+                    app:helper_text="@string/profile_excluded_subnets_hint">
+
+                    <com.google.android.material.textfield.TextInputEditText
+                        android:id="@+id/excluded_subnets"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:inputType="textNoSuggestions"
+                        android:singleLine="true" />
+
+                </org.strongswan.android.ui.widget.TextInputLayoutHelper>
+
+                <CheckBox
+                    android:id="@+id/split_tunneling_v4"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:text="@string/profile_split_tunnelingv4_title" />
+
+                <CheckBox
+                    android:id="@+id/split_tunneling_v6"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:text="@string/profile_split_tunnelingv6_title" />
+
+                <TextView
+                    android:id="@+id/apps"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="4dp"
+                    android:layout_marginLeft="4dp"
+                    android:layout_marginTop="20dp"
+                    android:layout_marginBottom="10dp"
+                    android:text="@string/profile_select_apps_label"
+                    android:textSize="20sp" />
+
+                <Spinner
+                    android:id="@+id/apps_handling"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:entries="@array/apps_handling"
+                    android:spinnerMode="dropdown" />
+
+                <include
+                    android:id="@+id/select_applications"
+                    layout="@layout/two_line_button" />
+
+                <TextView
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="4dp"
+                    android:layout_marginLeft="4dp"
+                    android:layout_marginTop="10dp"
+                    android:layout_marginBottom="10dp"
+                    android:text="@string/profile_proposals_label"
+                    android:textSize="20sp" />
+
+                <TextView
+                    android:id="@+id/proposal_intro"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginLeft="4dp"
+                    android:layout_marginTop="10dp"
+                    android:layout_marginBottom="10dp"
+                    android:text="@string/profile_proposals_intro"
+                    android:textSize="12sp" />
+
+                <org.strongswan.android.ui.widget.TextInputLayoutHelper
+                    android:id="@+id/ike_proposal_wrap"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:hint="@string/profile_proposals_ike_label"
+                    app:helper_text="@string/profile_proposals_ike_hint">
+
+                    <com.google.android.material.textfield.TextInputEditText
+                        android:id="@+id/ike_proposal"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:inputType="textNoSuggestions"
+                        android:singleLine="true" />
+
+                </org.strongswan.android.ui.widget.TextInputLayoutHelper>
+
+                <org.strongswan.android.ui.widget.TextInputLayoutHelper
+                    android:id="@+id/esp_proposal_wrap"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:hint="@string/profile_proposals_esp_label"
+                    app:helper_text="@string/profile_proposals_esp_hint">
+
+                    <com.google.android.material.textfield.TextInputEditText
+                        android:id="@+id/esp_proposal"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:inputType="textNoSuggestions"
+                        android:singleLine="true" />
+
+                </org.strongswan.android.ui.widget.TextInputLayoutHelper>
+
+                <TextView
+                    android:id="@+id/profile_id_label"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="4dp"
+                    android:layout_marginLeft="4dp"
+                    android:layout_marginTop="10dp"
+                    android:layout_marginBottom="10dp"
+                    android:text="@string/profile_profile_id"
+                    android:textSize="16sp" />
+
+                <TextView
+                    android:id="@+id/profile_id"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginLeft="4dp"
+                    android:layout_marginTop="10dp"
+                    android:layout_marginBottom="10dp"
+                    android:textIsSelectable="true"
+                    android:textSize="12sp" />
+
+            </LinearLayout>
 
         </LinearLayout>
 
-    </LinearLayout>
-
-</ScrollView>
+    </ScrollView>
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/src/frontends/android/app/src/main/res/layout/profile_list_item.xml
+++ b/src/frontends/android/app/src/main/res/layout/profile_list_item.xml
@@ -17,44 +17,60 @@
     for more details.
 -->
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
+    android:background="?android:attr/activatedBackgroundIndicator"
     android:orientation="vertical"
-    android:paddingBottom="6dip"
     android:paddingTop="4dip"
-    android:background="?android:attr/activatedBackgroundIndicator" >
+    android:paddingBottom="6dip">
 
     <TextView
         android:id="@+id/profile_item_name"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginLeft="15dp"
-        android:textAppearance="?android:attr/textAppearanceMedium" />
+        android:layout_marginStart="15dp"
+        android:textAppearance="?android:attr/textAppearanceMedium"
+        tools:text="Profile name" />
+
+    <TextView
+        android:id="@+id/profile_item_managed"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="15dp"
+        android:text="@string/profile_managed"
+        android:textAppearance="?android:attr/textAppearanceSmall"
+        android:textColor="@color/success_text"
+        android:visibility="gone"
+        tools:visibility="visible" />
 
     <TextView
         android:id="@+id/profile_item_gateway"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:textColor="?android:textColorSecondary"
+        android:layout_marginStart="15dp"
         android:textAppearance="?android:attr/textAppearanceSmall"
-        android:layout_marginLeft="15dp" />
+        android:textColor="?android:textColorSecondary"
+        tools:text="Server: vpn.example.com" />
 
     <TextView
         android:id="@+id/profile_item_username"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:textColor="?android:textColorSecondary"
+        android:layout_marginStart="15dp"
         android:textAppearance="?android:attr/textAppearanceSmall"
-        android:layout_marginLeft="15dp" />
+        android:textColor="?android:textColorSecondary"
+        tools:text="Username" />
 
     <TextView
         android:id="@+id/profile_item_certificate"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:textColor="?android:textColorSecondary"
-        android:textAppearance="?android:attr/textAppearanceSmall"
-        android:singleLine="true"
+        android:layout_marginStart="15dp"
         android:ellipsize="end"
-        android:layout_marginLeft="15dp" />
+        android:singleLine="true"
+        android:textAppearance="?android:attr/textAppearanceSmall"
+        android:textColor="?android:textColorSecondary"
+        tools:text="Certificate" />
 
 </LinearLayout>

--- a/src/frontends/android/app/src/main/res/values/restriction_constants.xml
+++ b/src/frontends/android/app/src/main/res/values/restriction_constants.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+
+    <string name="managed_config_vpn_type_default_value" translatable="false">IKEv2_EAP</string>
+    <string-array name="managed_config_vpn_type_values" translatable="false">
+        <item>ikev2-eap</item>
+        <item>ikev2-cert</item>
+        <item>ikev2-cert-eap</item>
+        <item>ikev2-eap-tls</item>
+        <item>ikev2-byod-eap</item>
+    </string-array>
+
+</resources>

--- a/src/frontends/android/app/src/main/res/values/restriction_values.xml
+++ b/src/frontends/android/app/src/main/res/values/restriction_values.xml
@@ -56,6 +56,8 @@
     <string name="managed_config_remote_id_description">@string/profile_remote_id_hint</string>
     <string name="managed_config_remote_cert_title">CA or server certificate (Optional)</string>
     <string name="managed_config_remote_cert_description">Base64-encoded CA or server certificate. Is imported into the app, not the system keystore. If not set, automatic CA certificate selection is enabled</string>
+    <string name="managed_config_remote_cert_alias_title">CA or server certificate alias</string>
+    <string name="managed_config_remote_cert_alias_description">The alias of the CA or server certificate</string>
     <string name="managed_config_remote_certreq_title">Send certificate requests</string>
     <string name="managed_config_remote_certreq_description">Specifies whether to send certificate requests for all installed or selected CA certificates. Disabling this may reduce the size of the IKE_AUTH message if the server does not support fragmentation. But it only works if the server doesn\'t require certificate requests to send back the server certificate</string>
     <string name="managed_config_remote_revocation_ocsp_title">@string/profile_use_ocsp_label</string>
@@ -74,6 +76,10 @@
     <string name="managed_config_local_id_description">@string/profile_local_id_hint_user</string>
     <string name="managed_config_local_p12_title">@string/profile_user_certificate_label</string>
     <string name="managed_config_local_p12_description">Base64-encoded PKCS#12-container with the client certificate and private key and optional certificate chain (the latter might cause warnings on older Android releases, see Android VPN client configuration for details). Not necessary for username/password-based EAP authentication or if the user already has the certificate/key installed as it may be selected while importing the profile</string>
+    <string name="managed_config_local_p12_alias_title">User certificate alias</string>
+    <string name="managed_config_local_p12_alias_description">Alias of the certificate and private key of the PKCS#12-container to use. If empty, the first alias found in the container is used</string>
+    <string name="managed_config_local_p12_password_title">User certificate password</string>
+    <string name="managed_config_local_p12_password_description">Password required to extract the private key of the PKCS#12-container for installation</string>
     <string name="managed_config_local_rsa_pss_title">@string/profile_rsa_pss_label</string>
     <string name="managed_config_local_rsa_pss_description">@string/profile_rsa_pss_hint</string>
 

--- a/src/frontends/android/app/src/main/res/values/restriction_values.xml
+++ b/src/frontends/android/app/src/main/res/values/restriction_values.xml
@@ -6,6 +6,8 @@
     <string name="managed_config_allow_profile_creation_description">Specifies whether users are allowed to add their own profiles</string>
     <string name="managed_config_allow_profile_import_title">Profile import allowed</string>
     <string name="managed_config_allow_profile_import_description">Specifies whether users are allowed to import their own profiles</string>
+    <string name="managed_config_allow_existing_profiles_title">Show existing profiles</string>
+    <string name="managed_config_allow_existing_profiles_description">Specifies whether users can continue to see and use their previously created profiles</string>
     <string name="managed_config_allow_certificate_import_title">Certificate import allowed</string>
     <string name="managed_config_allow_certificate_import_description">Specifies whether users are allowed to import certificates</string>
     <string name="managed_config_allow_settings_access_title">Settings allowed</string>

--- a/src/frontends/android/app/src/main/res/values/restriction_values.xml
+++ b/src/frontends/android/app/src/main/res/values/restriction_values.xml
@@ -1,0 +1,90 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+
+    <!-- Managed configuration -->
+    <string name="managed_config_allow_profile_creation_title">Create profiles allowed</string>
+    <string name="managed_config_allow_profile_creation_description">Specifies whether users are allowed to add their own profiles</string>
+    <string name="managed_config_allow_profile_import_title">Profile import allowed</string>
+    <string name="managed_config_allow_profile_import_description">Specifies whether users are allowed to import their own profiles</string>
+    <string name="managed_config_allow_certificate_import_title">Certificate import allowed</string>
+    <string name="managed_config_allow_certificate_import_description">Specifies whether users are allowed to import certificates</string>
+    <string name="managed_config_allow_settings_access_title">Settings allowed</string>
+    <string name="managed_config_allow_settings_access_description">Specifies whether users are allowed change app settings</string>
+    <string name="managed_config_default_vpn_profile_title">@string/pref_default_vpn_profile</string>
+    <string name="managed_config_default_vpn_profile_description">Unique identifier of the VPN profile to use by default</string>
+    <string name="managed_config_ignore_battery_optimizations_title">@string/pref_power_whitelist_title</string>
+    <string name="managed_config_ignore_battery_optimizations_description">@string/pref_power_whitelist_summary</string>
+    <string name="managed_config_profiles_array_title">VPN profiles</string>
+    <string name="managed_config_profiles_array_description">Collection of managed VPN profiles</string>
+    <string name="managed_config_profile_bundle_title">VPN profile</string>
+    <string name="managed_config_profile_bundle_description">A managed VPN profile</string>
+
+    <!-- Managed configuration, VPN profile -->
+    <string name="managed_config_uuid_title">Unique identifier</string>
+    <string name="managed_config_uuid_description">Unique identifier of the VPN profile. Version 4 UUIDs (random-generated) are recommended</string>
+    <string name="managed_config_name_title">@string/profile_name_label</string>
+    <string name="managed_config_name_description">@string/profile_name_hint</string>
+    <string name="managed_config_vpn_type_title">@string/profile_vpn_type_label</string>
+    <string name="managed_config_vpn_type_description">The type of client authentication used by the VPN profile</string>
+    <string name="managed_config_included_package_names_title">Apps allowed to use the VPN (Optional)</string>
+    <string name="managed_config_included_package_names_description">Space-separated list of package names; all other apps will not see the VPN</string>
+    <string name="managed_config_excluded_package_names_title">Apps forbidden to use the VPN (Optional)</string>
+    <string name="managed_config_excluded_package_names_description">Space-separated list of package names; apps not allowed to see the VPN, only used of allow list is empty</string>
+    <string name="managed_config_ike_proposal_title">@string/profile_proposals_ike_label</string>
+    <string name="managed_config_ike_proposal_description">@string/profile_proposals_ike_hint</string>
+    <string name="managed_config_esp_proposal_title">@string/profile_proposals_esp_label</string>
+    <string name="managed_config_esp_proposal_description">@string/profile_proposals_esp_hint</string>
+    <string name="managed_config_mtu_title">@string/profile_mtu_label</string>
+    <string name="managed_config_mtu_description">@string/profile_mtu_hint</string>
+    <string name="managed_config_nat_keepalive_title">@string/profile_nat_keepalive_label</string>
+    <string name="managed_config_nat_keepalive_description">@string/profile_nat_keepalive_hint</string>
+    <string name="managed_config_dns_server_host_names_title">@string/profile_dns_servers_label</string>
+    <string name="managed_config_dns_server_host_names_description">@string/profile_dns_servers_hint</string>
+    <string name="managed_config_ipv6_transport_title">@string/profile_ipv6_transport_label</string>
+    <string name="managed_config_ipv6_transport_description">@string/profile_ipv6_transport_hint</string>
+
+    <!-- Managed configuration, VPN profile, remote -->
+    <string name="managed_config_remote_bundle_title">Remote</string>
+    <string name="managed_config_remote_bundle_description">Specifies information about the server</string>
+    <string name="managed_config_remote_addr_title">@string/profile_gateway_label</string>
+    <string name="managed_config_remote_addr_description">@string/profile_gateway_hint</string>
+    <string name="managed_config_remote_port_title">@string/profile_port_label</string>
+    <string name="managed_config_remote_port_description">@string/profile_port_hint</string>
+    <string name="managed_config_remote_id_title">@string/profile_remote_id_label</string>
+    <string name="managed_config_remote_id_description">@string/profile_remote_id_hint</string>
+    <string name="managed_config_remote_cert_title">CA or server certificate (Optional)</string>
+    <string name="managed_config_remote_cert_description">Base64-encoded CA or server certificate. Is imported into the app, not the system keystore. If not set, automatic CA certificate selection is enabled</string>
+    <string name="managed_config_remote_certreq_title">Send certificate requests</string>
+    <string name="managed_config_remote_certreq_description">Specifies whether to send certificate requests for all installed or selected CA certificates. Disabling this may reduce the size of the IKE_AUTH message if the server does not support fragmentation. But it only works if the server doesn\'t require certificate requests to send back the server certificate</string>
+    <string name="managed_config_remote_revocation_ocsp_title">@string/profile_use_ocsp_label</string>
+    <string name="managed_config_remote_revocation_ocsp_description">@string/profile_use_ocsp_hint</string>
+    <string name="managed_config_remote_revocation_crl_title">@string/profile_use_crl_label</string>
+    <string name="managed_config_remote_revocation_crl_description">@string/profile_use_crl_hint</string>
+    <string name="managed_config_remote_revocation_strict_title">@string/profile_strict_revocation_label</string>
+    <string name="managed_config_remote_revocation_strict_description">@string/profile_strict_revocation_hint</string>
+
+    <!-- Managed configuration, VPN profile, local -->
+    <string name="managed_config_local_bundle_title">Local</string>
+    <string name="managed_config_local_bundle_description">Specifies information about the client</string>
+    <string name="managed_config_local_eap_id_title">Identity/username for EAP authentication (Optional)</string>
+    <string name="managed_config_local_eap_id_description">If this is required (for username/password-based EAP authentication) but not configured here, the user is prompted for it. If it is set, the user is not able to change it. In both cases the user may optionally enter the password</string>
+    <string name="managed_config_local_id_title">@string/profile_local_id_label</string>
+    <string name="managed_config_local_id_description">@string/profile_local_id_hint_user</string>
+    <string name="managed_config_local_p12_title">@string/profile_user_certificate_label</string>
+    <string name="managed_config_local_p12_description">Base64-encoded PKCS#12-container with the client certificate and private key and optional certificate chain (the latter might cause warnings on older Android releases, see Android VPN client configuration for details). Not necessary for username/password-based EAP authentication or if the user already has the certificate/key installed as it may be selected while importing the profile</string>
+    <string name="managed_config_local_rsa_pss_title">@string/profile_rsa_pss_label</string>
+    <string name="managed_config_local_rsa_pss_description">@string/profile_rsa_pss_hint</string>
+
+    <!-- Managed configuration, VPN profile, split-tunneling -->
+    <string name="managed_config_split_tunneling_bundle_title">@string/profile_split_tunneling_label</string>
+    <string name="managed_config_split_tunneling_bundle_description">@string/profile_split_tunneling_intro</string>
+    <string name="managed_config_split_tunneling_subnets_title">@string/profile_included_subnets_label</string>
+    <string name="managed_config_split_tunneling_subnets_description">@string/profile_included_subnets_hint</string>
+    <string name="managed_config_split_tunneling_excluded_title">@string/profile_excluded_subnets_label</string>
+    <string name="managed_config_split_tunneling_excluded_description">@string/profile_excluded_subnets_hint</string>
+    <string name="managed_config_split_tunneling_block_ipv4_title">@string/profile_split_tunnelingv4_title</string>
+    <string name="managed_config_split_tunneling_block_ipv4_description">Specifies whether to block IPv4 traffic that\'s not destined for the VPN. Forces all IPv4 traffic via VPN (traffic that does not match the negotiated traffic selector is then just dropped). Thus this is basically equivalent to including 0.0.0.0/0 in subnets</string>
+    <string name="managed_config_split_tunneling_block_ipv6_title">@string/profile_split_tunnelingv6_title</string>
+    <string name="managed_config_split_tunneling_block_ipv6_description">Specifies whether to block IPv6 traffic that\'s not destined for the VPN. Forces all IPv6 traffic via VPN (traffic that does not match the negotiated traffic selector is then just dropped). Thus this is basically equivalent to including ::/0 in subnets</string>
+
+</resources>

--- a/src/frontends/android/app/src/main/res/values/strings.xml
+++ b/src/frontends/android/app/src/main/res/values/strings.xml
@@ -149,6 +149,7 @@
     <string name="alert_text_no_subnets">Please enter valid subnets and/or IP addresses, separated by spaces</string>
     <string name="alert_text_no_ips">Please enter valid IP addresses, separated by spaces</string>
     <string name="alert_text_no_proposal">Please enter a valid list of algorithms, separated by hyphens</string>
+    <string name="alert_text_vpn_profile_read_only">This VPN profile is managed by your administrator and can\'t be modified. You can only change the profile\'s password</string>
     <string name="tnc_notice_title">EAP-TNC may affect your privacy</string>
     <string name="tnc_notice_subtitle">Device data is sent to the server operator</string>
     <string name="tnc_notice_details"><![CDATA[<p>Trusted Network Connect (TNC) allows server operators to assess the health of a client device.</p><p>For that purpose the server operator may request data such as a unique identifier, a list of installed packages, system settings, or cryptographic checksums of files.</p><b>Any data will be sent only after verifying the server\'s identity.</b>]]></string>

--- a/src/frontends/android/app/src/main/res/values/strings.xml
+++ b/src/frontends/android/app/src/main/res/values/strings.xml
@@ -139,6 +139,7 @@
     <string name="profile_cert_import">Import certificate from VPN profile</string>
     <string name="profile_cert_alias">Certificate for \"%1$s\"</string>
     <string name="profile_profile_id">Profile ID</string>
+    <string name="profile_managed">Managed profile</string>
     <!-- Warnings/Notifications in the details view -->
     <string name="alert_text_no_input_gateway">A value is required to initiate the connection</string>
     <string name="alert_text_no_input_username">Please enter your username </string>

--- a/src/frontends/android/app/src/main/res/xml/managed_configuration.xml
+++ b/src/frontends/android/app/src/main/res/xml/managed_configuration.xml
@@ -1,0 +1,274 @@
+<?xml version="1.0" encoding="utf-8"?>
+<restrictions xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <restriction
+        android:defaultValue="false"
+        android:description="@string/managed_config_allow_profile_creation_description"
+        android:key="allow_profile_create"
+        android:restrictionType="bool"
+        android:title="@string/managed_config_allow_profile_creation_title" />
+
+    <restriction
+        android:defaultValue="false"
+        android:description="@string/managed_config_allow_profile_import_description"
+        android:key="allow_profile_import"
+        android:restrictionType="bool"
+        android:title="@string/managed_config_allow_profile_import_title" />
+
+    <restriction
+        android:defaultValue="false"
+        android:description="@string/managed_config_allow_certificate_import_description"
+        android:key="allow_certificate_import"
+        android:restrictionType="bool"
+        android:title="@string/managed_config_allow_certificate_import_title" />
+
+    <restriction
+        android:defaultValue="false"
+        android:description="@string/managed_config_allow_settings_access_description"
+        android:key="allow_settings_access"
+        android:restrictionType="bool"
+        android:title="@string/managed_config_allow_settings_access_title" />
+
+    <restriction
+        android:defaultValue=""
+        android:description="@string/managed_config_default_vpn_profile_description"
+        android:key="pref_default_vpn_profile"
+        android:restrictionType="string"
+        android:title="@string/managed_config_default_vpn_profile_title" />
+
+    <restriction
+        android:defaultValue="false"
+        android:description="@string/managed_config_ignore_battery_optimizations_description"
+        android:key="pref_ignore_power_whitelist"
+        android:restrictionType="bool"
+        android:title="@string/managed_config_ignore_battery_optimizations_title" />
+
+    <restriction
+        android:description="@string/managed_config_profiles_array_description"
+        android:key="managed_profiles"
+        android:restrictionType="bundle_array"
+        android:title="@string/managed_config_profiles_array_title">
+
+        <restriction
+            android:description="@string/managed_config_profile_bundle_description"
+            android:key="managed_profile"
+            android:restrictionType="bundle"
+            android:title="@string/managed_config_profile_bundle_title">
+
+            <restriction
+                android:defaultValue=""
+                android:description="@string/managed_config_uuid_description"
+                android:key="_uuid"
+                android:restrictionType="string"
+                android:title="@string/managed_config_uuid_title" />
+
+            <restriction
+                android:defaultValue=""
+                android:description="@string/managed_config_name_description"
+                android:key="name"
+                android:restrictionType="string"
+                android:title="@string/managed_config_name_title" />
+
+            <restriction
+                android:defaultValue="@string/managed_config_vpn_type_default_value"
+                android:description="@string/managed_config_vpn_type_description"
+                android:entries="@array/vpn_types"
+                android:entryValues="@array/managed_config_vpn_type_values"
+                android:key="vpn_type"
+                android:restrictionType="choice"
+                android:title="@string/managed_config_vpn_type_title" />
+
+            <restriction
+                android:description="@string/managed_config_remote_bundle_description"
+                android:key="remote"
+                android:restrictionType="bundle"
+                android:title="@string/managed_config_remote_bundle_title">
+
+                <restriction
+                    android:defaultValue=""
+                    android:description="@string/managed_config_remote_addr_description"
+                    android:key="gateway"
+                    android:restrictionType="string"
+                    android:title="@string/managed_config_remote_addr_title" />
+
+                <restriction
+                    android:defaultValue="500"
+                    android:description="@string/managed_config_remote_port_description"
+                    android:key="port"
+                    android:restrictionType="integer"
+                    android:title="@string/managed_config_remote_port_title" />
+
+                <restriction
+                    android:defaultValue=""
+                    android:description="@string/managed_config_remote_id_description"
+                    android:key="remote_id"
+                    android:restrictionType="string"
+                    android:title="@string/managed_config_remote_id_title" />
+
+                <restriction
+                    android:defaultValue=""
+                    android:description="@string/managed_config_remote_cert_description"
+                    android:key="certificate"
+                    android:restrictionType="string"
+                    android:title="@string/managed_config_remote_cert_title" />
+
+                <restriction
+                    android:defaultValue="false"
+                    android:description="@string/managed_config_remote_certreq_description"
+                    android:key="remote_cert_req"
+                    android:restrictionType="bool"
+                    android:title="@string/managed_config_remote_certreq_title" />
+
+                <restriction
+                    android:defaultValue="true"
+                    android:description="@string/managed_config_remote_revocation_ocsp_description"
+                    android:key="remote_revocation_ocsp"
+                    android:restrictionType="bool"
+                    android:title="@string/managed_config_remote_revocation_ocsp_title" />
+
+                <restriction
+                    android:defaultValue="true"
+                    android:description="@string/managed_config_remote_revocation_crl_description"
+                    android:key="remote_revocation_crl"
+                    android:restrictionType="bool"
+                    android:title="@string/managed_config_remote_revocation_crl_title" />
+
+                <restriction
+                    android:defaultValue="false"
+                    android:description="@string/managed_config_remote_revocation_strict_description"
+                    android:key="remote_revocation_strict"
+                    android:restrictionType="bool"
+                    android:title="@string/managed_config_remote_revocation_strict_title" />
+            </restriction>
+
+            <restriction
+                android:description="@string/managed_config_local_bundle_description"
+                android:key="local"
+                android:restrictionType="bundle"
+                android:title="@string/managed_config_local_bundle_title">
+
+                <restriction
+                    android:defaultValue=""
+                    android:description="@string/managed_config_local_eap_id_description"
+                    android:key="username"
+                    android:restrictionType="string"
+                    android:title="@string/managed_config_local_eap_id_title" />
+
+                <restriction
+                    android:defaultValue=""
+                    android:description="@string/managed_config_local_id_description"
+                    android:key="local_id"
+                    android:restrictionType="string"
+                    android:title="@string/managed_config_local_id_title" />
+
+                <restriction
+                    android:defaultValue=""
+                    android:description="@string/managed_config_local_p12_description"
+                    android:key="user_certificate"
+                    android:restrictionType="string"
+                    android:title="@string/managed_config_local_p12_title" />
+
+                <restriction
+                    android:defaultValue="false"
+                    android:description="@string/managed_config_local_rsa_pss_description"
+                    android:key="local_rsa_pss"
+                    android:restrictionType="bool"
+                    android:title="@string/managed_config_local_rsa_pss_title" />
+
+            </restriction>
+
+            <restriction
+                android:defaultValue=""
+                android:description="@string/managed_config_included_package_names_description"
+                android:key="included_apps"
+                android:restrictionType="string"
+                android:title="@string/managed_config_included_package_names_title" />
+
+            <restriction
+                android:defaultValue=""
+                android:description="@string/managed_config_excluded_package_names_description"
+                android:key="excluded_apps"
+                android:restrictionType="string"
+                android:title="@string/managed_config_excluded_package_names_title" />
+
+            <restriction
+                android:defaultValue=""
+                android:description="@string/managed_config_ike_proposal_description"
+                android:key="ike_proposal"
+                android:restrictionType="string"
+                android:title="@string/managed_config_ike_proposal_title" />
+
+            <restriction
+                android:defaultValue=""
+                android:description="@string/managed_config_esp_proposal_description"
+                android:key="esp_proposal"
+                android:restrictionType="string"
+                android:title="@string/managed_config_esp_proposal_title" />
+
+            <restriction
+                android:defaultValue="-1"
+                android:description="@string/managed_config_mtu_description"
+                android:key="mtu"
+                android:restrictionType="integer"
+                android:title="@string/managed_config_mtu_title" />
+
+            <restriction
+                android:defaultValue="20"
+                android:description="@string/managed_config_nat_keepalive_description"
+                android:key="nat_keepalive"
+                android:restrictionType="integer"
+                android:title="@string/managed_config_nat_keepalive_title" />
+
+            <restriction
+                android:defaultValue=""
+                android:description="@string/managed_config_dns_server_host_names_description"
+                android:key="dns_servers"
+                android:restrictionType="string"
+                android:title="@string/managed_config_dns_server_host_names_title" />
+
+            <restriction
+                android:defaultValue="false"
+                android:description="@string/managed_config_ipv6_transport_description"
+                android:key="transport_IPv6"
+                android:restrictionType="bool"
+                android:title="@string/managed_config_ipv6_transport_title" />
+
+            <restriction
+                android:description="@string/managed_config_split_tunneling_bundle_description"
+                android:key="split_tunnelling"
+                android:restrictionType="bundle"
+                android:title="@string/managed_config_split_tunneling_bundle_title">
+
+                <restriction
+                    android:defaultValue=""
+                    android:description="@string/managed_config_split_tunneling_subnets_description"
+                    android:key="included_subnets"
+                    android:restrictionType="string"
+                    android:title="@string/managed_config_split_tunneling_subnets_title" />
+
+                <restriction
+                    android:defaultValue=""
+                    android:description="@string/managed_config_split_tunneling_excluded_description"
+                    android:key="excluded_subnets"
+                    android:restrictionType="string"
+                    android:title="@string/managed_config_split_tunneling_excluded_title" />
+
+                <restriction
+                    android:defaultValue="false"
+                    android:description="@string/managed_config_split_tunneling_block_ipv4_description"
+                    android:key="split_tunnelling_block_IPv4"
+                    android:restrictionType="bool"
+                    android:title="@string/managed_config_split_tunneling_block_ipv4_title" />
+
+                <restriction
+                    android:defaultValue="false"
+                    android:description="@string/managed_config_split_tunneling_block_ipv6_description"
+                    android:key="split_tunnelling_block_IPv6"
+                    android:restrictionType="bool"
+                    android:title="@string/managed_config_split_tunneling_block_ipv6_title" />
+
+            </restriction>
+
+        </restriction>
+    </restriction>
+</restrictions>

--- a/src/frontends/android/app/src/main/res/xml/managed_configuration.xml
+++ b/src/frontends/android/app/src/main/res/xml/managed_configuration.xml
@@ -17,6 +17,13 @@
 
     <restriction
         android:defaultValue="false"
+        android:description="@string/managed_config_allow_existing_profiles_description"
+        android:key="allow_existing_profiles"
+        android:restrictionType="bool"
+        android:title="@string/managed_config_allow_existing_profiles_title" />
+
+    <restriction
+        android:defaultValue="false"
         android:description="@string/managed_config_allow_certificate_import_description"
         android:key="allow_certificate_import"
         android:restrictionType="bool"

--- a/src/frontends/android/app/src/main/res/xml/managed_configuration.xml
+++ b/src/frontends/android/app/src/main/res/xml/managed_configuration.xml
@@ -120,6 +120,13 @@
                     android:title="@string/managed_config_remote_cert_title" />
 
                 <restriction
+                    android:defaultValue=""
+                    android:description="@string/managed_config_remote_cert_alias_description"
+                    android:key="certificate_alias"
+                    android:restrictionType="string"
+                    android:title="@string/managed_config_remote_cert_alias_title" />
+
+                <restriction
                     android:defaultValue="false"
                     android:description="@string/managed_config_remote_certreq_description"
                     android:key="remote_cert_req"
@@ -174,6 +181,20 @@
                     android:key="user_certificate"
                     android:restrictionType="string"
                     android:title="@string/managed_config_local_p12_title" />
+
+                <restriction
+                    android:defaultValue=""
+                    android:description="@string/managed_config_local_p12_alias_description"
+                    android:key="user_certificate_alias"
+                    android:restrictionType="string"
+                    android:title="@string/managed_config_local_p12_alias_title" />
+
+                <restriction
+                    android:defaultValue=""
+                    android:description="@string/managed_config_local_p12_password_description"
+                    android:key="user_certificate_password"
+                    android:restrictionType="string"
+                    android:title="@string/managed_config_local_p12_password_title" />
 
                 <restriction
                     android:defaultValue="false"

--- a/src/frontends/android/app/src/test/java/android/content/ContentValues.java
+++ b/src/frontends/android/app/src/test/java/android/content/ContentValues.java
@@ -1,0 +1,11 @@
+package android.content;
+
+import java.util.HashMap;
+
+public class ContentValues extends HashMap<String, Object>
+{
+	public void put(String key, String value)
+	{
+		super.put(key, value);
+	}
+}

--- a/src/frontends/android/app/src/test/java/android/database/sqlite/SQLiteQueryBuilder.java
+++ b/src/frontends/android/app/src/test/java/android/database/sqlite/SQLiteQueryBuilder.java
@@ -1,0 +1,18 @@
+package android.database.sqlite;
+
+public class SQLiteQueryBuilder
+{
+	public static void appendColumns(StringBuilder s, String[] columns)
+	{
+		boolean first = true;
+		for (String column : columns)
+		{
+			if (!first)
+			{
+				s.append(",");
+			}
+			s.append(column);
+			first = false;
+		}
+	}
+}

--- a/src/frontends/android/app/src/test/java/android/os/Bundle.java
+++ b/src/frontends/android/app/src/test/java/android/os/Bundle.java
@@ -1,0 +1,69 @@
+package android.os;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class Bundle
+{
+	private final Map<String, Object> map = new HashMap<>();
+
+	public void putBoolean(final String key, final boolean value)
+	{
+		map.put(key, value);
+	}
+
+	public void putBundle(final String key, final Bundle bundle)
+	{
+		map.put(key, bundle);
+	}
+
+	public void putInt(final String key, final int value)
+	{
+		map.put(key, value);
+	}
+
+	public void putString(final String key, final String value)
+	{
+		map.put(key, value);
+	}
+
+	public boolean getBoolean(final String key)
+	{
+		final Object obj = map.get(key);
+		if (obj != null)
+		{
+			return (boolean)obj;
+		}
+		return false;
+	}
+
+	public Bundle getBundle(final String key)
+	{
+		return (Bundle)map.get(key);
+	}
+
+	public int getInt(final String key)
+	{
+		final Object obj = map.get(key);
+		if (obj != null)
+		{
+			return (int)obj;
+		}
+		return 0;
+	}
+
+	public String getString(final String key)
+	{
+		return getString(key, null);
+	}
+
+	public String getString(final String key, final String fallback)
+	{
+		final Object obj = map.get(key);
+		if (obj != null)
+		{
+			return (String)obj;
+		}
+		return fallback;
+	}
+}

--- a/src/frontends/android/app/src/test/java/android/text/TextUtils.java
+++ b/src/frontends/android/app/src/test/java/android/text/TextUtils.java
@@ -1,0 +1,9 @@
+package android.text;
+
+public class TextUtils
+{
+	public static boolean isEmpty(final CharSequence value)
+	{
+		return value == null || value.length() == 0;
+	}
+}

--- a/src/frontends/android/app/src/test/java/android/util/Log.java
+++ b/src/frontends/android/app/src/test/java/android/util/Log.java
@@ -1,0 +1,16 @@
+package android.util;
+
+public class Log
+{
+	public static int d(String tag, String msg)
+	{
+		System.out.println("DEBUG: " + tag + ": " + msg);
+		return 0;
+	}
+
+	public static int w(String tag, String msg)
+	{
+		System.out.println("WARN: " + tag + ": " + msg);
+		return 0;
+	}
+}

--- a/src/frontends/android/app/src/test/java/org/strongswan/android/data/DatabaseHelperTest.java
+++ b/src/frontends/android/app/src/test/java/org/strongswan/android/data/DatabaseHelperTest.java
@@ -33,6 +33,8 @@ public class DatabaseHelperTest
 		databaseHelper.onCreate(database);
 
 		then(database).should().execSQL("CREATE TABLE IF NOT EXISTS vpnprofile (_id INTEGER PRIMARY KEY AUTOINCREMENT,_uuid TEXT UNIQUE,name TEXT NOT NULL,gateway TEXT NOT NULL,vpn_type TEXT NOT NULL DEFAULT '',username TEXT,password TEXT,certificate TEXT,user_certificate TEXT,mtu INTEGER,port INTEGER,split_tunneling INTEGER,local_id TEXT,remote_id TEXT,excluded_subnets TEXT,included_subnets TEXT,selected_apps INTEGER,selected_apps_list TEXT,nat_keepalive INTEGER,flags INTEGER,ike_proposal TEXT,esp_proposal TEXT,dns_servers TEXT);");
+		then(database).should().execSQL("CREATE TABLE IF NOT EXISTS usercertificate (_id INTEGER PRIMARY KEY AUTOINCREMENT,vpn_profile_uuid TEXT UNIQUE,configured_alias TEXT NOT NULL,effective_alias TEXT,data TEXT NOT NULL,password TEXT);");
+		then(database).should().execSQL("CREATE TABLE IF NOT EXISTS cacertificate (_id INTEGER PRIMARY KEY AUTOINCREMENT,vpn_profile_uuid TEXT UNIQUE,configured_alias TEXT NOT NULL,effective_alias TEXT,data TEXT NOT NULL);");
 	}
 
 	@Test
@@ -211,6 +213,15 @@ public class DatabaseHelperTest
 		databaseHelper.onUpgrade(database, 16, 17);
 
 		then(database).should().execSQL("ALTER TABLE vpnprofile ADD dns_servers TEXT;");
+	}
+
+	@Test
+	public void onUpgradeFrom17To18()
+	{
+		databaseHelper.onUpgrade(database, 17, 18);
+
+		then(database).should().execSQL("CREATE TABLE IF NOT EXISTS usercertificate (_id INTEGER PRIMARY KEY AUTOINCREMENT,vpn_profile_uuid TEXT UNIQUE,configured_alias TEXT NOT NULL,effective_alias TEXT,data TEXT NOT NULL,password TEXT);");
+		then(database).should().execSQL("CREATE TABLE IF NOT EXISTS cacertificate (_id INTEGER PRIMARY KEY AUTOINCREMENT,vpn_profile_uuid TEXT UNIQUE,configured_alias TEXT NOT NULL,effective_alias TEXT,data TEXT NOT NULL);");
 	}
 
 	@Test

--- a/src/frontends/android/app/src/test/java/org/strongswan/android/data/DatabaseHelperTest.java
+++ b/src/frontends/android/app/src/test/java/org/strongswan/android/data/DatabaseHelperTest.java
@@ -1,0 +1,233 @@
+package org.strongswan.android.data;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+
+import android.content.ContentValues;
+import android.database.Cursor;
+import android.database.sqlite.SQLiteDatabase;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+
+public class DatabaseHelperTest
+{
+	@Rule
+	public MockitoRule rule = MockitoJUnit.rule();
+
+	@Mock
+	private SQLiteDatabase database;
+	@Mock
+	private Cursor cursor;
+
+	private final DatabaseHelper databaseHelper = new DatabaseHelper(null);
+
+	@Test
+	public void onCreate()
+	{
+		databaseHelper.onCreate(database);
+
+		then(database).should().execSQL("CREATE TABLE IF NOT EXISTS vpnprofile (_id INTEGER PRIMARY KEY AUTOINCREMENT,_uuid TEXT UNIQUE,name TEXT NOT NULL,gateway TEXT NOT NULL,vpn_type TEXT NOT NULL DEFAULT '',username TEXT,password TEXT,certificate TEXT,user_certificate TEXT,mtu INTEGER,port INTEGER,split_tunneling INTEGER,local_id TEXT,remote_id TEXT,excluded_subnets TEXT,included_subnets TEXT,selected_apps INTEGER,selected_apps_list TEXT,nat_keepalive INTEGER,flags INTEGER,ike_proposal TEXT,esp_proposal TEXT,dns_servers TEXT);");
+	}
+
+	@Test
+	public void onUpgradeFrom1To2()
+	{
+		databaseHelper.onUpgrade(database, 1, 2);
+
+		then(database).should().execSQL("ALTER TABLE vpnprofile ADD user_certificate TEXT;");
+	}
+
+	@Test
+	public void onUpgradeFrom2To3()
+	{
+		databaseHelper.onUpgrade(database, 2, 3);
+
+		then(database).should().execSQL("ALTER TABLE vpnprofile ADD vpn_type TEXT NOT NULL DEFAULT '';");
+	}
+
+	@Test
+	public void onUpgradeFrom3To4()
+	{
+		databaseHelper.onUpgrade(database, 3, 4);
+
+		then(database).should().beginTransaction();
+		then(database).should().execSQL("ALTER TABLE vpnprofile RENAME TO tmp_vpnprofile;");
+		then(database).should().execSQL("CREATE TABLE IF NOT EXISTS vpnprofile (_id INTEGER PRIMARY KEY AUTOINCREMENT,name TEXT NOT NULL,gateway TEXT NOT NULL,vpn_type TEXT NOT NULL DEFAULT '',username TEXT,password TEXT,certificate TEXT,user_certificate TEXT);");
+		then(database).should().execSQL("INSERT INTO vpnprofile SELECT _id,name,gateway,vpn_type,username,password,certificate,user_certificate FROM tmp_vpnprofile;");
+		then(database).should().execSQL("DROP TABLE tmp_vpnprofile;");
+		then(database).should().setTransactionSuccessful();
+		then(database).should().endTransaction();
+	}
+
+	@Test
+	public void onUpgradeFrom4To5()
+	{
+		databaseHelper.onUpgrade(database, 4, 5);
+
+		then(database).should().execSQL("ALTER TABLE vpnprofile ADD mtu INTEGER;");
+	}
+
+	@Test
+	public void onUpgradeFrom5To6()
+	{
+		databaseHelper.onUpgrade(database, 5, 6);
+
+		then(database).should().execSQL("ALTER TABLE vpnprofile ADD port INTEGER;");
+	}
+
+	@Test
+	public void onUpgradeFrom6To7()
+	{
+		databaseHelper.onUpgrade(database, 6, 7);
+
+		then(database).should().execSQL("ALTER TABLE vpnprofile ADD split_tunneling INTEGER;");
+	}
+
+	@Test
+	public void onUpgradeFrom7To8()
+	{
+		databaseHelper.onUpgrade(database, 7, 8);
+
+		then(database).should().execSQL("ALTER TABLE vpnprofile ADD local_id TEXT;");
+		then(database).should().execSQL("ALTER TABLE vpnprofile ADD remote_id TEXT;");
+	}
+
+	@Test
+	public void onUpgradeFrom8To9()
+	{
+		databaseHelper.onUpgrade(database, 8, 9);
+
+		then(database).should().execSQL("ALTER TABLE vpnprofile ADD _uuid TEXT UNIQUE;");
+	}
+
+	@Test
+	public void onUpgradeFrom9To10()
+	{
+		databaseHelper.onUpgrade(database, 9, 10);
+
+		then(database).should().execSQL("ALTER TABLE vpnprofile ADD excluded_subnets TEXT;");
+	}
+
+	@Test
+	public void onUpgradeFrom10To11()
+	{
+		databaseHelper.onUpgrade(database, 10, 11);
+
+		then(database).should().execSQL("ALTER TABLE vpnprofile ADD included_subnets TEXT;");
+	}
+
+	@Test
+	public void onUpgradeFrom11To12()
+	{
+		databaseHelper.onUpgrade(database, 11, 12);
+
+		then(database).should().execSQL("ALTER TABLE vpnprofile ADD selected_apps INTEGER;");
+		then(database).should().execSQL("ALTER TABLE vpnprofile ADD selected_apps_list TEXT;");
+	}
+
+	@Test
+	public void onUpgradeFrom13To14()
+	{
+		databaseHelper.onUpgrade(database, 13, 14);
+
+		then(database).should().execSQL("ALTER TABLE vpnprofile ADD flags INTEGER;");
+	}
+
+	@Test
+	public void onUpgradeFrom14To15()
+	{
+		databaseHelper.onUpgrade(database, 14, 15);
+
+		then(database).should().execSQL("ALTER TABLE vpnprofile ADD ike_proposal TEXT;");
+		then(database).should().execSQL("ALTER TABLE vpnprofile ADD esp_proposal TEXT;");
+	}
+
+	@Test
+	public void onUpgradeFrom15To16()
+	{
+		// given
+		given(database.query(
+			"vpnprofile",
+			new String[]{
+				"_id",
+				"_uuid",
+				"name",
+				"gateway",
+				"vpn_type",
+				"username",
+				"password",
+				"certificate",
+				"user_certificate",
+				"mtu",
+				"port",
+				"split_tunneling",
+				"local_id",
+				"remote_id",
+				"excluded_subnets",
+				"included_subnets",
+				"selected_apps",
+				"selected_apps_list",
+				"nat_keepalive",
+				"flags",
+				"ike_proposal",
+				"esp_proposal",
+			},
+			"_uuid is NULL",
+			null,
+			null,
+			null,
+			null))
+			.willReturn(cursor);
+
+		given(cursor.isAfterLast())
+			.willReturn(false)
+			.willReturn(true);
+
+		given(cursor.getLong(cursor.getColumnIndexOrThrow("_id")))
+			.willReturn(1L);
+
+		// when
+		databaseHelper.onUpgrade(database, 15, 16);
+
+		// then
+		then(database).should().beginTransaction();
+		then(database).should().update(eq("vpnprofile"), any(ContentValues.class), eq("_id = 1"), eq(null));
+
+		then(cursor).should().close();
+
+		then(database).should().setTransactionSuccessful();
+		then(database).should().endTransaction();
+	}
+
+	@Test
+	public void onUpgradeFrom16To17()
+	{
+		databaseHelper.onUpgrade(database, 16, 17);
+
+		then(database).should().execSQL("ALTER TABLE vpnprofile ADD dns_servers TEXT;");
+	}
+
+	@Test
+	public void onUpgradeFrom2To5()
+	{
+		databaseHelper.onUpgrade(database, 2, 5);
+
+		then(database).should().execSQL("ALTER TABLE vpnprofile ADD vpn_type TEXT NOT NULL DEFAULT '';");
+
+		then(database).should().beginTransaction();
+		then(database).should().execSQL("ALTER TABLE vpnprofile RENAME TO tmp_vpnprofile;");
+		then(database).should().execSQL("CREATE TABLE IF NOT EXISTS vpnprofile (_id INTEGER PRIMARY KEY AUTOINCREMENT,name TEXT NOT NULL,gateway TEXT NOT NULL,vpn_type TEXT NOT NULL DEFAULT '',username TEXT,password TEXT,certificate TEXT,user_certificate TEXT);");
+		then(database).should().execSQL("INSERT INTO vpnprofile SELECT _id,name,gateway,vpn_type,username,password,certificate,user_certificate FROM tmp_vpnprofile;");
+		then(database).should().execSQL("DROP TABLE tmp_vpnprofile;");
+		then(database).should().setTransactionSuccessful();
+		then(database).should().endTransaction();
+
+		then(database).should().execSQL("ALTER TABLE vpnprofile ADD mtu INTEGER;");
+	}
+}

--- a/src/frontends/android/app/src/test/java/org/strongswan/android/data/ManagedVpnProfileTest.java
+++ b/src/frontends/android/app/src/test/java/org/strongswan/android/data/ManagedVpnProfileTest.java
@@ -1,0 +1,273 @@
+package org.strongswan.android.data;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import android.os.Bundle;
+
+import org.junit.Test;
+
+public class ManagedVpnProfileTest
+{
+	private static final String KEY_REMOTE = "remote";
+	private static final String KEY_LOCAL = "local";
+	private static final String KEY_INCLUDED_APPS = "included_apps";
+	private static final String KEY_EXCLUDED_APPS = "excluded_apps";
+	private static final String KEY_SPLIT_TUNNELING = "split_tunneling";
+	private static final String KEY_SPLIT_TUNNELLING_BLOCK_IPV4 = "split_tunnelling_block_IPv4";
+	private static final String KEY_SPLIT_TUNNELLING_BLOCK_IPV6 = "split_tunnelling_block_IPv6";
+
+	private static final String KEY_TRANSPORT_IPV6_FLAG = "transport_IPv6";
+	private static final String KEY_REMOTE_CERT_REQ_FLAG = "remote_cert_req";
+	private static final String KEY_REMOTE_REVOCATION_CRL_FLAG = "remote_revocation_crl";
+	private static final String KEY_REMOTE_REVOCATION_OCSP_FLAG = "remote_revocation_ocsp";
+	private static final String KEY_REMOTE_REVOCATION_STRICT_FLAG = "remote_revocation_strict";
+	private static final String KEY_LOCAL_RSA_PSS_FLAG = "local_rsa_pss";
+
+	private static final String VPN_PROFILE_UUID = "00000000-0000-0000-0000-000000000001";
+	private static final String VPN_PROFILE_NAME = "vpn-profile-name";
+	private static final String GATEWAY = "gateway.example.com";
+	private static final int PORT = 500;
+	private static final String REMOTE_ID = "remote-id";
+	private static final String CERTIFICATE = "x.509-certificate-base64";
+	private static final String LOCAL_ID = "local-id";
+	private static final String USERNAME = "username";
+	private static final String USER_CERTIFICATE = "PKCS#12-user-certificate-base64";
+	private static final String USER_CERTIFICATE_PASSWORD = "user-certificate-password";
+	private static final String INCLUDED_APPS = "a b c";
+	private static final String EXCLUDED_APPS = "d e f";
+	private static final String IKE_PROPOSAL = "ike-proposal";
+	private static final String ESP_PROPOSAL = "esp-proposal";
+	private static final String DNS_SERVERS = "1.1.1.1 8.8.8.8";
+	private static final String INCLUDED_SUBNETS = "included subnets";
+	private static final String EXCLUDED_SUBNETS = "excluded subnets";
+
+	@Test
+	public void testDefaultValues()
+	{
+		final Bundle bundle = new Bundle();
+		bundle.putString(VpnProfileDataSource.KEY_NAME, VPN_PROFILE_NAME);
+		bundle.putInt(VpnProfileDataSource.KEY_MTU, 2000);
+		bundle.putInt(VpnProfileDataSource.KEY_NAT_KEEPALIVE, 200);
+
+		final ManagedVpnProfile vpnProfile = new ManagedVpnProfile(bundle, VPN_PROFILE_UUID);
+
+		assertThat(vpnProfile.getUUID()).hasToString(VPN_PROFILE_UUID);
+		assertThat(vpnProfile.getName()).isEqualTo(VPN_PROFILE_NAME);
+		assertThat(vpnProfile.getVpnType()).isEqualTo(VpnType.IKEV2_EAP);
+
+		assertThat(vpnProfile.getGateway()).isNull();
+		assertThat(vpnProfile.getPort()).isNull();
+		assertThat(vpnProfile.getRemoteId()).isNull();
+		assertThat(vpnProfile.getCertificateAlias()).isNull();
+		assertThat(vpnProfile.getCaCertificate()).isNull();
+
+		assertThat(vpnProfile.getLocalId()).isNull();
+		assertThat(vpnProfile.getUsername()).isNull();
+		assertThat(vpnProfile.getUserCertificateAlias()).isNull();
+		assertThat(vpnProfile.getUserCertificate()).isNull();
+
+		assertThat(vpnProfile.getFlags()).isZero();
+
+		assertThat(vpnProfile.getMTU()).isNull();
+		assertThat(vpnProfile.getNATKeepAlive()).isNull();
+
+		assertThat(vpnProfile.getIkeProposal()).isNull();
+		assertThat(vpnProfile.getEspProposal()).isNull();
+		assertThat(vpnProfile.getDnsServers()).isNull();
+
+		assertThat(vpnProfile.getSelectedAppsHandling()).isEqualTo(VpnProfile.SelectedAppsHandling.SELECTED_APPS_DISABLE);
+		assertThat(vpnProfile.getSelectedAppsSet()).isEmpty();
+
+		assertThat(vpnProfile.getExcludedSubnets()).isNull();
+		assertThat(vpnProfile.getIncludedSubnets()).isNull();
+
+		assertThat(vpnProfile.getSplitTunneling()).isZero();
+	}
+
+	@Test
+	public void testRemote()
+	{
+		final Bundle remote = new Bundle();
+		remote.putString(VpnProfileDataSource.KEY_GATEWAY, GATEWAY);
+		remote.putInt(VpnProfileDataSource.KEY_PORT, PORT);
+		remote.putString(VpnProfileDataSource.KEY_REMOTE_ID, REMOTE_ID);
+		remote.putString(VpnProfileDataSource.KEY_CERTIFICATE, CERTIFICATE);
+
+		final Bundle bundle = new Bundle();
+		bundle.putBundle(KEY_REMOTE, remote);
+
+		final ManagedVpnProfile vpnProfile = new ManagedVpnProfile(bundle, VPN_PROFILE_UUID);
+
+		assertThat(vpnProfile.getGateway()).isEqualTo(GATEWAY);
+		assertThat(vpnProfile.getPort()).isEqualTo(PORT);
+		assertThat(vpnProfile.getRemoteId()).isEqualTo(REMOTE_ID);
+		assertThat(vpnProfile.getCertificateAlias()).isEqualTo("remote:" + VPN_PROFILE_UUID);
+		assertThat(vpnProfile.getCaCertificate()).isEqualTo(new CaCertificate(
+			VPN_PROFILE_UUID,
+			"remote:" + VPN_PROFILE_UUID,
+			CERTIFICATE)
+		);
+	}
+
+	@Test
+	public void testLocal()
+	{
+		final Bundle local = new Bundle();
+		local.putString(VpnProfileDataSource.KEY_LOCAL_ID, LOCAL_ID);
+		local.putString(VpnProfileDataSource.KEY_USERNAME, USERNAME);
+		local.putString(VpnProfileDataSource.KEY_USER_CERTIFICATE, USER_CERTIFICATE);
+		local.putString(VpnProfileDataSource.KEY_USER_CERTIFICATE_PASSWORD, USER_CERTIFICATE_PASSWORD);
+
+		final Bundle bundle = new Bundle();
+		bundle.putBundle(KEY_LOCAL, local);
+
+		final ManagedVpnProfile vpnProfile = new ManagedVpnProfile(bundle, VPN_PROFILE_UUID);
+
+		assertThat(vpnProfile.getLocalId()).isEqualTo(LOCAL_ID);
+		assertThat(vpnProfile.getUsername()).isEqualTo(USERNAME);
+		assertThat(vpnProfile.getUserCertificateAlias()).isEqualTo("local:" + VPN_PROFILE_UUID);
+		assertThat(vpnProfile.getUserCertificate()).isEqualTo(new UserCertificate(
+			VPN_PROFILE_UUID,
+			"local:" + VPN_PROFILE_UUID,
+			USER_CERTIFICATE,
+			USER_CERTIFICATE_PASSWORD)
+		);
+	}
+
+	@Test
+	public void testIncludedApps()
+	{
+		final Bundle bundle = new Bundle();
+		bundle.putString(KEY_INCLUDED_APPS, INCLUDED_APPS);
+		bundle.putString(KEY_EXCLUDED_APPS, EXCLUDED_APPS);
+
+		final ManagedVpnProfile vpnProfile = new ManagedVpnProfile(bundle, VPN_PROFILE_UUID);
+
+		assertThat(vpnProfile.getSelectedApps()).isEqualTo(INCLUDED_APPS);
+		assertThat(vpnProfile.getSelectedAppsSet()).contains("a", "b", "c");
+		assertThat(vpnProfile.getSelectedAppsHandling()).isEqualTo(VpnProfile.SelectedAppsHandling.SELECTED_APPS_ONLY);
+	}
+
+	@Test
+	public void testExcludedApps()
+	{
+		final Bundle bundle = new Bundle();
+		bundle.putString(KEY_INCLUDED_APPS, null);
+		bundle.putString(KEY_EXCLUDED_APPS, EXCLUDED_APPS);
+
+		final ManagedVpnProfile vpnProfile = new ManagedVpnProfile(bundle, VPN_PROFILE_UUID);
+
+		assertThat(vpnProfile.getSelectedApps()).isEqualTo(EXCLUDED_APPS);
+		assertThat(vpnProfile.getSelectedAppsSet()).contains("d", "e", "f");
+		assertThat(vpnProfile.getSelectedAppsHandling()).isEqualTo(VpnProfile.SelectedAppsHandling.SELECTED_APPS_EXCLUDE);
+	}
+
+	@Test
+	public void testMtuKeepaliveProposals()
+	{
+		final Bundle bundle = new Bundle();
+		bundle.putInt(VpnProfileDataSource.KEY_MTU, 1500);
+		bundle.putInt(VpnProfileDataSource.KEY_NAT_KEEPALIVE, 120);
+		bundle.putString(VpnProfileDataSource.KEY_IKE_PROPOSAL, IKE_PROPOSAL);
+		bundle.putString(VpnProfileDataSource.KEY_ESP_PROPOSAL, ESP_PROPOSAL);
+		bundle.putString(VpnProfileDataSource.KEY_DNS_SERVERS, DNS_SERVERS);
+
+		final ManagedVpnProfile vpnProfile = new ManagedVpnProfile(bundle, VPN_PROFILE_UUID);
+
+		assertThat(vpnProfile.getMTU()).isEqualTo(1500);
+		assertThat(vpnProfile.getNATKeepAlive()).isEqualTo(120);
+		assertThat(vpnProfile.getIkeProposal()).isEqualTo(IKE_PROPOSAL);
+		assertThat(vpnProfile.getEspProposal()).isEqualTo(ESP_PROPOSAL);
+		assertThat(vpnProfile.getDnsServers()).isEqualTo(DNS_SERVERS);
+	}
+
+	@Test
+	public void testSplitTunneling()
+	{
+		final Bundle splitTunneling = new Bundle();
+		splitTunneling.putBoolean(KEY_SPLIT_TUNNELLING_BLOCK_IPV4, true);
+		splitTunneling.putBoolean(KEY_SPLIT_TUNNELLING_BLOCK_IPV6, true);
+		splitTunneling.putString(VpnProfileDataSource.KEY_INCLUDED_SUBNETS, INCLUDED_SUBNETS);
+		splitTunneling.putString(VpnProfileDataSource.KEY_EXCLUDED_SUBNETS, EXCLUDED_SUBNETS);
+
+		final Bundle bundle = new Bundle();
+		bundle.putBundle(KEY_SPLIT_TUNNELING, splitTunneling);
+
+		final ManagedVpnProfile vpnProfile = new ManagedVpnProfile(bundle, VPN_PROFILE_UUID);
+
+		assertThat(vpnProfile.getSplitTunneling()).isEqualTo(VpnProfile.SPLIT_TUNNELING_BLOCK_IPV4 | VpnProfile.SPLIT_TUNNELING_BLOCK_IPV6);
+		assertThat(vpnProfile.getIncludedSubnets()).isEqualTo(INCLUDED_SUBNETS);
+		assertThat(vpnProfile.getExcludedSubnets()).isEqualTo(EXCLUDED_SUBNETS);
+	}
+
+	@Test
+	public void testSplitTunnelingIPv4()
+	{
+		final Bundle splitTunneling = new Bundle();
+		splitTunneling.putBoolean(KEY_SPLIT_TUNNELLING_BLOCK_IPV4, true);
+
+		final Bundle bundle = new Bundle();
+		bundle.putBundle(KEY_SPLIT_TUNNELING, splitTunneling);
+
+		final ManagedVpnProfile vpnProfile = new ManagedVpnProfile(bundle, VPN_PROFILE_UUID);
+
+		assertThat(vpnProfile.getSplitTunneling()).isEqualTo(VpnProfile.SPLIT_TUNNELING_BLOCK_IPV4);
+	}
+
+	@Test
+	public void testSplitTunnelingIPv6()
+	{
+		final Bundle splitTunneling = new Bundle();
+		splitTunneling.putBoolean(KEY_SPLIT_TUNNELLING_BLOCK_IPV6, true);
+
+		final Bundle bundle = new Bundle();
+		bundle.putBundle(KEY_SPLIT_TUNNELING, splitTunneling);
+
+		final ManagedVpnProfile vpnProfile = new ManagedVpnProfile(bundle, VPN_PROFILE_UUID);
+
+		assertThat(vpnProfile.getSplitTunneling()).isEqualTo(VpnProfile.SPLIT_TUNNELING_BLOCK_IPV6);
+	}
+
+	@Test
+	public void testNegativeFlags()
+	{
+		final Bundle remote = new Bundle();
+		final Bundle local = new Bundle();
+
+		final Bundle bundle = new Bundle();
+		bundle.putBundle(KEY_REMOTE, remote);
+		bundle.putBundle(KEY_LOCAL, local);
+
+		final ManagedVpnProfile vpnProfile = new ManagedVpnProfile(bundle, VPN_PROFILE_UUID);
+
+		assertThat(vpnProfile.getFlags()).isEqualTo(
+			VpnProfile.FLAGS_SUPPRESS_CERT_REQS |
+				VpnProfile.FLAGS_DISABLE_CRL |
+				VpnProfile.FLAGS_DISABLE_OCSP);
+	}
+
+	@Test
+	public void testPositiveFlags()
+	{
+		final Bundle remote = new Bundle();
+		remote.putBoolean(KEY_REMOTE_CERT_REQ_FLAG, true);
+		remote.putBoolean(KEY_REMOTE_REVOCATION_CRL_FLAG, true);
+		remote.putBoolean(KEY_REMOTE_REVOCATION_OCSP_FLAG, true);
+		remote.putBoolean(KEY_REMOTE_REVOCATION_STRICT_FLAG, true);
+
+		final Bundle local = new Bundle();
+		local.putBoolean(KEY_LOCAL_RSA_PSS_FLAG, true);
+
+		final Bundle bundle = new Bundle();
+		bundle.putBundle(KEY_REMOTE, remote);
+		bundle.putBundle(KEY_LOCAL, local);
+		bundle.putBoolean(KEY_TRANSPORT_IPV6_FLAG, true);
+
+		final ManagedVpnProfile vpnProfile = new ManagedVpnProfile(bundle, VPN_PROFILE_UUID);
+
+		assertThat(vpnProfile.getFlags()).isEqualTo(
+			VpnProfile.FLAGS_STRICT_REVOCATION |
+				VpnProfile.FLAGS_RSA_PSS |
+				VpnProfile.FLAGS_IPv6_TRANSPORT);
+	}
+}

--- a/src/frontends/android/app/src/test/java/org/strongswan/android/utils/DifferenceTest.java
+++ b/src/frontends/android/app/src/test/java/org/strongswan/android/utils/DifferenceTest.java
@@ -1,0 +1,130 @@
+package org.strongswan.android.utils;
+
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.Test;
+
+import java.util.List;
+import java.util.Objects;
+
+import androidx.core.util.Pair;
+
+public class DifferenceTest
+{
+	@Test
+	public void testElementAdded()
+	{
+		final Element element = new Element("a", 0);
+		final List<Element> existing = List.of();
+		final List<Element> modified = List.of(element);
+
+		final Difference<Element> diff = Difference.between(existing, modified, Element::getKey);
+
+		assertThat(diff.getInserts()).containsExactly(element);
+		assertThat(diff.getUpdates()).isEmpty();
+		assertThat(diff.getDeletes()).isEmpty();
+	}
+
+	@Test
+	public void testElementRemoved()
+	{
+		final Element element = new Element("a", 0);
+		final List<Element> existing = List.of(element);
+		final List<Element> modified = List.of();
+
+		final Difference<Element> diff = Difference.between(existing, modified, Element::getKey);
+
+		assertThat(diff.getInserts()).isEmpty();
+		assertThat(diff.getUpdates()).isEmpty();
+		assertThat(diff.getDeletes()).containsExactly(element);
+	}
+
+	@Test
+	public void testElementIdentical()
+	{
+		final Element element0 = new Element("a", 0);
+		final Element element1 = new Element("a", 0);
+		final List<Element> existing = List.of(element0);
+		final List<Element> modified = List.of(element1);
+
+		final Difference<Element> diff = Difference.between(existing, modified, Element::getKey);
+
+		assertThat(diff.getInserts()).isEmpty();
+		assertThat(diff.getUpdates()).isEmpty();
+		assertThat(diff.getDeletes()).isEmpty();
+	}
+
+	@Test
+	public void testElementSwap()
+	{
+		final Element elementA = new Element("a", 0);
+		final Element elementB = new Element("b", 0);
+		final List<Element> existing = List.of(elementA);
+		final List<Element> modified = List.of(elementB);
+
+		final Difference<Element> diff = Difference.between(existing, modified, Element::getKey);
+
+		assertThat(diff.getInserts()).containsExactly(elementB);
+		assertThat(diff.getUpdates()).isEmpty();
+		assertThat(diff.getDeletes()).containsExactly(elementA);
+	}
+
+	@Test
+	public void testElementUpdate()
+	{
+		final Element elementA0 = new Element("a", 0);
+		final Element elementA1 = new Element("a", 1);
+		final List<Element> existing = List.of(elementA0);
+		final List<Element> modified = List.of(elementA1);
+
+		final Difference<Element> diff = Difference.between(existing, modified, Element::getKey);
+
+		assertThat(diff.getInserts()).isEmpty();
+		assertThat(diff.getUpdates()).containsExactly(Pair.create(elementA0, elementA1));
+		assertThat(diff.getDeletes()).isEmpty();
+	}
+
+	private static class Element
+	{
+		private final String key;
+		private final int value;
+
+		public Element(final String key, final int value)
+		{
+			this.key = key;
+			this.value = value;
+		}
+
+		public String getKey()
+		{
+			return key;
+		}
+
+		public int getValue()
+		{
+			return value;
+		}
+
+		@Override
+		public boolean equals(Object o)
+		{
+			if (this == o)
+			{
+				return true;
+			}
+			if (o == null || getClass() != o.getClass())
+			{
+				return false;
+			}
+			Element element = (Element)o;
+			return value == element.value && Objects.equals(key, element.key);
+		}
+
+		@Override
+		public int hashCode()
+		{
+			return Objects.hash(key, value);
+		}
+	}
+}

--- a/src/frontends/android/build.gradle
+++ b/src/frontends/android/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.4.2'
+        classpath 'com.android.tools.build:gradle:8.1.1'
     }
 }
 

--- a/src/frontends/android/build.gradle
+++ b/src/frontends/android/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.3.0'
+        classpath 'com.android.tools.build:gradle:7.4.2'
     }
 }
 

--- a/src/frontends/android/build.gradle
+++ b/src/frontends/android/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.1.1'
+        classpath 'com.android.tools.build:gradle:8.1.3'
     }
 }
 

--- a/src/frontends/android/gradle.properties
+++ b/src/frontends/android/gradle.properties
@@ -1,2 +1,5 @@
+android.defaults.buildfeatures.buildconfig=true
 android.enableJetifier=true
+android.nonFinalResIds=false
+android.nonTransitiveRClass=false
 android.useAndroidX=true

--- a/src/frontends/android/gradle/wrapper/gradle-wrapper.properties
+++ b/src/frontends/android/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-all.zip

--- a/src/frontends/android/gradle/wrapper/gradle-wrapper.properties
+++ b/src/frontends/android/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.0-all.zip


### PR DESCRIPTION
This adds support for [managed configuration](https://developer.android.com/work/managed-configurations) to the Android frontend of strongSwan. This allows administrators to remotely configure the strongSwan app, when installed on an Android device enrolled through Android Enterprise.

Additionally, the app has been extended with the ability to install user certificates through the [DevicePolicyManager](https://developer.android.com/reference/android/app/admin/DevicePolicyManager), which is possible on enrolled devices, if the app has been granted the `CERT_INSTALL` [delegate scope](https://developers.google.com/android/management/reference/rest/v1/enterprises.policies#delegatedscope)

The changes also make it possible for an administrator to hide the option to create or use existing unmanaged VPN profiles.