### PR TITLE
Adding support for RFC 4806

### DIFF
--- a/src/libcharon/config/ike_cfg.c
+++ b/src/libcharon/config/ike_cfg.c
@@ -97,6 +97,11 @@ struct private_ike_cfg_t {
 	bool certreq;
 
 	/**
+	 * should we send an OCSP status request?
+	 */
+	bool ocsp_certreq;
+
+	/**
 	 * enforce UDP encapsulation
 	 */
 	bool force_encap;
@@ -132,6 +137,12 @@ METHOD(ike_cfg_t, send_certreq, bool,
 	private_ike_cfg_t *this)
 {
 	return this->certreq;
+}
+
+METHOD(ike_cfg_t, send_ocsp_certreq, bool,
+	private_ike_cfg_t *this)
+{
+	return this->ocsp_certreq;
 }
 
 METHOD(ike_cfg_t, force_encap_, bool,
@@ -388,6 +399,7 @@ METHOD(ike_cfg_t, equals, bool,
 	return
 		this->version == other->version &&
 		this->certreq == other->certreq &&
+		this->ocsp_certreq == other->ocsp_certreq &&
 		this->force_encap == other->force_encap &&
 		this->fragmentation == other->fragmentation &&
 		this->childless == other->childless &&
@@ -587,6 +599,7 @@ ike_cfg_t *ike_cfg_create(ike_cfg_create_t *data)
 		.public = {
 			.get_version = _get_version,
 			.send_certreq = _send_certreq,
+			.send_ocsp_certreq = _send_ocsp_certreq,
 			.force_encap = _force_encap_,
 			.fragmentation = _fragmentation,
 			.childless = _childless,
@@ -611,6 +624,7 @@ ike_cfg_t *ike_cfg_create(ike_cfg_create_t *data)
 		.refcount = 1,
 		.version = data->version,
 		.certreq = !data->no_certreq,
+		.ocsp_certreq = !data->no_ocsp_certreq,
 		.force_encap = data->force_encap,
 		.fragmentation = data->fragmentation,
 		.childless = data->childless,

--- a/src/libcharon/config/ike_cfg.h
+++ b/src/libcharon/config/ike_cfg.h
@@ -211,6 +211,13 @@ struct ike_cfg_t {
 	bool (*send_certreq) (ike_cfg_t *this);
 
 	/**
+	 * Should we send an OCSP status request in IKE_SA_INIT?
+	 *
+	 * @return				OCSP status request sending policy
+	 */
+	bool (*send_ocsp_certreq) (ike_cfg_t *this);
+
+	/**
 	 * Enforce UDP encapsulation by faking NATD notifies?
 	 *
 	 * @return				TRUE to enforce UDP encapsulation
@@ -288,6 +295,8 @@ struct ike_cfg_create_t {
 	uint16_t remote_port;
 	/** TRUE to not send any certificate requests */
 	bool no_certreq;
+	/** TRUE to not send OCSP status requests */
+	bool no_ocsp_certreq;
 	/** Enforce UDP encapsulation by faking NATD notify */
 	bool force_encap;
 	/** Use IKE fragmentation */

--- a/src/libcharon/config/peer_cfg.c
+++ b/src/libcharon/config/peer_cfg.c
@@ -32,6 +32,13 @@ ENUM(cert_policy_names, CERT_ALWAYS_SEND, CERT_NEVER_SEND,
 	"CERT_NEVER_SEND",
 );
 
+ENUM(ocsp_policy_names, OCSP_BOTH, OCSP_NEVER,
+	"OCSP_BOTH",
+	"OCSP_REPLY",
+	"OCSP_REQUEST",
+	"OCSP_NEVER",
+);
+
 ENUM(unique_policy_names, UNIQUE_NEVER, UNIQUE_KEEP,
 	"UNIQUE_NEVER",
 	"UNIQUE_NO",
@@ -80,6 +87,11 @@ struct private_peer_cfg_t {
 	 * should we send a certificate
 	 */
 	cert_policy_t cert_policy;
+
+	/**
+	 * should we send OCSP status request/response
+	 */
+	ocsp_policy_t ocsp_policy;
 
 	/**
 	 * uniqueness of an IKE_SA
@@ -495,6 +507,12 @@ METHOD(peer_cfg_t, get_cert_policy, cert_policy_t,
 	return this->cert_policy;
 }
 
+METHOD(peer_cfg_t, get_ocsp_policy, ocsp_policy_t,
+	private_peer_cfg_t *this)
+{
+	return this->ocsp_policy;
+}
+
 METHOD(peer_cfg_t, get_unique_policy, unique_policy_t,
 	private_peer_cfg_t *this)
 {
@@ -741,6 +759,7 @@ METHOD(peer_cfg_t, equals, bool,
 	return (
 		get_ike_version(this) == get_ike_version(other) &&
 		this->cert_policy == other->cert_policy &&
+		this->ocsp_policy == other->ocsp_policy &&
 		this->unique == other->unique &&
 		this->keyingtries == other->keyingtries &&
 		this->use_mobike == other->use_mobike &&
@@ -828,6 +847,7 @@ peer_cfg_t *peer_cfg_create(char *name, ike_cfg_t *ike_cfg,
 			.create_child_cfg_enumerator = _create_child_cfg_enumerator,
 			.select_child_cfg = _select_child_cfg,
 			.get_cert_policy = _get_cert_policy,
+			.get_ocsp_policy = _get_ocsp_policy,
 			.get_unique_policy = _get_unique_policy,
 			.get_keyingtries = _get_keyingtries,
 			.get_rekey_time = _get_rekey_time,
@@ -861,6 +881,7 @@ peer_cfg_t *peer_cfg_create(char *name, ike_cfg_t *ike_cfg,
 		.child_cfgs = linked_list_create(),
 		.lock = rwlock_create(RWLOCK_TYPE_DEFAULT),
 		.cert_policy = data->cert_policy,
+		.ocsp_policy = data->ocsp_policy,
 		.unique = data->unique,
 		.keyingtries = data->keyingtries,
 		.rekey_time = data->rekey_time,

--- a/src/libcharon/config/peer_cfg.h
+++ b/src/libcharon/config/peer_cfg.h
@@ -62,18 +62,22 @@ enum cert_policy_t {
  */
 extern enum_name_t *cert_policy_names;
 
+#if defined(WIN32) && defined(OCSP_REQUEST)
+#undef OCSP_REQUEST
+#endif
+
 /**
  * OCSP status request/response sending policy.
  */
 enum ocsp_policy_t {
 	/** both request OCSP status and reply to OCSP status request */
-	OCSP_BOTH =     0,
+	OCSP_BOTH =		0,
 	/** send OCSP status upon OCSP status request */
-	OCSP_REPLY =    1,
+	OCSP_REPLY =	1,
 	/** send OCSP status request */
-	OCSP_REQUEST =  2,
+	OCSP_REQUEST =	2,
 	/** never send OCSP status request or response */
-	OCSP_NEVER =    3,
+	OCSP_NEVER =	3,
 };
 
 /**

--- a/src/libcharon/config/peer_cfg.h
+++ b/src/libcharon/config/peer_cfg.h
@@ -25,6 +25,7 @@
 #define PEER_CFG_H_
 
 typedef enum cert_policy_t cert_policy_t;
+typedef enum ocsp_policy_t ocsp_policy_t;
 typedef enum unique_policy_t unique_policy_t;
 typedef struct peer_cfg_t peer_cfg_t;
 typedef struct peer_cfg_create_t peer_cfg_create_t;
@@ -60,6 +61,25 @@ enum cert_policy_t {
  * enum strings for cert_policy_t
  */
 extern enum_name_t *cert_policy_names;
+
+/**
+ * OCSP status request/response sending policy.
+ */
+enum ocsp_policy_t {
+	/** both request OCSP status and reply to OCSP status request */
+	OCSP_BOTH =     0,
+	/** send OCSP status upon OCSP status request */
+	OCSP_REPLY =    1,
+	/** send OCSP status request */
+	OCSP_REQUEST =  2,
+	/** never send OCSP status request or response */
+	OCSP_NEVER =    3,
+};
+
+/**
+ * enum strings for ocsp_policy_t
+ */
+extern enum_name_t *ocsp_policy_names;
 
 /**
  * Uniqueness of an IKE_SA, used to drop multiple connections with one peer.
@@ -212,6 +232,13 @@ struct peer_cfg_t {
 	 * @return			certificate sending policy
 	 */
 	cert_policy_t (*get_cert_policy) (peer_cfg_t *this);
+
+	/**
+	 * Should an OCSP status request/response be sent for this connection?
+	 *
+	 * @return			OCSP sending policy
+	 */
+	ocsp_policy_t (*get_ocsp_policy) (peer_cfg_t *this);
 
 	/**
 	 * How to handle uniqueness of IKE_SAs?
@@ -397,6 +424,8 @@ struct peer_cfg_t {
 struct peer_cfg_create_t {
 	/** Whether to send a certificate payload */
 	cert_policy_t cert_policy;
+	/** Whether to send OCSP status request/response */
+	ocsp_policy_t ocsp_policy;
 	/** Uniqueness of an IKE_SA */
 	unique_policy_t unique;
 	/** How many keying tries should be done before giving up */

--- a/src/libcharon/encoding/payloads/cert_payload.c
+++ b/src/libcharon/encoding/payloads/cert_payload.c
@@ -230,6 +230,9 @@ METHOD(cert_payload_t, get_cert, certificate_t*,
 		case ENC_CRL:
 			type = CERT_X509_CRL;
 			break;
+		case ENC_OCSP_CONTENT:
+			type = CERT_X509_OCSP_RESPONSE;
+			break;
 		default:
 			return NULL;
 	}
@@ -338,6 +341,9 @@ cert_payload_t *cert_payload_create_from_cert(payload_type_t type,
 			break;
 		case CERT_X509_AC:
 			this->encoding = ENC_X509_ATTRIBUTE;
+			break;
+		case CERT_X509_OCSP_RESPONSE:
+			this->encoding = ENC_OCSP_CONTENT;
 			break;
 		default:
 			DBG1(DBG_ENC, "embedding %N certificate in payload failed",

--- a/src/libcharon/encoding/payloads/certreq_payload.c
+++ b/src/libcharon/encoding/payloads/certreq_payload.c
@@ -244,6 +244,8 @@ METHOD(certreq_payload_t, get_cert_type, certificate_type_t,
 	{
 		case ENC_X509_SIGNATURE:
 			return CERT_X509;
+		case ENC_OCSP_CONTENT:
+			return CERT_X509_OCSP_REQUEST;
 		default:
 			return CERT_ANY;
 	}
@@ -301,6 +303,9 @@ certreq_payload_t *certreq_payload_create_type(certificate_type_t type)
 	{
 		case CERT_X509:
 			this->encoding = ENC_X509_SIGNATURE;
+			break;
+		case CERT_X509_OCSP_REQUEST:
+			this->encoding = ENC_OCSP_CONTENT;
 			break;
 		default:
 			DBG1(DBG_ENC, "certificate type %N not supported in requests",

--- a/src/libcharon/plugins/vici/vici_config.c
+++ b/src/libcharon/plugins/vici/vici_config.c
@@ -314,6 +314,7 @@ typedef struct {
 	identification_t *ppk_id;
 	bool ppk_required;
 	cert_policy_t send_cert;
+	ocsp_policy_t ocsp;
 	uint64_t dpd_delay;
 	uint64_t dpd_timeout;
 	fragmentation_t fragmentation;
@@ -425,6 +426,7 @@ static void log_peer_data(peer_data_t *data)
 	DBG2(DBG_CFG, "  remote_port = %u", data->remote_port);
 	DBG2(DBG_CFG, "  send_certreq = %u", data->send_certreq);
 	DBG2(DBG_CFG, "  send_cert = %N", cert_policy_names, data->send_cert);
+	DBG2(DBG_CFG, "  ocsp = %N", ocsp_policy_names, data->ocsp);
 	DBG2(DBG_CFG, "  ppk_id = %Y",  data->ppk_id);
 	DBG2(DBG_CFG, "  ppk_required = %u",  data->ppk_required);
 	DBG2(DBG_CFG, "  mobike = %u", data->mobike);
@@ -1679,6 +1681,28 @@ CALLBACK(parse_send_cert, bool,
 }
 
 /**
+ * Parse an ocsp_policy_t
+ */
+CALLBACK(parse_ocsp, bool,
+	ocsp_policy_t *out, chunk_t v)
+{
+	enum_map_t map[] = {
+		{ "reply",		OCSP_REPLY		},
+		{ "both",		OCSP_BOTH		},
+		{ "request",	OCSP_REQUEST	},
+		{ "never",		OCSP_NEVER		},
+	};
+	int d;
+
+	if (parse_map(map, countof(map), &d, v))
+	{
+		*out = d;
+		return TRUE;
+	}
+	return FALSE;
+}
+
+/**
  * Parse a unique_policy_t
  */
 CALLBACK(parse_unique, bool,
@@ -1879,6 +1903,7 @@ CALLBACK(peer_kv, bool,
 		{ "childless",		parse_childless,	&peer->childless			},
 		{ "send_certreq",	parse_bool,			&peer->send_certreq			},
 		{ "send_cert",		parse_send_cert,	&peer->send_cert			},
+		{ "ocsp",			parse_ocsp,			&peer->ocsp					},
 		{ "keyingtries",	parse_uint32,		&peer->keyingtries			},
 		{ "unique",			parse_unique,		&peer->unique				},
 		{ "local_port",		parse_uint32,		&peer->local_port			},
@@ -2498,6 +2523,7 @@ CALLBACK(config_sn, bool,
 		.send_certreq = TRUE,
 		.pull = TRUE,
 		.send_cert = CERT_SEND_IF_ASKED,
+		.ocsp = OCSP_REPLY,
 		.version = IKE_ANY,
 		.remote_port = IKEV2_UDP_PORT,
 		.fragmentation = FRAGMENTATION_YES,
@@ -2646,6 +2672,7 @@ CALLBACK(config_sn, bool,
 		.remote = peer.remote_addrs,
 		.remote_port = peer.remote_port,
 		.no_certreq = !peer.send_certreq,
+		.no_ocsp_certreq = !(peer.ocsp == OCSP_BOTH || peer.ocsp == OCSP_REQUEST),
 		.force_encap = peer.encap,
 		.fragmentation = peer.fragmentation,
 		.childless = peer.childless,
@@ -2655,6 +2682,7 @@ CALLBACK(config_sn, bool,
 
 	cfg = (peer_cfg_create_t){
 		.cert_policy = peer.send_cert,
+		.ocsp_policy = peer.ocsp,
 		.unique = peer.unique,
 		.keyingtries = peer.keyingtries,
 		.rekey_time = peer.rekey_time,

--- a/src/libcharon/sa/ike_sa.h
+++ b/src/libcharon/sa/ike_sa.h
@@ -250,6 +250,11 @@ enum ike_condition_t {
 	 * All authentication rounds have been completed successfully
 	 */
 	COND_AUTHENTICATED = (1<<14),
+
+	/**
+	 * An OCSP status request was received
+	 */
+	COND_OCSP_REQUEST = (1<<15),
 };
 
 /**

--- a/src/libcharon/sa/ikev2/tasks/ike_cert_post.c
+++ b/src/libcharon/sa/ikev2/tasks/ike_cert_post.c
@@ -216,6 +216,95 @@ static void add_attribute_certs(private_ike_cert_post_t *this,
 }
 
 /**
+ * Build CERT payload with OCSP status for the given cert
+ */
+static cert_payload_t *build_cert_ocsp_payload(certificate_t *cert,
+											   certificate_t *issuer, auth_cfg_t *auth)
+{
+	cert_payload_t *payload;
+	certificate_t *response;
+
+	response = lib->credmgr->get_ocsp(lib->credmgr, cert, issuer, auth);
+	if (!response)
+	{
+		DBG2(DBG_IKE, "no OCSP status for cert \"%Y\"", cert->get_subject(cert));
+		return NULL;
+	}
+
+	payload = cert_payload_create_from_cert(PLV2_CERTIFICATE, response);
+	response->destroy(response);
+
+	return payload;
+}
+
+/**
+ * Add subject certificate and intermediate CA certificates OCSP status to message
+ */
+static void add_cert_ocsp(private_ike_cert_post_t *this, auth_cfg_t *auth,
+						  message_t *message)
+{
+	auth_rule_t type;
+	cert_payload_t *payload;
+	certificate_t *cert, *issuer;
+	enumerator_t *enumerator;
+
+	cert = auth->get(auth, AUTH_RULE_SUBJECT_CERT);
+	if (!cert)
+	{
+		return;
+	}
+
+	enumerator = auth->create_enumerator(auth);
+	while (enumerator->enumerate(enumerator, &type, &issuer))
+	{
+		if (type == AUTH_RULE_CA_CERT || type == AUTH_RULE_IM_CERT)
+		{
+			payload = build_cert_ocsp_payload(cert, issuer, auth);
+			if (payload)
+			{
+					DBG1(DBG_IKE, "sending OCSP status for cert \"%Y\"", cert->get_subject(cert));
+					message->add_payload(message, (payload_t*)payload);
+			}
+			if (type == AUTH_RULE_CA_CERT)
+			{
+				break;
+			}
+			cert = issuer;
+		}
+	}
+	enumerator->destroy(enumerator);
+
+	issuer = lib->credmgr->get_issuer_cert(lib->credmgr, cert, TRUE, NULL);
+	if (!issuer)
+	{
+		DBG1(DBG_IKE, "Failed to retrieve \"%Y\" from local trusted CA", cert->get_issuer(cert));
+		return;
+	}
+	cert = issuer;
+
+	while (!cert->issued_by(cert, cert, NULL))
+	{
+		issuer = lib->credmgr->get_issuer_cert(lib->credmgr, cert, TRUE, NULL);
+
+		if (!issuer)
+		{
+			DBG1(DBG_IKE, "Failed to retrieve \"%Y\" from local trusted CA", cert->get_issuer(cert));
+			return;
+		}
+
+		payload = build_cert_ocsp_payload(cert, issuer, auth);
+		if (payload)
+		{
+			DBG1(DBG_IKE, "sending OCSP status for cert \"%Y\"", cert->get_subject(cert));
+			message->add_payload(message, (payload_t*)payload);
+		}
+
+		cert = issuer;
+	}
+	DBG2(DBG_IKE, "Reached root CA \"%Y\"", cert->get_subject(cert));
+}
+
+/**
  * add certificates to message
  */
 static void build_certs(private_ike_cert_post_t *this, message_t *message)
@@ -247,6 +336,23 @@ static void build_certs(private_ike_cert_post_t *this, message_t *message)
 			{
 				add_im_certs(this, auth, message);
 				add_attribute_certs(this, auth, message);
+			}
+			break;
+	}
+
+	switch(peer_cfg->get_ocsp_policy(peer_cfg))
+	{
+		case OCSP_NEVER:
+		case OCSP_REQUEST:
+			break;
+		case OCSP_REPLY:
+		case OCSP_BOTH:
+			if (this->ike_sa->has_condition(this->ike_sa, COND_OCSP_REQUEST) &&
+				!this->ike_sa->has_condition(this->ike_sa, COND_ONLINE_VALIDATION_SUSPENDED))
+			{
+				DBG1(DBG_IKE, "building CERT payloads with OCSP status");
+				auth = this->ike_sa->get_auth_cfg(this->ike_sa, TRUE);
+				add_cert_ocsp(this, auth, message);
 			}
 			break;
 	}

--- a/src/libstrongswan/credentials/auth_cfg.h
+++ b/src/libstrongswan/credentials/auth_cfg.h
@@ -97,6 +97,8 @@ enum auth_rule_t {
 	AUTH_RULE_CRL_VALIDATION,
 	/** result of a OCSP validation, cert_validation_t */
 	AUTH_RULE_OCSP_VALIDATION,
+	/** certificat ocsp signer, certificate_t* */
+	AUTH_RULE_OCSP_VALIDATOR,
 	/** CRL/OCSP validation is disabled, bool */
 	AUTH_RULE_CERT_VALIDATION_SUSPENDED,
 	/** subject is member of a group, identification_t*
@@ -247,9 +249,10 @@ struct auth_cfg_t {
 	/**
 	 * Purge all rules in a config.
 	 *
-	 * @param keep_ca	whether to keep AUTH_RULE_CA_CERT entries
+	 * @param partial	whether to keep AUTH_RULE_CA_CERT and
+	 *					AUTH_RULE_OCSP_VALIDATOR entries
 	 */
-	void (*purge)(auth_cfg_t *this, bool keep_ca);
+	void (*purge)(auth_cfg_t *this, bool partial);
 
 	/**
 	 * Check two configs for equality.

--- a/src/libstrongswan/credentials/cert_validator.h
+++ b/src/libstrongswan/credentials/cert_validator.h
@@ -90,6 +90,18 @@ struct cert_validator_t {
 	bool (*validate_online)(cert_validator_t *this, certificate_t *subject,
 							certificate_t *issuer, u_int pathlen, bool anchor,
 							auth_cfg_t *auth);
+
+	/**
+	 * Do OCSP checking for the given subject certificate
+	 * in relation to its issuer.
+	 *
+	 * @param subject		subject certificate to check
+	 * @param issuer		issuer of subject
+	 * @param auth			used to retrieve cert received during certreq ocsp request
+	 * @return				a valid OCSP response, NULL otherwise
+	 */
+	certificate_t* (*ocsp)(cert_validator_t *this, certificate_t *subject,
+						   certificate_t *issuer, auth_cfg_t *auth);
 };
 
 #endif /** CERT_VALIDATOR_H_ @}*/

--- a/src/libstrongswan/credentials/credential_manager.h
+++ b/src/libstrongswan/credentials/credential_manager.h
@@ -149,6 +149,19 @@ struct credential_manager_t {
 	certificate_t *(*get_cert)(credential_manager_t *this,
 							   certificate_type_t cert, key_type_t key,
 							   identification_t *id, bool trusted);
+
+	/**
+	 * Get the issuing certificate of a subject certificate.
+	 *
+	 * @param subject	subject certificate to use
+	 * @param trusted	TRUE to get a trusted certificate only
+	 * @param scheme	receives used signature scheme and parameters, if
+	 *					given (allocated)
+	 * @return			issuer certificate, if found, NULL otherwise
+	 */
+	certificate_t *(*get_issuer_cert)(credential_manager_t *this, certificate_t *subject,
+									  bool trusted, signature_params_t **scheme);
+
 	/**
 	 * Get the best matching shared key for two IDs.
 	 *
@@ -175,6 +188,18 @@ struct credential_manager_t {
 	 */
 	private_key_t* (*get_private)(credential_manager_t *this, key_type_t type,
 								  identification_t *id, auth_cfg_t *auth);
+
+	/**
+	 * Get an OCSP response for the given subject certificate in relation toi
+	 * its issuer.
+	 *
+	 * @param subject	subject certificate to check
+	 * @param issuer	issuer of subject
+	 * @param auth		used to retrieve cert received during certreq request
+	 * @return			a valid OCSP response, NULL otherwise
+	 */
+	certificate_t* (*get_ocsp)(credential_manager_t *this, certificate_t *subject,
+							   certificate_t *issuer, auth_cfg_t *auth);
 
 	/**
 	 * Create an enumerator over trusted certificates.

--- a/src/swanctl/swanctl.opt
+++ b/src/swanctl/swanctl.opt
@@ -205,6 +205,21 @@ connections.<conn>.send_cert = ifasked
 	certificate payloads altogether, _always_ causes certificate payloads to be
 	sent unconditionally whenever certificate authentication is used.
 
+connections.<conn>.ocsp = reply
+	Send OCSP extension in certificate request payload or certificate payloads
+	(_never_, _reply, _request_ or _both_).
+
+	Send OCSP status request in certificate request payloads when using
+	certificate authentication or/and send OCSP status response in certificate
+	payloads when using certificate authentication. With the default of _reply_
+	the daemon sends OCSP status response in certificate payloads only if an
+	OCSP status request in certificate request payload have been received.
+	_never_ disables sending of OCSP status request and response in certificate
+	request and certificate payloads altogether, _request_ causes OCSP status
+	request in certificate request payloads to be sent whenever certificate
+	authentication is used, _both_ combines _reply_ and _request_ whenever
+	certificate authentication is used.
+
 connections.<conn>.ppk_id =
 	String identifying the Postquantum Preshared Key (PPK) to be used.
 


### PR DESCRIPTION
Hello,

As evoked in https://github.com/strongswan/strongswan/discussions/1845, we added support for RFC 4806.
A new token `connections.<conn>.ocsp` was added and can take 4 values: `never`, `reply`, `request` or `both`.
If `never` is set, the functionality is disabled entirely.
If `reply` is set, request for OCSP status are replied to.
If `request` is set, request for OCSP status are sent.
If `both` is set, request for OCSP status are replied to and request are sent.

A request is answered through the revocation plugin making use of the caching feature.
When a reply is received, it is cached in the same fashion that CRL in CERT payload. It is later checked for validity while taking into account the certificate hash received in the OCSP certreq payload (if any).

As described in RFC 4806 and suggested by @strongX509, OCSP signer certificates from the group `b`  (see section 3.1) can be added in `swanctl/x509ocsp` and while added to OCSP certreq payload.