### PR TITLE
ipsec: strongSwan is not exclusive to Linux kernels

### DIFF
--- a/src/charon/charon.c
+++ b/src/charon/charon.c
@@ -376,7 +376,7 @@ int main(int argc, char *argv[])
 				status = 0;
 				goto deinit;
 			case 'v':
-				printf("Linux strongSwan %s\n", VERSION);
+				printf("strongSwan %s\n", VERSION);
 				status = 0;
 				goto deinit;
 			case 'l':

--- a/src/ipsec/_ipsec.8.in
+++ b/src/ipsec/_ipsec.8.in
@@ -277,15 +277,15 @@ command.
 .TP
 .B "\-\-version"
 returns the version in the form of
-.B Linux strongSwan U<strongSwan userland version>/K<Linux kernel version>
-if strongSwan uses the native NETKEY IPsec stack of the Linux kernel it is
+.B strongSwan U<strongSwan userland version>/K<kernel version>
+if strongSwan uses the native NETKEY IPsec stack of the kernel it is
 running on.
 .
 .TP
 .B "\-\-versioncode"
 returns the version number in the form of
-.B U<strongSwan userland version>/K<Linux kernel version>
-if strongSwan uses the native NETKEY IPsec stack of the Linux kernel it is
+.B U<strongSwan userland version>/K<kernel version>
+if strongSwan uses the native NETKEY IPsec stack of the kernel it is
 running on.
 .
 .TP


### PR DESCRIPTION
The project is now called "the strongSwan project" rather than "Linux strongSwan" to better reflect this.