### PR TITLE
Uses refactored packet filtering code to implement the DHCP plugin on FreeBSD & macOS

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1853,6 +1853,7 @@ AM_CONDITIONAL(USE_ATTR, test x$attr = xtrue)
 AM_CONDITIONAL(USE_ATTR_SQL, test x$attr_sql = xtrue)
 AM_CONDITIONAL(USE_COUNTERS, test x$counters = xtrue)
 AM_CONDITIONAL(USE_SELINUX, test x$selinux = xtrue)
+AM_CONDITIONAL(USE_PF_HANDLER, test x$dhcp = xtrue -o x$farp = xtrue )
 
 #  other options
 # ---------------

--- a/src/libcharon/Makefile.am
+++ b/src/libcharon/Makefile.am
@@ -147,6 +147,14 @@ if USE_SYSLOG
     bus/listeners/sys_logger.c bus/listeners/sys_logger.h
 endif
 
+if USE_PF_HANDLER
+  libcharon_la_SOURCES += \
+    pf_handler.c pf_handler.h
+
+pf_handler.lo : $(top_builddir)/config.status
+
+endif
+
 daemon.lo :		$(top_builddir)/config.status
 
 AM_CPPFLAGS = \

--- a/src/libcharon/pf_handler.c
+++ b/src/libcharon/pf_handler.c
@@ -1,0 +1,621 @@
+/*
+ * Copyright (C) 2021 Tobias Brunner
+ * Copyright (C) 2010 Martin Willi
+ *
+ * Copyright (C) secunet Security Networks AG
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation; either version 2 of the License, or (at your
+ * option) any later version.  See <http://www.fsf.org/copyleft/gpl.txt>.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * for more details.
+ */
+
+/*
+ * For the Apple BPF implementation and refactoring packet handling.
+ *
+ * Copyright (C) 2020 Dan James <sddj@me.com>
+ * Copyright (C) 2023 Dan James <sddj@me.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#include "pf_handler.h"
+
+#include <library.h>
+#include <unistd.h>
+
+#if !defined(__APPLE__) && !defined(__FreeBSD__)
+#include <linux/if_arp.h>
+#include <linux/if_ether.h>
+#include <linux/filter.h>
+#include <threading/rwlock.h>
+#else
+#include <fcntl.h>
+#include <ifaddrs.h>
+#include <net/bpf.h>
+#include <net/if.h>
+#include <net/if_dl.h>
+#endif /* !defined(__APPLE__) && !defined(__FreeBSD__) */
+
+#include <errno.h>
+#include <net/ethernet.h>
+#include <sys/ioctl.h>
+
+#if !defined(__APPLE__) && !defined(__FreeBSD__)
+
+struct pf_socket_t {
+    /**
+     * index of the interface
+     */
+    int if_index;
+    /**
+     * name of the interface
+     */
+    char if_name[IFNAMSIZ];
+    /**
+     * hardware (mac) address of the interface
+     */
+     u_char hwaddr[ETHER_ADDR_LEN];
+     /**
+      * chunk for the hardware (mac) address of the interface
+      */
+    chunk_t mac;
+    /**
+     * count of the times this info is used, for lru cache
+     */
+    int used;
+};
+typedef struct pf_socket_t pf_socket_t;
+
+struct pf_sockets_t {
+    /**
+     * count of entries in use
+     */
+    int count;
+    /**
+     * fixed sized array of recently used interface information
+     */
+    pf_socket_t entries[8];
+};
+typedef struct pf_sockets_t pf_sockets_t;
+
+#endif /* !defined(__APPLE__) && !defined(__FreeBSD__) */
+
+typedef struct private_pf_handler_t private_pf_handler_t;
+
+struct private_pf_handler_t {
+    pf_handler_t public;
+    const char* name;
+    void *packet_this;
+    pf_packet_handler_t packet_handler;
+#if !defined(__APPLE__) && !defined(__FreeBSD__)
+    /**
+     * receive socket
+     */
+    int receive;
+    /**
+     * cache of recently used socket info
+     */
+    pf_sockets_t pf_sockets;
+    /**
+     * RWlock for socket slots
+     */
+    rwlock_t *lock;
+#else
+    /**
+     * receive socket handlers -- freebsd & macos need to open multiple sockets
+     */
+    linked_list_t *pf_filter_handlers;
+#endif /* !defined(__APPLE__) && !defined(__FreeBSD__) */
+};
+
+#if !defined(__APPLE__) && !defined(__FreeBSD__)
+
+/**
+ * @param this pf_sockets_t *
+ * @return the slot in the array of entries to use for this request
+ */
+static int find_least_used_socket_entry(pf_sockets_t *this) {
+    int i, idx, least_used, max = sizeof(this->entries) / sizeof(pf_socket_t);
+
+    if (this->count + 1 < max) {
+        /* not all slots used, choose the next unused slot */
+        idx = ++this->count;
+    } else {
+        least_used = 0;
+        idx = 0;
+
+        /* all slots in use, choose the one with the lowest usage */
+        for (i = 0; i < max; i++) {
+            if (this->entries[i].used < least_used) {
+                idx = i;
+                least_used = this->entries[i].used;
+            }
+        }
+    }
+
+    return idx;
+}
+
+static pf_socket_t *find_socket(private_pf_handler_t *this, int fd,
+                                struct sockaddr_ll *addr) {
+    int idx;
+    struct ifreq req;
+    char if_name[IFNAMSIZ];
+    pf_socket_t *entries = this->pf_sockets.entries;
+
+    this->lock->read_lock(this->lock);
+    for (idx = 0; idx < this->pf_sockets.count; idx++) {
+        if (entries[idx].if_index == addr->sll_ifindex) {
+            entries[idx].used++;
+            this->lock->unlock(this->lock);
+            return &entries[idx];
+        }
+    }
+    this->lock->unlock(this->lock);
+
+    req.ifr_ifindex = addr->sll_ifindex;
+    if (ioctl(fd, SIOCGIFNAME, &req) == 0) {
+        memcpy(if_name, req.ifr_name, IFNAMSIZ);
+        if (ioctl(fd, SIOCGIFHWADDR, &req) == 0 &&
+            req.ifr_hwaddr.sa_family == ARPHRD_ETHER) {
+            this->lock->write_lock(this->lock);
+            idx = find_least_used_socket_entry(&this->pf_sockets);
+            entries[idx].if_index = addr->sll_ifindex;
+            memcpy(entries[idx].if_name, req.ifr_name, IFNAMSIZ);
+            memcpy(entries[idx].hwaddr, req.ifr_hwaddr.sa_data, ETHER_ADDR_LEN);
+            entries[idx].mac = chunk_create(entries[idx].hwaddr, ETHER_ADDR_LEN);
+            entries[idx].used = 1;
+            this->lock->unlock(this->lock);
+            return &entries[idx];
+        } else {
+            DBG1(DBG_NET, "find_socket(SIOCGIFHWADDR) failed: %s", strerror(errno));
+        }
+    } else {
+        DBG1(DBG_NET, "find_socket(SIOCGIFNAME) failed: %s", strerror(errno));
+    }
+
+    return NULL;
+}
+
+/**
+ * Receive responses
+ */
+CALLBACK(receive_packet, bool,
+         private_pf_handler_t *this, int fd, watcher_event_t event)
+{
+	struct sockaddr_ll addr;
+	socklen_t addr_len = sizeof(addr);
+	u_int8_t packet[1500];
+	size_t len = recvfrom(fd, &packet, sizeof(packet), MSG_DONTWAIT,
+                          (struct sockaddr*)&addr, &addr_len);
+    pf_socket_t *entry = find_socket(this, fd, &addr);
+    if (entry) {
+        this->packet_handler(this->packet_this, entry->if_name, entry->if_index,
+                             &entry->mac, fd, &packet, len);
+    } else {
+        DBG1(DBG_NET, "receive_packet: no socket entry found");
+    }
+
+	return TRUE;
+}
+
+METHOD(pf_handler_t, destroy, void, private_pf_handler_t *this) {
+    if (this->receive > 0)
+    {
+        lib->watcher->remove(lib->watcher, this->receive);
+        close(this->receive);
+        this->receive = 0;
+        this->lock->destroy(this->lock);
+    }
+}
+
+static bool setup_filter_handlers(private_pf_handler_t *this, char *iface,
+                                  struct sock_fprog *packet_filter)
+{
+    int protocol = strcmp(this->name, "ARP") ? ETH_P_IP : ETH_P_ARP;
+	this->receive = socket(AF_PACKET, SOCK_DGRAM, htons(protocol));
+	if (this->receive == -1)
+	{
+		DBG1(DBG_NET, "opening receive socket failed: %s", strerror(errno));
+		return FALSE;
+	}
+	if (setsockopt(this->receive, SOL_SOCKET, SO_ATTACH_FILTER, packet_filter,
+                   sizeof(struct sock_fprog)) < 0)
+	{
+		DBG1(DBG_NET, "installing socket filter failed: %s", strerror(errno));
+		return FALSE;
+	}
+	if (iface && !bind_to_device(this->receive, iface)) {
+        return FALSE;
+	}
+	lib->watcher->add(lib->watcher, this->receive, WATCHER_READ,
+                      (watcher_cb_t)receive_packet, this);
+    DBG1(DBG_NET, "listening for %s(protocol=0x%04x) requests on fd=%d",
+         this->name, protocol, this->receive);
+    this->pf_sockets.count = 0;
+    this->lock = rwlock_create(RWLOCK_TYPE_DEFAULT);
+    return TRUE;
+}
+
+/**
+ * Bind a socket to a particular interface name
+ */
+bool bind_to_device(int fd, char *iface)
+{
+    int status;
+    struct ifreq ifreq = {};
+
+    if (strlen(iface) > sizeof(ifreq.ifr_name))
+    {
+        DBG1(DBG_CFG, "name for DHCP interface too long: '%s'", iface);
+        return FALSE;
+    }
+    memcpy(ifreq.ifr_name, iface, sizeof(ifreq.ifr_name));
+    status = setsockopt(fd, SOL_SOCKET, SO_BINDTODEVICE, &ifreq, sizeof(ifreq));
+    if (status)
+    {
+        DBG1(DBG_CFG, "binding DHCP socket to '%s' failed: %s",
+             iface, strerror(errno));
+        return FALSE;
+    }
+    return TRUE;
+}
+
+#else
+
+/**
+ * A handler is required for each interface.
+ */
+struct pf_socket_t {
+    /**
+     * Reference to the private packet filter handler.
+     */
+    private_pf_handler_t *this;
+
+    /**
+     * The name of the interface to be handled.
+     */
+    char *name;
+
+    /**
+     * index of the interface
+     */
+    int if_index;
+
+    /**
+     * The Ethernet MAC address of this interface.
+     */
+    chunk_t mac;
+
+    /**
+     * The IPv4 address of this interface.
+     */
+    host_t *ipv4;
+
+    /**
+     * The BPF file descriptor for this interface.
+     */
+    int fd;
+
+    /**
+     * The BPF packet buffer length as read from the BPF fd.
+     */
+    size_t buflen;
+
+    /**
+     * An allocated buffer for receiving packets from BPF.
+     */
+    uint8_t *bufdat;
+};
+
+typedef struct pf_socket_t pf_socket_t;
+
+/**
+ * Free resources used by a handler.
+ */
+static void destroy_filter_handler(pf_socket_t *handler) {
+    if (handler->fd >= 0) {
+        lib->watcher->remove(lib->watcher, handler->fd);
+        close(handler->fd);
+    }
+    DESTROY_IF(handler->ipv4);
+    chunk_free(&handler->mac);
+    free(handler->bufdat);
+    free(handler->name);
+    free(handler);
+}
+
+static void destroy_filter_handlers(private_pf_handler_t *this) {
+    enumerator_t *enumerator;
+    pf_socket_t *handler;
+
+    if (this->pf_filter_handlers != NULL) {
+        enumerator = this->pf_filter_handlers->create_enumerator(this->pf_filter_handlers);
+        while (enumerator->enumerate(enumerator, &handler)) {
+            destroy_filter_handler(handler);
+        }
+        enumerator->destroy(enumerator);
+        this->pf_filter_handlers->destroy(this->pf_filter_handlers);
+        this->pf_filter_handlers = NULL;
+    }
+}
+
+/**
+ * Find the handler for the named interface, creating one if needed.
+ */
+static pf_socket_t *get_handler(private_pf_handler_t *this, char *interface_name) {
+    pf_socket_t *handler, *found = NULL;
+    enumerator_t *enumerator;
+
+    enumerator =
+        this->pf_filter_handlers->create_enumerator(this->pf_filter_handlers);
+    while (enumerator->enumerate(enumerator, &handler)) {
+        if (streq(handler->name, interface_name)) {
+            found = handler;
+            break;
+        }
+    }
+    enumerator->destroy(enumerator);
+
+    if (!found) {
+        INIT(found,
+             .this = this,
+             .name = strdup(interface_name),
+             .fd = -1,
+        );
+        this->pf_filter_handlers->insert_last(this->pf_filter_handlers, found);
+    }
+    return found;
+}
+
+/**
+ * Find and open an available BPF device.
+ */
+static int bpf_open() {
+    static int no_cloning_bpf = 0;
+    /* enough space for: /dev/bpf000\0 */
+    char device[12];
+    int n = no_cloning_bpf ? 0 : -1;
+    int fd;
+
+    do {
+        if (n < 0) {
+            snprintf(device, sizeof(device), "/dev/bpf");
+        } else {
+            snprintf(device, sizeof(device), "/dev/bpf%d", n);
+        }
+
+        fd = open(device, O_RDWR);
+
+        if (n++ < 0 && fd < 0 && errno == ENOENT) {
+            no_cloning_bpf = 1;
+            errno = EBUSY;
+        }
+    } while (fd < 0 && errno == EBUSY && n < 1000);
+
+    return fd;
+}
+
+/**
+ * Receive and examine the available packets. Hand them off to the registered handler.
+ */
+CALLBACK(handler_onpkt, bool, pf_socket_t *handler, int fd, watcher_event_t event) {
+    struct bpf_hdr *bh;
+    void *a;
+    uint8_t *p = handler->bufdat;
+    ssize_t n;
+    size_t pktlen;
+
+    n = read(handler->fd, handler->bufdat, handler->buflen);
+    if (n <= 0) {
+        DBG1(DBG_NET, "reading %s request from %s failed: %s",
+             handler->this->name, handler->name, strerror(errno));
+        return FALSE;
+    }
+
+    while (p < handler->bufdat + n) {
+        bh = (struct bpf_hdr *) p;
+        a = (void *) (p + bh->bh_hdrlen + sizeof(struct ether_header));
+        pktlen = bh->bh_caplen - sizeof(struct ether_header);
+        handler->this->packet_handler(handler->this->packet_this, handler->name,
+                                      handler->if_index, &handler->mac, handler->fd,
+                                      a, pktlen);
+        p += bh->bh_hdrlen + bh->bh_caplen;
+    }
+    return TRUE;
+}
+
+static int should_listen_to_handler(pf_socket_t *handler, char *iface) {
+    return handler->mac.ptr && handler->ipv4 &&
+        (iface == NULL || strcmp(handler->name, iface) == 0);
+}
+
+/**
+ * Create an initialize a BPF handler for the interface specified in the farp
+ * handler. This entails opening a BPF device, binding it to the interface,
+ * setting the packet filter, and allocating a buffer for receiving packets.
+ */
+static bool setup_handler(pf_socket_t *handler, pf_program_t *program) {
+    struct ifreq req;
+    uint32_t disable = 1;
+    uint32_t enable = 1;
+    uint32_t dlt = 0;
+
+    snprintf(req.ifr_name, sizeof(req.ifr_name), "%s", handler->name);
+
+    if ((handler->fd = bpf_open()) < 0) {
+        DBG1(DBG_NET, "bpf_open(%s): %s", handler->name, strerror(errno));
+        return FALSE;
+    }
+
+    if (ioctl(handler->fd, BIOCSETIF, &req) < 0) {
+        DBG1(DBG_NET, "BIOCSETIF(%s): %s", handler->name, strerror(errno));
+        return FALSE;
+    }
+
+    if (ioctl(handler->fd, BIOCSHDRCMPLT, &enable) < 0) {
+        DBG1(DBG_NET, "BIOCSHDRCMPLT(%s): %s", handler->name, strerror(errno));
+        return FALSE;
+    }
+
+    if (ioctl(handler->fd, BIOCSSEESENT, &disable) < 0) {
+        DBG1(DBG_NET, "BIOCSSEESENT(%s): %s", handler->name, strerror(errno));
+        return FALSE;
+    }
+
+    if (ioctl(handler->fd, BIOCIMMEDIATE, &enable) < 0) {
+        DBG1(DBG_NET, "BIOCIMMEDIATE(%s): %s", handler->name, strerror(errno));
+        return FALSE;
+    }
+
+    if (ioctl(handler->fd, BIOCGDLT, &dlt) < 0) {
+        DBG1(DBG_NET, "BIOCGDLT(%s): %s", handler->name, strerror(errno));
+        return FALSE;
+    } else if (dlt != DLT_EN10MB) {
+        return FALSE;
+    }
+
+    if (ioctl(handler->fd, BIOCSETF, program) < 0) {
+        DBG1(DBG_NET, "BIOCSETF(%s): %s", handler->name, strerror(errno));
+        return FALSE;
+    }
+
+    if (ioctl(handler->fd, BIOCGBLEN, &handler->buflen) < 0) {
+        DBG1(DBG_NET, "BIOCGBLEN(%s): %s", handler->name, strerror(errno));
+        return FALSE;
+    }
+    handler->bufdat = malloc(handler->buflen);
+
+    lib->watcher->add(lib->watcher, handler->fd, WATCHER_READ,
+                      handler_onpkt, handler);
+    return TRUE;
+}
+
+static bool setup_filter_handlers(private_pf_handler_t *this, char *iface,
+                                  pf_program_t *program) {
+    struct ifaddrs *ifas;
+    struct ifaddrs *ifa;
+    struct sockaddr_dl *dl;
+    pf_socket_t * handler;
+    enumerator_t *enumerator;
+    host_t *ipv4;
+
+    this->pf_filter_handlers = linked_list_create();
+    if (this->pf_filter_handlers == NULL) {
+        DBG1(DBG_NET, "%s cannot create a linked list", this->name);
+        return FALSE;
+    }
+    if (getifaddrs(&ifas) < 0) {
+        DBG1(DBG_NET, "%s cannot find interfaces: %s", this->name, strerror(errno));
+        return FALSE;
+    }
+    for (ifa = ifas; ifa != NULL; ifa = ifa->ifa_next) {
+        switch (ifa->ifa_addr->sa_family) {
+            case AF_LINK:
+                dl = (struct sockaddr_dl *) ifa->ifa_addr;
+                if (dl->sdl_alen == ETHER_ADDR_LEN) {
+                    handler = get_handler(this, ifa->ifa_name);
+                    handler->mac = chunk_clone(chunk_create(LLADDR(dl), dl->sdl_alen));
+                    handler->if_index = dl->sdl_index;
+                }
+                break;
+            case AF_INET:
+                ipv4 = host_create_from_sockaddr(ifa->ifa_addr);
+                if (ipv4 && !ipv4->is_anyaddr(ipv4)) {
+                    handler = get_handler(this, ifa->ifa_name);
+                    if (!handler->ipv4) {
+                        handler->ipv4 = ipv4->clone(ipv4);
+                    }
+                }
+                DESTROY_IF(ipv4);
+                break;
+            default:
+                break;
+        }
+    }
+    freeifaddrs(ifas);
+
+    enumerator = this->pf_filter_handlers->create_enumerator(this->pf_filter_handlers);
+    while (enumerator->enumerate(enumerator, &handler)) {
+        if (should_listen_to_handler(handler, iface) &&
+            setup_handler(handler, program)) {
+            DBG1(DBG_NET, "listening for %s requests on %s (%H, %#B)",
+                 this->name, handler->name, handler->ipv4, &handler->mac);
+        } else {
+            this->pf_filter_handlers->remove_at(this->pf_filter_handlers, enumerator);
+            destroy_filter_handler(handler);
+        }
+    }
+    enumerator->destroy(enumerator);
+
+    return this->pf_filter_handlers->get_count(this->pf_filter_handlers) > 0;
+}
+
+METHOD(pf_handler_t, destroy, void, private_pf_handler_t *this) {
+    destroy_filter_handlers(this);
+    free(this);
+}
+
+/**
+ * Bind a socket to a particular interface name
+ */
+bool bind_to_device(int fd, char *iface)
+{
+#if defined(__FreeBSD__)
+    DBG1(DBG_CFG, "binding DHCP socket to '%s' failed: IP_SENDIF not implemented yet.", iface);
+    return FALSE;
+#else /* defined(__FreeBSD__) */
+    unsigned int idx = if_nametoindex(iface);
+    int status = setsockopt(fd, IPPROTO_IP, IP_BOUND_IF, &idx, sizeof(idx));
+    if (status)
+    {
+        DBG1(DBG_CFG, "binding DHCP socket to '%s' failed: %s",
+             iface, strerror(errno));
+        return FALSE;
+    }
+    return TRUE;
+#endif /* defined(__FreeBSD__) */
+}
+
+#endif /* !defined(__APPLE__) && !defined(__FreeBSD__) */
+
+pf_handler_t *pf_handler_create(void *packet_this, const char* name, char *iface,
+                                pf_packet_handler_t packet_handler,
+                                pf_program_t *program) {
+    private_pf_handler_t *this;
+    INIT(this,
+         .public = {
+            .destroy = _destroy,
+         },
+         .name = name,
+         .packet_this = packet_this,
+         .packet_handler = packet_handler,
+    );
+    if (!setup_filter_handlers(this, iface, program)) {
+        destroy(this);
+        return NULL;
+    }
+    return &this->public;
+}

--- a/src/libcharon/pf_handler.h
+++ b/src/libcharon/pf_handler.h
@@ -1,0 +1,81 @@
+/*
+ * Copyright (C) 2010 Martin Willi
+ *
+ * Copyright (C) secunet Security Networks AG
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation; either version 2 of the License, or (at your
+ * option) any later version.  See <http://www.fsf.org/copyleft/gpl.txt>.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * for more details.
+ */
+
+/*
+ * For the Apple BPF implementation and refactoring packet handling.
+ *
+ * Copyright (C) 2020 Dan James <sddj@me.com>
+ * Copyright (C) 2023 Dan James <sddj@me.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#ifndef PF_HANDLER_H_
+#define PF_HANDLER_H_
+
+#include <sys/types.h>
+#include <utils/chunk.h>
+
+typedef struct pf_handler_t pf_handler_t;
+
+/**
+ * bpf implementation for freebsd / macos
+ */
+struct pf_handler_t {
+	/**
+	 * Destroy a pf_handlers_t.
+	 */
+	void (*destroy)(pf_handler_t *this);
+};
+
+typedef void (*pf_packet_handler_t)(void *this, char* if_name, int if_index,
+        chunk_t *mac, int fd, void *packet, size_t packet_length);
+
+#if !defined(__APPLE__) && !defined(__FreeBSD__)
+typedef struct sock_fprog pf_program_t;
+#else
+typedef struct bpf_program pf_program_t;
+#endif /* !defined(__APPLE__) && !defined(__FreeBSD__) */
+
+/**
+ * Create a pf_handler_t instance.
+ */
+pf_handler_t *pf_handler_create(void *packet_this, const char *name, char *iface,
+                                pf_packet_handler_t packet_handler,
+                                pf_program_t *program);
+
+/**
+ * Bind a socket to a particular interface name
+ */
+bool bind_to_device(int fd, char *iface);
+
+#endif /** PF_HANDLER_H_ */

--- a/src/libcharon/plugins/dhcp/dhcp_socket.c
+++ b/src/libcharon/plugins/dhcp/dhcp_socket.c
@@ -15,17 +15,48 @@
  * for more details.
  */
 
+/*
+ * For the Apple BPF implementation and refactoring packet handling.
+ *
+ * Copyright (C) 2023 Dan James <sddj@me.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
 #include "dhcp_socket.h"
 
 #include <unistd.h>
 #include <errno.h>
-#include <string.h>
 #include <netinet/in.h>
 #include <netinet/ip.h>
 #include <netinet/udp.h>
+
+#if !defined(__APPLE__) && !defined(__FreeBSD__)
+#include <string.h>
 #include <linux/if_arp.h>
-#include <linux/if_ether.h>
 #include <linux/filter.h>
+#else
+#include <net/bpf.h>
+#include <net/ethernet.h>
+#include <net/if.h>
+#include <net/if_arp.h>
+#endif /* !defined(__APPLE__) && !defined(__FreeBSD__) */
 
 #include <collections/linked_list.h>
 #include <utils/identification.h>
@@ -34,6 +65,7 @@
 #include <threading/thread.h>
 
 #include <daemon.h>
+#include <pf_handler.h>
 #include <processing/jobs/callback_job.h>
 
 #define DHCP_SERVER_PORT 67
@@ -93,9 +125,9 @@ struct private_dhcp_socket_t {
 	int send;
 
 	/**
-	 * DHCP receive socket
+	 * DHCP receive handler
 	 */
-	int receive;
+	pf_handler_t *pf_handler;
 
 	/**
 	 * Do we use per-identity or random leases (and MAC addresses)
@@ -178,7 +210,7 @@ typedef struct __attribute__((packed)) {
 	uint32_t your_address;
 	uint32_t server_address;
 	uint32_t gateway_address;
-	char client_hw_addr[6];
+	uint8_t client_hw_addr[6];
 	char client_hw_padding[10];
 	char server_hostname[64];
 	char boot_filename[128];
@@ -199,14 +231,15 @@ static inline bool is_broadcast(host_t *host)
 /**
  * Prepare a DHCP message for a given transaction
  */
-static int prepare_dhcp(private_dhcp_socket_t *this,
+static size_t prepare_dhcp(private_dhcp_socket_t *this,
 						dhcp_transaction_t *transaction,
 						dhcp_message_type_t type, dhcp_t *dhcp)
 {
 	chunk_t chunk;
 	identification_t *identity;
 	dhcp_option_t *option;
-	int optlen = 0, remaining;
+	size_t optlen = 0;
+	size_t remaining;
 	uint32_t id;
 
 	memset(dhcp, 0, sizeof(*dhcp));
@@ -281,7 +314,7 @@ static int prepare_dhcp(private_dhcp_socket_t *this,
  * Send a DHCP message with given options length
  */
 static bool send_dhcp(private_dhcp_socket_t *this,
-					  dhcp_transaction_t *transaction, dhcp_t *dhcp, int optlen)
+					  dhcp_transaction_t *transaction, dhcp_t *dhcp, size_t optlen)
 {
 	host_t *dst;
 	ssize_t len;
@@ -304,7 +337,7 @@ static bool discover(private_dhcp_socket_t *this,
 {
 	dhcp_option_t *option;
 	dhcp_t dhcp;
-	int optlen;
+	size_t optlen;
 
 	optlen = prepare_dhcp(this, transaction, DHCP_DISCOVER, &dhcp);
 
@@ -340,7 +373,7 @@ static bool request(private_dhcp_socket_t *this,
 	dhcp_t dhcp;
 	host_t *offer, *server;
 	chunk_t chunk;
-	int optlen;
+	size_t optlen;
 
 	optlen = prepare_dhcp(this, transaction, DHCP_REQUEST, &dhcp);
 
@@ -483,7 +516,7 @@ METHOD(dhcp_socket_t, release, void,
 	dhcp_t dhcp;
 	host_t *release, *server;
 	chunk_t chunk;
-	int optlen;
+	size_t optlen;
 
 	optlen = prepare_dhcp(this, transaction, DHCP_RELEASE, &dhcp);
 
@@ -517,7 +550,7 @@ METHOD(dhcp_socket_t, release, void,
 /**
  * Handle a DHCP OFFER
  */
-static void handle_offer(private_dhcp_socket_t *this, dhcp_t *dhcp, int optlen)
+static void handle_offer(private_dhcp_socket_t *this, dhcp_t *dhcp, size_t optlen)
 {
 	dhcp_transaction_t *transaction = NULL;
 	enumerator_t *enumerator;
@@ -551,7 +584,7 @@ static void handle_offer(private_dhcp_socket_t *this, dhcp_t *dhcp, int optlen)
 
 	if (transaction)
 	{
-		int optsize, optpos = 0, pos;
+		size_t optsize, optpos = 0, pos;
 		dhcp_option_t *option;
 
 		while (optlen > sizeof(dhcp_option_t))
@@ -596,7 +629,7 @@ static void handle_offer(private_dhcp_socket_t *this, dhcp_t *dhcp, int optlen)
 /**
  * Handle a DHCP ACK
  */
-static void handle_ack(private_dhcp_socket_t *this, dhcp_t *dhcp, int optlen)
+static void handle_ack(private_dhcp_socket_t *this, dhcp_t *dhcp)
 {
 	dhcp_transaction_t *transaction;
 	enumerator_t *enumerator;
@@ -617,34 +650,30 @@ static void handle_ack(private_dhcp_socket_t *this, dhcp_t *dhcp, int optlen)
 	this->condvar->broadcast(this->condvar);
 }
 
+struct __attribute__((packed)) dhcp_packet_t {
+	struct ip ip;
+	struct udphdr udp;
+	dhcp_t dhcp;
+};
+typedef struct dhcp_packet_t dhcp_packet_t;
+
 /**
  * Receive DHCP responses
  */
-static bool receive_dhcp(private_dhcp_socket_t *this, int fd,
-						 watcher_event_t event)
-{
-	struct sockaddr_ll addr;
-	socklen_t addr_len = sizeof(addr);
-	struct __attribute__((packed)) {
-		struct iphdr ip;
-		struct udphdr udp;
-		dhcp_t dhcp;
-	} packet;
-	int optlen, origoptlen, optsize, optpos = 0;
-	ssize_t len;
+static void receive_dhcp(void *this, char *if_name, int if_index, chunk_t *mac,
+						 int _fd, void *_packet, size_t len) {
+	dhcp_packet_t *packet = (dhcp_packet_t*)_packet;
+	size_t optlen, origoptlen, optpos = 0, optsize;
 	dhcp_option_t *option;
 
-	len = recvfrom(fd, &packet, sizeof(packet), MSG_DONTWAIT,
-					(struct sockaddr*)&addr, &addr_len);
-
-	if (len >= sizeof(struct iphdr) + sizeof(struct udphdr) +
+	if (len >= sizeof(struct ip) + sizeof(struct udphdr) +
 		offsetof(dhcp_t, options))
 	{
-		origoptlen = optlen = len - sizeof(struct iphdr) +
+		origoptlen = optlen = len - sizeof(struct ip) +
 					 sizeof(struct udphdr) + offsetof(dhcp_t, options);
 		while (optlen > sizeof(dhcp_option_t))
 		{
-			option = (dhcp_option_t*)&packet.dhcp.options[optpos];
+			option = (dhcp_option_t*)&packet->dhcp.options[optpos];
 			optsize = sizeof(dhcp_option_t) + option->len;
 			if (option->type == DHCP_OPTEND || optlen < optsize)
 			{
@@ -655,10 +684,10 @@ static bool receive_dhcp(private_dhcp_socket_t *this, int fd,
 				switch (option->data[0])
 				{
 					case DHCP_OFFER:
-						handle_offer(this, &packet.dhcp, origoptlen);
+						handle_offer(this, &packet->dhcp, origoptlen);
 						break;
 					case DHCP_ACK:
-						handle_ack(this, &packet.dhcp, origoptlen);
+						handle_ack(this, &packet->dhcp);
 					default:
 						break;
 				}
@@ -668,7 +697,6 @@ static bool receive_dhcp(private_dhcp_socket_t *this, int fd,
 			optpos += optsize;
 		}
 	}
-	return TRUE;
 }
 
 METHOD(dhcp_socket_t, destroy, void,
@@ -682,11 +710,6 @@ METHOD(dhcp_socket_t, destroy, void,
 	{
 		close(this->send);
 	}
-	if (this->receive > 0)
-	{
-		lib->watcher->remove(lib->watcher, this->receive);
-		close(this->receive);
-	}
 	this->mutex->destroy(this->mutex);
 	this->condvar->destroy(this->condvar);
 	this->discover->destroy_offset(this->discover,
@@ -695,31 +718,10 @@ METHOD(dhcp_socket_t, destroy, void,
 								offsetof(dhcp_transaction_t, destroy));
 	this->completed->destroy_offset(this->completed,
 								offsetof(dhcp_transaction_t, destroy));
+	DESTROY_IF(this->pf_handler);
 	DESTROY_IF(this->rng);
 	DESTROY_IF(this->dst);
 	free(this);
-}
-
-/**
- * Bind a socket to a particular interface name
- */
-static bool bind_to_device(int fd, char *iface)
-{
-	struct ifreq ifreq = {};
-
-	if (strlen(iface) > sizeof(ifreq.ifr_name))
-	{
-		DBG1(DBG_CFG, "name for DHCP interface too long: '%s'", iface);
-		return FALSE;
-	}
-	memcpy(ifreq.ifr_name, iface, sizeof(ifreq.ifr_name));
-	if (setsockopt(fd, SOL_SOCKET, SO_BINDTODEVICE, &ifreq, sizeof(ifreq)))
-	{
-		DBG1(DBG_CFG, "binding DHCP socket to '%s' failed: %s",
-			 iface, strerror(errno));
-		return FALSE;
-	}
-	return TRUE;
 }
 
 /**
@@ -737,30 +739,27 @@ dhcp_socket_t *dhcp_socket_create()
 	};
 	socklen_t addr_len;
 	char *iface;
-	int on = 1, rcvbuf = 0;
+	int on = 1;
+#if !defined(__APPLE__) && !defined(__FreeBSD__)
+	int rcvbuf = 0;
+	const size_t skip_ip4 = sizeof(struct iphdr);
+	const size_t skip_udp = skip_ip4 + sizeof(struct udphdr);
 	struct sock_filter dhcp_filter_code[] = {
-		BPF_STMT(BPF_LD+BPF_B+BPF_ABS,
-				 offsetof(struct iphdr, protocol)),
+		BPF_STMT(BPF_LD+BPF_B+BPF_ABS, offsetof(struct iphdr, protocol)),
 		BPF_JUMP(BPF_JMP+BPF_JEQ+BPF_K, IPPROTO_UDP, 0, 16),
-		BPF_STMT(BPF_LD+BPF_H+BPF_ABS, sizeof(struct iphdr) +
-				 offsetof(struct udphdr, source)),
+		BPF_STMT(BPF_LD+BPF_H+BPF_ABS, skip_ip4 + offsetof(struct udphdr, source)),
 		BPF_JUMP(BPF_JMP+BPF_JEQ+BPF_K, DHCP_SERVER_PORT, 0, 14),
-		BPF_STMT(BPF_LD+BPF_H+BPF_ABS, sizeof(struct iphdr) +
-				 offsetof(struct udphdr, dest)),
+		BPF_STMT(BPF_LD+BPF_H+BPF_ABS, skip_ip4 + offsetof(struct udphdr, dest)),
 		BPF_JUMP(BPF_JMP+BPF_JEQ+BPF_K, DHCP_CLIENT_PORT, 2, 0),
 		BPF_JUMP(BPF_JMP+BPF_JEQ+BPF_K, DHCP_SERVER_PORT, 1, 0),
 		BPF_JUMP(BPF_JMP+BPF_JA, 10, 0, 0),
-		BPF_STMT(BPF_LD+BPF_B+BPF_ABS, sizeof(struct iphdr) +
-				 sizeof(struct udphdr) + offsetof(dhcp_t, opcode)),
+		BPF_STMT(BPF_LD+BPF_B+BPF_ABS, skip_udp + offsetof(dhcp_t, opcode)),
 		BPF_JUMP(BPF_JMP+BPF_JEQ+BPF_K, BOOTREPLY, 0, 8),
-		BPF_STMT(BPF_LD+BPF_B+BPF_ABS, sizeof(struct iphdr) +
-				 sizeof(struct udphdr) + offsetof(dhcp_t, hw_type)),
+		BPF_STMT(BPF_LD+BPF_B+BPF_ABS, skip_udp + offsetof(dhcp_t, hw_type)),
 		BPF_JUMP(BPF_JMP+BPF_JEQ+BPF_K, ARPHRD_ETHER, 0, 6),
-		BPF_STMT(BPF_LD+BPF_B+BPF_ABS, sizeof(struct iphdr) +
-				 sizeof(struct udphdr) + offsetof(dhcp_t, hw_addr_len)),
+		BPF_STMT(BPF_LD+BPF_B+BPF_ABS, skip_udp + offsetof(dhcp_t, hw_addr_len)),
 		BPF_JUMP(BPF_JMP+BPF_JEQ+BPF_K, 6, 0, 4),
-		BPF_STMT(BPF_LD+BPF_W+BPF_ABS, sizeof(struct iphdr) +
-				 sizeof(struct udphdr) + offsetof(dhcp_t, magic_cookie)),
+		BPF_STMT(BPF_LD+BPF_W+BPF_ABS, skip_udp + offsetof(dhcp_t, magic_cookie)),
 		BPF_JUMP(BPF_JMP+BPF_JEQ+BPF_K, 0x63825363, 0, 2),
 		BPF_STMT(BPF_LD+BPF_W+BPF_LEN, 0),
 		BPF_STMT(BPF_RET+BPF_A, 0),
@@ -770,6 +769,44 @@ dhcp_socket_t *dhcp_socket_create()
 		sizeof(dhcp_filter_code) / sizeof(struct sock_filter),
 		dhcp_filter_code,
 	};
+#else
+	int rcvbuf = 1;
+	const size_t skip_eth = sizeof(struct ether_header);
+	const size_t skip_ip4 = skip_eth + sizeof(struct ip);
+	const size_t skip_udp = skip_ip4 + sizeof(struct udphdr);
+	struct bpf_insn instructions[] = {
+			BPF_STMT(BPF_LD + BPF_B + BPF_ABS, skip_eth +
+					 offsetof(struct ip, ip_p)),
+			BPF_JUMP(BPF_JMP + BPF_JEQ + BPF_K, IPPROTO_UDP, 0, 16),
+			BPF_STMT(BPF_LD + BPF_H + BPF_ABS, skip_ip4 +
+					 offsetof(struct udphdr, uh_sport)),
+			BPF_JUMP(BPF_JMP + BPF_JEQ + BPF_K, DHCP_SERVER_PORT, 0, 14),
+			BPF_STMT(BPF_LD + BPF_H + BPF_ABS, skip_ip4 +
+					 offsetof(struct udphdr, uh_dport)),
+			BPF_JUMP(BPF_JMP + BPF_JEQ + BPF_K, DHCP_CLIENT_PORT, 2, 0),
+			BPF_JUMP(BPF_JMP + BPF_JEQ + BPF_K, DHCP_SERVER_PORT, 1, 0),
+			BPF_JUMP(BPF_JMP + BPF_JA, 10, 0, 0),
+			BPF_STMT(BPF_LD + BPF_B + BPF_ABS, skip_udp +
+					 offsetof(dhcp_t, opcode)),
+			BPF_JUMP(BPF_JMP + BPF_JEQ + BPF_K, BOOTREPLY, 0, 8),
+			BPF_STMT(BPF_LD + BPF_B + BPF_ABS, skip_udp +
+					 offsetof(dhcp_t, hw_type)),
+			BPF_JUMP(BPF_JMP + BPF_JEQ + BPF_K, ARPHRD_ETHER, 0, 6),
+			BPF_STMT(BPF_LD + BPF_B + BPF_ABS, skip_udp +
+					 offsetof(dhcp_t, hw_addr_len)),
+			BPF_JUMP(BPF_JMP + BPF_JEQ + BPF_K, 6, 0, 4),
+			BPF_STMT(BPF_LD + BPF_W + BPF_ABS, skip_udp +
+					 offsetof(dhcp_t, magic_cookie)),
+			BPF_JUMP(BPF_JMP + BPF_JEQ + BPF_K, 0x63825363, 0, 2),
+			BPF_STMT(BPF_LD + BPF_W + BPF_LEN, 0),
+			BPF_STMT(BPF_RET + BPF_A, 0),
+			BPF_STMT(BPF_RET + BPF_K, 0),
+	};
+	struct bpf_program dhcp_filter = {
+			sizeof(instructions) / sizeof(struct bpf_insn),
+			&instructions[0]
+	};
+#endif /* !defined(__APPLE__) && !defined(__FreeBSD__) */
 
 	INIT(this,
 		.public = {
@@ -863,27 +900,15 @@ dhcp_socket_t *dhcp_socket_create()
 		destroy(this);
 		return NULL;
 	}
-
-	this->receive = socket(AF_PACKET, SOCK_DGRAM, htons(ETH_P_IP));
-	if (this->receive == -1)
-	{
-		DBG1(DBG_NET, "opening DHCP receive socket failed: %s", strerror(errno));
-		destroy(this);
-		return NULL;
-	}
-	if (setsockopt(this->receive, SOL_SOCKET, SO_ATTACH_FILTER,
-				   &dhcp_filter, sizeof(dhcp_filter)) < 0)
-	{
-		DBG1(DBG_CFG, "installing DHCP socket filter failed: %s",
-			 strerror(errno));
+	this->pf_handler = pf_handler_create(this, "DHCP", iface,
+										 receive_dhcp, &dhcp_filter);
+	if (!this->pf_handler) {
 		destroy(this);
 		return NULL;
 	}
 	if (iface)
 	{
-		if (!bind_to_device(this->send, iface) ||
-			!bind_to_device(this->receive, iface))
-		{
+		if (!bind_to_device(this->send, iface)) {
 			destroy(this);
 			return NULL;
 		}
@@ -907,9 +932,6 @@ dhcp_socket_t *dhcp_socket_create()
 			return NULL;
 		}
 	}
-
-	lib->watcher->add(lib->watcher, this->receive, WATCHER_READ,
-					  (watcher_cb_t)receive_dhcp, this);
 
 	return &this->public;
 }

--- a/src/libcharon/plugins/farp/farp_spoofer.c
+++ b/src/libcharon/plugins/farp/farp_spoofer.c
@@ -16,9 +16,10 @@
  */
 
 /*
- * For the Apple BPF implementation.
+ * For the Apple BPF implementation and refactoring packet handling.
  *
  * Copyright (C) 2020 Dan James <sddj@me.com>
+ * Copyright (C) 2023 Dan James <sddj@me.com>
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -51,16 +52,14 @@
 #include <linux/if_ether.h>
 #include <linux/filter.h>
 #else
-#include <fcntl.h>
-#include <ifaddrs.h>
 #include <net/bpf.h>
-#include <net/ethernet.h>
-#include <net/if.h>
 #include <net/if_arp.h>
 #include <net/if_dl.h>
 #endif /* !defined(__APPLE__) && !defined(__FreeBSD__) */
 
+#include <net/ethernet.h>
 #include <daemon.h>
+#include <pf_handler.h>
 #include <threading/thread.h>
 #include <processing/jobs/callback_job.h>
 
@@ -81,17 +80,10 @@ struct private_farp_spoofer_t {
 	 */
 	farp_listener_t *listener;
 
-#if !defined(__APPLE__) && !defined(__FreeBSD__)
 	/**
 	 * RAW socket for ARP requests
 	 */
-	int skt;
-#else
-	/**
-	 * Linked list of interface handlers
-	 */
-	linked_list_t *handlers;
-#endif /* !defined(__APPLE__) && !defined(__FreeBSD__) */
+	pf_handler_t *pf_handler;
 };
 
 /**
@@ -103,9 +95,9 @@ typedef struct __attribute__((packed)) {
 	uint8_t hardware_size;
 	uint8_t protocol_size;
 	uint16_t opcode;
-	uint8_t sender_mac[6];
+	uint8_t sender_mac[ETHER_ADDR_LEN];
 	uint8_t sender_ip[4];
-	uint8_t target_mac[6];
+	uint8_t target_mac[ETHER_ADDR_LEN];
 	uint8_t target_ip[4];
 } arp_t;
 
@@ -113,19 +105,19 @@ typedef struct __attribute__((packed)) {
 /**
  * Send faked ARP response
  */
-static void send_arp(private_farp_spoofer_t *this,
-					 arp_t *arp, struct sockaddr_ll *addr)
+static void send_arp(char *if_name, int if_index, chunk_t *mac, int fd,
+					 arp_t *arp, host_t *sender, host_t *target)
 {
-	struct ifreq req;
 	char tmp[4];
+#if DEBUG_LEVEL >= 1
+	chunk_t sender_mac = chunk_create((u_char*)arp->sender_mac, ETHER_ADDR_LEN);
 
-	req.ifr_ifindex = addr->sll_ifindex;
-	if (ioctl(this->skt, SIOCGIFNAME, &req) == 0 &&
-		ioctl(this->skt, SIOCGIFHWADDR, &req) == 0 &&
-		req.ifr_hwaddr.sa_family == ARPHRD_ETHER)
-	{
+	DBG1(DBG_NET, "ARP %H is-at %#B to %H (%#B) on %s",
+		 target, mac, sender, &sender_mac, if_name);
+#endif
+
 		memcpy(arp->target_mac, arp->sender_mac, 6);
-		memcpy(arp->sender_mac, req.ifr_hwaddr.sa_data, 6);
+		memcpy(arp->sender_mac, mac->ptr, 6);
 
 		memcpy(tmp, arp->sender_ip, 4);
 		memcpy(arp->sender_ip, arp->target_ip, 4);
@@ -133,146 +125,28 @@ static void send_arp(private_farp_spoofer_t *this,
 
 		arp->opcode = htons(ARPOP_REPLY);
 
-		sendto(this->skt, arp, sizeof(*arp), 0,
-			   (struct sockaddr*)addr, sizeof(*addr));
-	}
-}
-
-CALLBACK(receive_arp, bool,
-	private_farp_spoofer_t *this, int fd, watcher_event_t event)
-{
-	struct sockaddr_ll addr;
-	socklen_t addr_len = sizeof(addr);
-	arp_t arp;
-	ssize_t len;
-	host_t *local, *remote;
-
-	len = recvfrom(this->skt, &arp, sizeof(arp), MSG_DONTWAIT,
-				   (struct sockaddr*)&addr, &addr_len);
-	if (len == sizeof(arp))
-	{
-		local = host_create_from_chunk(AF_INET,
-									chunk_create((char*)&arp.sender_ip, 4), 0);
-		remote = host_create_from_chunk(AF_INET,
-									chunk_create((char*)&arp.target_ip, 4), 0);
-		if (this->listener->has_tunnel(this->listener, local, remote))
-		{
-			send_arp(this, &arp, &addr);
-		}
-		local->destroy(local);
-		remote->destroy(remote);
-	}
-
-	return TRUE;
-}
-
-METHOD(farp_spoofer_t, destroy, void,
-	private_farp_spoofer_t *this)
-{
-	lib->watcher->remove(lib->watcher, this->skt);
-	close(this->skt);
-	free(this);
-}
-
-/**
- * See header
- */
-farp_spoofer_t *farp_spoofer_create(farp_listener_t *listener)
-{
-	private_farp_spoofer_t *this;
-	struct sock_filter arp_request_filter_code[] = {
-		BPF_STMT(BPF_LD+BPF_H+BPF_ABS, offsetof(arp_t, protocol_type)),
-		BPF_JUMP(BPF_JMP+BPF_JEQ+BPF_K, ETH_P_IP, 0, 9),
-		BPF_STMT(BPF_LD+BPF_B+BPF_ABS, offsetof(arp_t, hardware_size)),
-		BPF_JUMP(BPF_JMP+BPF_JEQ+BPF_K, 6, 0, 7),
-		BPF_STMT(BPF_LD+BPF_B+BPF_ABS, offsetof(arp_t, protocol_size)),
-		BPF_JUMP(BPF_JMP+BPF_JEQ+BPF_K, 4, 0, 5),
-		BPF_STMT(BPF_LD+BPF_H+BPF_ABS, offsetof(arp_t, opcode)),
-		BPF_JUMP(BPF_JMP+BPF_JEQ+BPF_K, ARPOP_REQUEST, 0, 3),
-		BPF_STMT(BPF_LD+BPF_W+BPF_LEN, 0),
-		BPF_JUMP(BPF_JMP+BPF_JGE+BPF_K, sizeof(arp_t), 0, 1),
-		BPF_STMT(BPF_RET+BPF_K, sizeof(arp_t)),
-		BPF_STMT(BPF_RET+BPF_K, 0),
+	struct sockaddr_ll addr = {
+		.sll_family = AF_PACKET,
+		.sll_protocol = htons(ETH_P_ARP),
+		.sll_ifindex = if_index,
+		.sll_hatype = ARPHRD_ETHER,
+		.sll_pkttype = PACKET_OTHERHOST,
+		.sll_halen = ETHER_ADDR_LEN
 	};
-	struct sock_fprog arp_request_filter = {
-		sizeof(arp_request_filter_code) / sizeof(struct sock_filter),
-		arp_request_filter_code,
-	};
+	memcpy(addr.sll_addr, arp->target_mac, ETHER_ADDR_LEN);
 
-	INIT(this,
-		.public = {
-			.destroy = _destroy,
-		},
-		.listener = listener,
-	);
-
-	this->skt = socket(AF_PACKET, SOCK_DGRAM, htons(ETH_P_ARP));
-	if (this->skt == -1)
-	{
-		DBG1(DBG_NET, "opening ARP packet socket failed: %s", strerror(errno));
-		free(this);
-		return NULL;
-	}
-
-	if (setsockopt(this->skt, SOL_SOCKET, SO_ATTACH_FILTER,
-				   &arp_request_filter, sizeof(arp_request_filter)) < 0)
-	{
-		DBG1(DBG_NET, "installing ARP packet filter failed: %s",
+	ssize_t len = sendto(fd, arp, sizeof(*arp), 0,
+						 (const struct sockaddr*)&addr, sizeof(addr));
+	if (len != sizeof(*arp)) {
+		DBG1(DBG_NET, "ARP failed to send response to %H (%#B)"
+			 "[fd=%d buf=%p n=%d addr=%p addr_len=%d]: %s",
+			 target, mac,
+			 fd, arp, sizeof(*arp), &addr, sizeof(addr),
 			 strerror(errno));
-		close(this->skt);
-		free(this);
-		return NULL;
 	}
-
-	lib->watcher->add(lib->watcher, this->skt, WATCHER_READ, receive_arp, this);
-
-	return &this->public;
 }
 
 #else /* !defined(__APPLE__) && !defined(__FreeBSD__) */
-
-/**
- * A handler is required for each interface.
- */
-struct farp_handler_t {
-
-	/**
-	 * Reference to the private farp spoofer.
-	 */
-	private_farp_spoofer_t *this;
-
-	/**
-	 * The name of the interface to be handled.
-	 */
-	char *name;
-
-	/**
-	 * The IPv4 address of this interface.
-	 */
-	host_t *ipv4;
-
-	/**
-	 * The Ethernet MAC address of this interface.
-	 */
-	chunk_t mac;
-
-	/**
-	 * The BPF file descriptor for this interface.
-	 */
-	int fd;
-
-	/**
-	 * The BPF packet buffer length as read from the BPF fd.
-	 */
-	size_t buflen;
-
-	/**
-	 * An allocated buffer for receiving packets from BPF.
-	 */
-	uint8_t *bufdat;
-};
-
-typedef struct farp_handler_t farp_handler_t;
 
 /**
  * An Ethernet frame for an ARP packet.
@@ -285,102 +159,22 @@ struct frame_t {
 typedef struct frame_t frame_t;
 
 /**
- * Find and open an available BPF device.
- */
-static int bpf_open()
-{
-	static int no_cloning_bpf = 0;
-	/* enough space for: /dev/bpf000\0 */
-	char device[12];
-	int n = no_cloning_bpf ? 0 : -1;
-	int fd;
-
-	do
-	{
-		if (n < 0)
-		{
-			snprintf(device, sizeof(device), "/dev/bpf");
-		}
-		else
-		{
-			snprintf(device, sizeof(device), "/dev/bpf%d", n);
-		}
-
-		fd = open(device, O_RDWR);
-
-		if (n++ < 0 && fd < 0 && errno == ENOENT)
-		{
-			no_cloning_bpf = 1;
-			errno = EBUSY;
-		}
-	}
-	while (fd < 0 && errno == EBUSY && n < 1000);
-
-	return fd;
-}
-
-/**
- * Free resources used by a handler.
- */
-static void handler_destroy(farp_handler_t *handler)
-{
-	if (handler->fd >= 0)
-	{
-		lib->watcher->remove(lib->watcher, handler->fd);
-		close(handler->fd);
-	}
-	DESTROY_IF(handler->ipv4);
-	chunk_free(&handler->mac);
-	free(handler->bufdat);
-	free(handler->name);
-	free(handler);
-}
-
-/**
- * Find the handler for the named interface, creating one if needed.
- */
-static farp_handler_t *get_handler(private_farp_spoofer_t* this,
-									char *interface_name)
-{
-	farp_handler_t *handler, *found = NULL;
-	enumerator_t *enumerator;
-
-	enumerator = this->handlers->create_enumerator(this->handlers);
-	while (enumerator->enumerate(enumerator, &handler))
-	{
-		if (streq(handler->name, interface_name))
-		{
-			found = handler;
-			break;
-		}
-	}
-	enumerator->destroy(enumerator);
-
-	if (!found)
-	{
-		INIT(found,
-			.this = this,
-			.name = strdup(interface_name),
-			.fd = -1,
-		);
-		this->handlers->insert_last(this->handlers, found);
-	}
-	return found;
-}
-
-/**
  * Send an ARP response for the given ARP request.
  */
-static void handler_send(farp_handler_t *handler, arp_t *arpreq, host_t *lcl,
-						 host_t *rmt)
+static void send_arp(char *if_name, int if_index, chunk_t *mac, int fd,
+					 const arp_t *arpreq, host_t *sender, host_t *target)
 {
 	frame_t frame;
-	chunk_t mac;
 	ssize_t n;
+#if DEBUG_LEVEL >= 1
+	chunk_t sender_mac = chunk_create((u_char*)arpreq->sender_mac, ETHER_ADDR_LEN);
+
+	DBG1(DBG_NET, "ARP %H is-at %#B to %H (%#B) on %s",
+		 target, mac, sender, &sender_mac, if_name);
+#endif
 
 	memcpy(frame.e.ether_dhost, arpreq->sender_mac, ETHER_ADDR_LEN);
-	mac = chunk_create(frame.e.ether_dhost, ETHER_ADDR_LEN);
-	memcpy(frame.e.ether_shost, handler->mac.ptr, ETHER_ADDR_LEN);
+	memcpy(frame.e.ether_shost, mac->ptr, ETHER_ADDR_LEN);
 	frame.e.ether_type = htons(ETHERTYPE_ARP);
 
 	frame.a.hardware_type = htons(1);
@@ -388,228 +182,47 @@ static void handler_send(farp_handler_t *handler, arp_t *arpreq, host_t *lcl,
 	frame.a.hardware_size = arpreq->hardware_size;
 	frame.a.protocol_size = arpreq->protocol_size;
 	frame.a.opcode = htons(ARPOP_REPLY);
-	memcpy(frame.a.sender_mac, handler->mac.ptr, ETHER_ADDR_LEN);
+	memcpy(frame.a.sender_mac, mac->ptr, ETHER_ADDR_LEN);
 	memcpy(frame.a.sender_ip, arpreq->target_ip, sizeof(arpreq->target_ip));
 	memcpy(frame.a.target_mac, arpreq->sender_mac, sizeof(arpreq->sender_mac));
 	memcpy(frame.a.target_ip, arpreq->sender_ip, sizeof(arpreq->sender_ip));
 
-	DBG2(DBG_NET, "replying to ARP request for %H from %H (%#B) on %s",
-		 rmt, lcl, &mac, handler->name);
-
-	n = write(handler->fd, &frame, sizeof(frame));
+	n = write(fd, &frame, sizeof(frame));
 	if (n != sizeof(frame))
 	{
 		DBG1(DBG_NET, "sending ARP reply failed: %s", strerror(errno));
 	}
 }
 
-/**
- * Receive and examine the available ARP requests. If a tunnel exists, send an
- * ARP response back out the same interface.
- */
-CALLBACK(handler_onarp, bool,
-	farp_handler_t *handler, int fd, watcher_event_t event)
-{
-	struct bpf_hdr *bh;
-	arp_t *a;
-	host_t *lcl, *rmt;
-	uint8_t *p = handler->bufdat;
-	ssize_t n;
+#endif /* !defined(__APPLE__) && !defined(__FreeBSD__) */
 
-	n = read(handler->fd, handler->bufdat, handler->buflen);
-	if (n <= 0)
-	{
-		DBG1(DBG_NET, "reading ARP request from %s failed: %s", handler->name,
-			 strerror(errno));
-		return FALSE;
-	}
+static void handle_arp_pkt(void *_this, char *if_name, int if_index, chunk_t *mac,
+						   int fd, void *_packet, size_t len) {
+	const private_farp_spoofer_t *this = (private_farp_spoofer_t *) _this;
+	arp_t *a = (arp_t *) _packet;
+	host_t *sender;
+	host_t *target;
 
-	while (p < handler->bufdat + n)
-	{
-		bh = (struct bpf_hdr*)p;
-		a = (arp_t*)(p + bh->bh_hdrlen + sizeof(struct ether_header));
-
-		lcl = host_create_from_chunk(AF_INET, chunk_create(a->sender_ip, 4), 0);
-		rmt = host_create_from_chunk(AF_INET, chunk_create(a->target_ip, 4), 0);
-		if (lcl && rmt &&
-			handler->this->listener->has_tunnel(handler->this->listener,
-												lcl, rmt))
-		{
-			handler_send(handler, a, lcl, rmt);
+	if (len == sizeof(arp_t)) {
+		sender = host_create_from_chunk(AF_INET,
+										chunk_create((char*)a->sender_ip, 4), 0);
+		target = host_create_from_chunk(AF_INET,
+										chunk_create((char*)a->target_ip, 4), 0);
+		if (sender && target) {
+			if (this->listener->has_tunnel(this->listener, sender, target)) {
+				send_arp(if_name, if_index, mac, fd, a, sender, target);
+			} else {
+			  DBG2(DBG_NET, "ARP no tunnel between %H <-> %H", target, sender);
+			}
+		} else {
+		  DBG1(DBG_NET, "ARP missing host sender=%s target=%s",
+			   sender ? "t" : "f", target ? "t" : "f");
 		}
-		DESTROY_IF(rmt);
-		DESTROY_IF(lcl);
-
-		p += BPF_WORDALIGN(bh->bh_hdrlen + bh->bh_caplen);
+		DESTROY_IF(target);
+		DESTROY_IF(sender);
+	} else {
+	  DBG1(DBG_NET, "ARP wrong size expected=%d != actual=%d", sizeof(arp_t), len);
 	}
-	return TRUE;
-}
-
-/**
- * Create an initialize a BPF handler for the interface specified in the farp
- * handler. This entails opening a BPF device, binding it to the interface,
- * setting the packet filter, and allocating a buffer for receiving packets.
- */
-static bool setup_handler(private_farp_spoofer_t *this, farp_handler_t *handler)
-{
-	struct bpf_insn instructions[] = {
-		BPF_STMT(BPF_LD+BPF_W+BPF_LEN, 0),
-		BPF_JUMP(BPF_JMP+BPF_JGE+BPF_K,
-				 sizeof(struct ether_header) + sizeof(arp_t), 0, 11),
-		BPF_STMT(BPF_LD+BPF_H+BPF_ABS,
-				 offsetof(struct  ether_header, ether_type)),
-		BPF_JUMP(BPF_JMP+BPF_JEQ+BPF_K, ETHERTYPE_ARP, 0, 9),
-		BPF_STMT(BPF_LD+BPF_H+BPF_ABS,
-				 sizeof(struct ether_header) + offsetof(arp_t, protocol_type)),
-		BPF_JUMP(BPF_JMP+BPF_JEQ+BPF_K, ETHERTYPE_IP, 0, 7),
-		BPF_STMT(BPF_LD+BPF_B+BPF_ABS,
-				 sizeof(struct ether_header) + offsetof(arp_t, hardware_size)),
-		BPF_JUMP(BPF_JMP+BPF_JEQ+BPF_K, 6, 0, 5),
-		BPF_STMT(BPF_LD+BPF_B+BPF_ABS,
-				 sizeof(struct ether_header) + offsetof(arp_t, protocol_size)),
-		BPF_JUMP(BPF_JMP+BPF_JEQ+BPF_K, 4, 0, 3),
-		BPF_STMT(BPF_LD+BPF_H+BPF_ABS,
-				 sizeof(struct ether_header) + offsetof(arp_t, opcode)),
-		BPF_JUMP(BPF_JMP+BPF_JEQ+BPF_K, ARPOP_REQUEST, 0, 1),
-		BPF_STMT(BPF_RET+BPF_K, 14 + sizeof(arp_t)),
-		BPF_STMT(BPF_RET+BPF_K, 0)
-	};
-	struct bpf_program program;
-	struct ifreq req;
-	uint32_t disable = 1;
-	uint32_t enable = 1;
-	uint32_t dlt = 0;
-
-	snprintf(req.ifr_name, sizeof(req.ifr_name), "%s", handler->name);
-
-	if ((handler->fd = bpf_open()) < 0)
-	{
-		DBG1(DBG_NET, "bpf_open(%s): %s", handler->name, strerror(errno));
-		return FALSE;
-	}
-
-	if (ioctl(handler->fd, BIOCSETIF, &req) < 0)
-	{
-		DBG1(DBG_NET, "BIOCSETIF(%s): %s", handler->name, strerror(errno));
-		return FALSE;
-	}
-
-	if (ioctl(handler->fd, BIOCSHDRCMPLT, &enable) < 0)
-	{
-		DBG1(DBG_NET, "BIOCSHDRCMPLT(%s): %s", handler->name, strerror(errno));
-		return FALSE;
-	}
-
-	if (ioctl(handler->fd, BIOCSSEESENT, &disable) < 0)
-	{
-		DBG1(DBG_NET, "BIOCSSEESENT(%s): %s", handler->name, strerror(errno));
-		return FALSE;
-	}
-
-	if (ioctl(handler->fd, BIOCIMMEDIATE, &enable) < 0)
-	{
-		DBG1(DBG_NET, "BIOCIMMEDIATE(%s): %s", handler->name, strerror(errno));
-		return FALSE;
-	}
-
-	if (ioctl(handler->fd, BIOCGDLT, &dlt) < 0)
-	{
-		DBG1(DBG_NET, "BIOCGDLT(%s): %s", handler->name, strerror(errno));
-		return FALSE;
-	}
-	else if (dlt != DLT_EN10MB)
-	{
-		return FALSE;
-	}
-
-	program.bf_len = sizeof(instructions) / sizeof(struct bpf_insn);
-	program.bf_insns = &instructions[0];
-
-	if (ioctl(handler->fd, BIOCSETF, &program) < 0)
-	{
-		DBG1(DBG_NET, "BIOCSETF(%s): %s", handler->name, strerror(errno));
-		return FALSE;
-	}
-
-	if (ioctl(handler->fd, BIOCGBLEN, &handler->buflen) < 0)
-	{
-		DBG1(DBG_NET, "BIOCGBLEN(%s): %s", handler->name, strerror(errno));
-		return FALSE;
-	}
-	handler->bufdat = malloc(handler->buflen);
-
-	lib->watcher->add(lib->watcher, handler->fd, WATCHER_READ,
-					  handler_onarp, handler);
-	return TRUE;
-}
-
-/**
- * Create a handler for each BPF capable interface. The interface must have an
- * Ethernet MAC address, an IPv4 address, and use an Ethernet data link layer.
- */
-static bool setup_handlers(private_farp_spoofer_t *this)
-{
-	struct ifaddrs *ifas;
-	struct ifaddrs *ifa;
-	struct sockaddr_dl *dl;
-	farp_handler_t* handler;
-	enumerator_t *enumerator;
-	host_t *ipv4;
-
-	if (getifaddrs(&ifas) < 0)
-	{
-		DBG1(DBG_NET, "farp cannot find interfaces: %s", strerror(errno));
-		return FALSE;
-	}
-	for (ifa = ifas; ifa != NULL; ifa = ifa->ifa_next)
-	{
-		switch (ifa->ifa_addr->sa_family)
-		{
-			case AF_LINK:
-				dl = (struct sockaddr_dl*)ifa->ifa_addr;
-				if (dl->sdl_alen == ETHER_ADDR_LEN)
-				{
-					handler = get_handler(this, ifa->ifa_name);
-					handler->mac = chunk_clone(chunk_create(LLADDR(dl),
-															dl->sdl_alen));
-				}
-				break;
-			case AF_INET:
-				ipv4 = host_create_from_sockaddr(ifa->ifa_addr);
-				if (ipv4 && !ipv4->is_anyaddr(ipv4))
-				{
-					handler = get_handler(this, ifa->ifa_name);
-					if (!handler->ipv4)
-					{
-						handler->ipv4 = ipv4->clone(ipv4);
-					}
-				}
-				DESTROY_IF(ipv4);
-				break;
-			default:
-				break;
-		}
-	}
-	freeifaddrs(ifas);
-
-	enumerator = this->handlers->create_enumerator(this->handlers);
-	while (enumerator->enumerate(enumerator, &handler))
-	{
-		if (handler->mac.ptr && handler->ipv4 &&
-			setup_handler(this, handler))
-		{
-			DBG1(DBG_NET, "listening for ARP requests on %s (%H, %#B)",
-			     handler->name, handler->ipv4, &handler->mac);
-		}
-		else
-		{
-			this->handlers->remove_at(this->handlers, enumerator);
-			handler_destroy(handler);
-		}
-	}
-	enumerator->destroy(enumerator);
-
-	return this->handlers->get_count(this->handlers) > 0;
 }
 
 /**
@@ -617,16 +230,7 @@ static bool setup_handlers(private_farp_spoofer_t *this)
  */
 METHOD(farp_spoofer_t, destroy, void, private_farp_spoofer_t *this)
 {
-	enumerator_t *enumerator;
-	farp_handler_t *handler;
-
-	enumerator = this->handlers->create_enumerator(this->handlers);
-	while (enumerator->enumerate(enumerator, &handler))
-	{
-		handler_destroy(handler);
-	}
-	enumerator->destroy(enumerator);
-	this->handlers->destroy(this->handlers);
+	this->pf_handler->destroy(this->pf_handler);
 	free(this);
 }
 
@@ -635,6 +239,48 @@ METHOD(farp_spoofer_t, destroy, void, private_farp_spoofer_t *this)
  */
 farp_spoofer_t *farp_spoofer_create(farp_listener_t *listener)
 {
+#if !defined(__APPLE__) && !defined(__FreeBSD__)
+	struct sock_filter arp_request_filter_code[] = {
+			BPF_STMT(BPF_LD+BPF_H+BPF_ABS, offsetof(arp_t, protocol_type)),
+			BPF_JUMP(BPF_JMP+BPF_JEQ+BPF_K, ETH_P_IP, 0, 9),
+			BPF_STMT(BPF_LD+BPF_B+BPF_ABS, offsetof(arp_t, hardware_size)),
+			BPF_JUMP(BPF_JMP+BPF_JEQ+BPF_K, 6, 0, 7),
+			BPF_STMT(BPF_LD+BPF_B+BPF_ABS, offsetof(arp_t, protocol_size)),
+			BPF_JUMP(BPF_JMP+BPF_JEQ+BPF_K, 4, 0, 5),
+			BPF_STMT(BPF_LD+BPF_H+BPF_ABS, offsetof(arp_t, opcode)),
+			BPF_JUMP(BPF_JMP+BPF_JEQ+BPF_K, ARPOP_REQUEST, 0, 3),
+			BPF_STMT(BPF_LD+BPF_W+BPF_LEN, 0),
+			BPF_JUMP(BPF_JMP+BPF_JGE+BPF_K, sizeof(arp_t), 0, 1),
+			BPF_STMT(BPF_RET+BPF_K, sizeof(arp_t)),
+			BPF_STMT(BPF_RET+BPF_K, 0),
+	};
+	struct sock_fprog arp_request_filter = {
+			sizeof(arp_request_filter_code) / sizeof(struct sock_filter),
+			arp_request_filter_code,
+	};
+#else
+	const size_t skip_eth = sizeof(struct ether_header);
+	struct bpf_insn instructions[] = {
+		BPF_STMT(BPF_LD+BPF_W+BPF_LEN, 0),
+		BPF_JUMP(BPF_JMP+BPF_JGE+BPF_K, skip_eth + sizeof(arp_t), 0, 11),
+		BPF_STMT(BPF_LD+BPF_H+BPF_ABS, offsetof(struct ether_header, ether_type)),
+		BPF_JUMP(BPF_JMP+BPF_JEQ+BPF_K, ETHERTYPE_ARP, 0, 9),
+		BPF_STMT(BPF_LD+BPF_H+BPF_ABS, skip_eth + offsetof(arp_t, protocol_type)),
+		BPF_JUMP(BPF_JMP+BPF_JEQ+BPF_K, ETHERTYPE_IP, 0, 7),
+		BPF_STMT(BPF_LD+BPF_B+BPF_ABS, skip_eth + offsetof(arp_t, hardware_size)),
+		BPF_JUMP(BPF_JMP+BPF_JEQ+BPF_K, 6, 0, 5),
+		BPF_STMT(BPF_LD+BPF_B+BPF_ABS, skip_eth + offsetof(arp_t, protocol_size)),
+		BPF_JUMP(BPF_JMP+BPF_JEQ+BPF_K, 4, 0, 3),
+		BPF_STMT(BPF_LD+BPF_H+BPF_ABS, skip_eth + offsetof(arp_t, opcode)),
+		BPF_JUMP(BPF_JMP+BPF_JEQ+BPF_K, ARPOP_REQUEST, 0, 1),
+		BPF_STMT(BPF_RET+BPF_K, 14 + sizeof(arp_t)),
+		BPF_STMT(BPF_RET+BPF_K, 0)
+	};
+	struct bpf_program arp_request_filter = {
+		sizeof(instructions) / sizeof(struct bpf_insn),
+		&instructions[0]
+	};
+#endif
 	private_farp_spoofer_t *this;
 
 	INIT(this,
@@ -642,15 +288,14 @@ farp_spoofer_t *farp_spoofer_create(farp_listener_t *listener)
 			.destroy = _destroy,
 		},
 		.listener = listener,
-		.handlers = linked_list_create(),
 	);
 
-	if (!setup_handlers(this))
+	this->pf_handler = pf_handler_create(this, "ARP", 0,
+										 handle_arp_pkt, &arp_request_filter);
+	if (!this->pf_handler)
 	{
 		destroy(this);
 		return NULL;
 	}
 	return &this->public;
 }
-
-#endif /* !defined(__APPLE__) && !defined(__FreeBSD__) */

--- a/src/libstrongswan/tests/suites/test_process.c
+++ b/src/libstrongswan/tests/suites/test_process.c
@@ -195,6 +195,11 @@ START_TEST(test_shell)
 }
 END_TEST
 
+#if defined(__APPLE__) || defined(__FreeBSD__)
+#undef tcase_create
+#define tcase_create(name) ({TCase *tc_ = test_case_create(name); tc_->timeout = 15; tc_;})
+#endif
+
 Suite *process_suite_create()
 {
 	Suite *s;


### PR DESCRIPTION
- Pulled the packet filtering code out of the farp_spoofer.c into shared files pf_handler.c & pf_handler.h
- Updated farp_spoofer.c to use the shared code.
- Updated dhcp_socket.c to use the shared code.
- Implemented the glue code for DHCP in dhcp_socket.c for FreeBSD & macOS
- Updated curl_plugin.c to compile with recently released curl changes