### PR TITLE
HA: add support for PPK

### DIFF
--- a/src/libcharon/bus/bus.c
+++ b/src/libcharon/bus/bus.c
@@ -637,6 +637,33 @@ METHOD(bus_t, ike_derived_keys, void,
 	this->mutex->unlock(this->mutex);
 }
 
+METHOD(bus_t, ike_ppk, void,
+	private_bus_t *this, ike_sa_t *ike_sa, identification_t *ppk_id)
+{
+	enumerator_t *enumerator;
+	entry_t *entry;
+	bool keep;
+
+	this->mutex->lock(this->mutex);
+	enumerator = this->listeners->create_enumerator(this->listeners);
+	while (enumerator->enumerate(enumerator, &entry))
+	{
+		if (entry->calling || !entry->listener->ike_ppk)
+		{
+			continue;
+		}
+		entry->calling++;
+		keep = entry->listener->ike_ppk(entry->listener, ike_sa, ppk_id);
+		entry->calling--;
+		if (!keep)
+		{
+			unregister_listener(this, entry, enumerator);
+		}
+	}
+	enumerator->destroy(enumerator);
+	this->mutex->unlock(this->mutex);
+}
+
 METHOD(bus_t, child_keys, void,
 	private_bus_t *this, child_sa_t *child_sa, bool initiator,
 	key_exchange_t *dh, chunk_t nonce_i, chunk_t nonce_r)
@@ -1144,6 +1171,7 @@ bus_t *bus_create()
 			.message = _message,
 			.ike_keys = _ike_keys,
 			.ike_derived_keys = _ike_derived_keys,
+			.ike_ppk = _ike_ppk,
 			.child_keys = _child_keys,
 			.child_derived_keys = _child_derived_keys,
 			.ike_updown = _ike_updown,

--- a/src/libcharon/bus/bus.h
+++ b/src/libcharon/bus/bus.h
@@ -377,6 +377,14 @@ struct bus_t {
 							 chunk_t sk_pi, chunk_t sk_pr);
 
 	/**
+	 * IKE_SA apply PPK hook
+	 *
+	 * @param ike_sa	IKE_SA the PPK was applied to
+	 * @param ppk_id	the id of the applied PPK
+	 */
+	void (*ike_ppk)(bus_t *this, ike_sa_t *ike_sa, identification_t *ppk_id);
+
+	/**
 	 * CHILD_SA keymat hook.
 	 *
 	 * @param child_sa	CHILD_SA this keymat is used for

--- a/src/libcharon/bus/listeners/listener.h
+++ b/src/libcharon/bus/listeners/listener.h
@@ -114,6 +114,16 @@ struct listener_t {
 							 chunk_t sk_er, chunk_t sk_pi, chunk_t sk_pr);
 
 	/**
+	 * Hook called with applied PPK id.
+	 *
+	 * @param ike_sa	IKE_SA the PPK was applied to
+	 * @param ppk_id	the id of the applied PPK
+	 */
+
+	bool (*ike_ppk)(listener_t *this, ike_sa_t *ike_sa,
+					identification_t *ppk_id);
+
+	/**
 	 * Hook called with CHILD_SA key material.
 	 *
 	 * @param ike_sa	IKE_SA the child sa belongs to

--- a/src/libcharon/plugins/ha/ha_ike.c
+++ b/src/libcharon/plugins/ha/ha_ike.c
@@ -165,6 +165,30 @@ METHOD(listener_t, ike_keys, bool,
 	return TRUE;
 }
 
+METHOD(listener_t, ike_ppk, bool,
+	private_ha_ike_t *this, ike_sa_t *ike_sa, identification_t *ppk_id)
+{
+	ha_message_t *m;
+
+	if (ike_sa->get_state(ike_sa) == IKE_PASSIVE)
+	{	/* only sync active IKE_SAs */
+		return TRUE;
+	}
+	if (this->tunnel && this->tunnel->is_sa(this->tunnel, ike_sa))
+	{	/* do not sync SA between nodes */
+		return TRUE;
+	}
+
+	m = ha_message_create(HA_IKE_PPK);
+	m->add_attribute(m, HA_IKE_ID, ike_sa->get_id(ike_sa));
+	m->add_attribute(m, HA_PPK_ID, ppk_id);
+
+	this->socket->push(this->socket, m);
+	this->cache->cache(this->cache, ike_sa, m);
+
+	return TRUE;
+}
+
 METHOD(listener_t, ike_updown, bool,
 	private_ha_ike_t *this, ike_sa_t *ike_sa, bool up)
 {
@@ -402,6 +426,7 @@ ha_ike_t *ha_ike_create(ha_socket_t *socket, ha_tunnel_t *tunnel,
 			.listener = {
 				.alert = _alert,
 				.ike_keys = _ike_keys,
+				.ike_ppk = _ike_ppk,
 				.ike_updown = _ike_updown,
 				.ike_rekey = _ike_rekey,
 				.ike_state_change = _ike_state_change,

--- a/src/libcharon/plugins/ha/ha_message.c
+++ b/src/libcharon/plugins/ha/ha_message.c
@@ -47,7 +47,7 @@ struct private_ha_message_t {
 	chunk_t buf;
 };
 
-ENUM(ha_message_type_names, HA_IKE_ADD, HA_IKE_IV,
+ENUM(ha_message_type_names, HA_IKE_ADD, HA_IKE_PPK,
 	"IKE_ADD",
 	"IKE_UPDATE",
 	"IKE_MID_INITIATOR",
@@ -60,6 +60,7 @@ ENUM(ha_message_type_names, HA_IKE_ADD, HA_IKE_IV,
 	"STATUS",
 	"RESYNC",
 	"IKE_IV",
+	"IKE_PPK",
 );
 
 typedef struct ike_sa_id_encoding_t ike_sa_id_encoding_t;
@@ -168,6 +169,7 @@ METHOD(ha_message_t, add_attribute, void,
 		case HA_LOCAL_ID:
 		case HA_REMOTE_ID:
 		case HA_REMOTE_EAP_ID:
+		case HA_PPK_ID:
 		{
 			identification_encoding_t *enc;
 			identification_t *id;
@@ -377,6 +379,7 @@ METHOD(enumerator_t, attribute_enumerate, bool,
 		case HA_LOCAL_ID:
 		case HA_REMOTE_ID:
 		case HA_REMOTE_EAP_ID:
+		case HA_PPK_ID:
 		{
 			identification_encoding_t *enc;
 

--- a/src/libcharon/plugins/ha/ha_message.h
+++ b/src/libcharon/plugins/ha/ha_message.h
@@ -66,6 +66,8 @@ enum ha_message_type_t {
 	HA_RESYNC,
 	/** IV synchronization for IKEv1 Main/Aggressive mode */
 	HA_IKE_IV,
+	/** update an existing IKE_SA with PPK */
+	HA_IKE_PPK,
 };
 
 /**
@@ -159,6 +161,8 @@ enum ha_message_attribute_t {
 	HA_IV,
 	/** uint16_t, auth_method_t for IKEv1 key derivation */
 	HA_AUTH_METHOD,
+	/** identification_t*, PPK id */
+	HA_PPK_ID,
 };
 
 /**

--- a/src/libcharon/sa/ikev2/tasks/ike_auth.c
+++ b/src/libcharon/sa/ikev2/tasks/ike_auth.c
@@ -964,6 +964,7 @@ static bool apply_ppk(private_ike_auth_t *this)
 		}
 		DBG1(DBG_CFG, "using PPK for PPK_ID '%Y'", this->ppk_id);
 		this->ike_sa->set_condition(this->ike_sa, COND_PPK, TRUE);
+		charon->bus->ike_ppk(charon->bus, this->ike_sa, this->ppk_id);
 	}
 	clear_ppk(this);
 	return TRUE;


### PR DESCRIPTION
Postquantum Preshared Keys for IKEv2 support was added in 5.7.0 but without support in the HA plugin.
A tunnel using PPK can't recover in HA since inserted Child SA keys are wrong.
A new HA message was added `HA_IKE_PPK` including the PPK id  used in authentication. It allows the passive segments to derive correctly using the shared secret.