### PR TITLE
charon-nm: Allow configuring local traffic selector

### DIFF
--- a/src/charon-nm/nm/nm_service.c
+++ b/src/charon-nm/nm/nm_service.c
@@ -946,8 +946,32 @@ static gboolean connect_(NMVpnServicePlugin *plugin, NMConnection *connection,
 		child_cfg->add_proposal(child_cfg, proposal_create_default_aead(PROTO_ESP));
 		child_cfg->add_proposal(child_cfg, proposal_create_default(PROTO_ESP));
 	}
-	ts = traffic_selector_create_dynamic(0, 0, 65535);
-	child_cfg->add_traffic_selector(child_cfg, TRUE, ts);
+	str = nm_setting_vpn_get_data_item(vpn, "local-ts");
+	if (str && strlen(str))
+	{
+		enumerator = enumerator_create_token(str, ";", "");
+		while (enumerator->enumerate(enumerator, &str))
+		{
+			ts = traffic_selector_create_from_cidr((char*)str, 0, 0, 65535);
+			if (!ts)
+			{
+				g_set_error(err, NM_VPN_PLUGIN_ERROR,
+							NM_VPN_PLUGIN_ERROR_LAUNCH_FAILED,
+							"Invalid remote traffic selector.");
+				enumerator->destroy(enumerator);
+				child_cfg->destroy(child_cfg);
+				peer_cfg->destroy(peer_cfg);
+				return FALSE;
+			}
+			child_cfg->add_traffic_selector(child_cfg, TRUE, ts);
+		}
+		enumerator->destroy(enumerator);
+	}
+	else
+	{
+		ts = traffic_selector_create_dynamic(0, 0, 65535);
+		child_cfg->add_traffic_selector(child_cfg, TRUE, ts);
+	}
 	str = nm_setting_vpn_get_data_item(vpn, "remote-ts");
 	if (str && strlen(str))
 	{


### PR DESCRIPTION
Here is a rather trivial patch that allows one to set the local traffic selector by setting a value for the `local-ts` configuration key.  In the absence of `local-ts`  the behavior is the same as before: the local traffic selector is created dynamically.