### PR TITLE
openssl: Add missing error checking to ED private key get_encoding method

### DIFF
--- a/src/libstrongswan/plugins/openssl/openssl_ed_private_key.c
+++ b/src/libstrongswan/plugins/openssl/openssl_ed_private_key.c
@@ -19,6 +19,7 @@
 #if OPENSSL_VERSION_NUMBER >= 0x1010100fL && !defined(OPENSSL_NO_EC)
 
 #include "openssl_ed_private_key.h"
+#include "openssl_util.h"
 
 #include <utils/debug.h>
 
@@ -157,8 +158,6 @@ METHOD(private_key_t, get_fingerprint, bool,
 METHOD(private_key_t, get_encoding, bool,
 	private_private_key_t *this, cred_encoding_type_t type, chunk_t *encoding)
 {
-	u_char *p;
-
 	if (this->engine)
 	{
 		return FALSE;
@@ -171,9 +170,7 @@ METHOD(private_key_t, get_encoding, bool,
 		{
 			bool success = TRUE;
 
-			*encoding = chunk_alloc(i2d_PrivateKey(this->key, NULL));
-			p = encoding->ptr;
-			i2d_PrivateKey(this->key, &p);
+			*encoding = openssl_i2chunk(PrivateKey, this->key);
 
 			if (type == PRIVKEY_PEM)
 			{


### PR DESCRIPTION
This applies the same logic found in other private key implementations like
`openssl_ec_private_key.c`.
