### PR TITLE
openssl: Condition out unsupported curves for AWS-LC

### DIFF
--- a/src/libstrongswan/plugins/openssl/openssl_plugin.c
+++ b/src/libstrongswan/plugins/openssl/openssl_plugin.c
@@ -301,7 +301,8 @@ static private_key_t *openssl_private_key_load(key_type_t type, va_list args)
 				case EVP_PKEY_EC:
 					return openssl_ec_private_key_create(key, FALSE);
 #endif
-#if OPENSSL_VERSION_NUMBER >= 0x1010100fL && !defined(OPENSSL_NO_EC)
+#if OPENSSL_VERSION_NUMBER >= 0x1010100fL && !defined(OPENSSL_NO_EC) \
+	&& !defined(OPENSSL_IS_AWSLC)
 				case EVP_PKEY_ED25519:
 				case EVP_PKEY_ED448:
 					return openssl_ed_private_key_create(key, FALSE);
@@ -654,7 +655,8 @@ METHOD(plugin_t, get_features, int,
 		PLUGIN_PROVIDE(PUBKEY_VERIFY, SIGN_ECDSA_521),
 #endif
 #endif /* OPENSSL_NO_ECDSA */
-#if OPENSSL_VERSION_NUMBER >= 0x1010100fL && !defined(OPENSSL_NO_EC)
+#if OPENSSL_VERSION_NUMBER >= 0x1010100fL && !defined(OPENSSL_NO_EC) \
+	&& !defined(OPENSSL_IS_AWSLC)
 		/* EdDSA private/public key loading */
 		PLUGIN_REGISTER(PUBKEY, openssl_ed_public_key_load, TRUE),
 			PLUGIN_PROVIDE(PUBKEY, KEY_ED25519),
@@ -705,8 +707,10 @@ METHOD(plugin_t, get_features, int,
 		PLUGIN_REGISTER(KE, openssl_x_diffie_hellman_create),
 			/* available since 1.1.0a, but we require 1.1.1 features */
 			PLUGIN_PROVIDE(KE, CURVE_25519),
+#ifndef OPENSSL_IS_AWSLC
 			/* available since 1.1.1 */
 			PLUGIN_PROVIDE(KE, CURVE_448),
+#endif /* OPENSSL_IS_AWSLC */
 #endif /* OPENSSL_VERSION_NUMBER && !OPENSSL_NO_ECDH */
 	};
 	static plugin_feature_t f[countof(f_base) + countof(f_ecdh) + countof(f_xdh)] = {};


### PR DESCRIPTION
AWS-LC lacks support for a number of elliptic curve algorithms so this PR
adds some conditional macros to avoid registering the related plugins. Support
for curves ed448 and x448 is completely absent and are not planned for
implementation as they are no longer recommended for use. While ed25519 is
supported by the library, a single missing API for ASN.1 DER encoding of its
private keys is missing which prevents its use in strongSwan. Future work may
remove this limitation, but for now we will disable the functionality.

Related to Issue #1907
