### PR TITLE
openssl: Add thread local cleanup for AWS-LC

### DIFF
--- a/src/libstrongswan/plugins/openssl/openssl_plugin.c
+++ b/src/libstrongswan/plugins/openssl/openssl_plugin.c
@@ -746,7 +746,9 @@ METHOD(plugin_t, destroy, void,
 	threading_cleanup();
 	ERR_free_strings();
 #endif /* OPENSSL_VERSION_NUMBER */
-
+#ifdef OPENSSL_IS_AWSLC
+	AWSLC_thread_local_clear();
+#endif
 	free(this);
 }
 


### PR DESCRIPTION
The leak-detective CI checks were flagging a memory leak of internal
`RAND_bytes` related state which suggests that the thread's destructor was not
getting called. This adds an explicit call to cleanup the thread specific state
in the openssl plugin's destructor which seems to address the CI failures.

References Issue #1907
