### PR TITLE
configure: don't set DL_LIBS to 'none required'

### DIFF
--- a/src/frontends/gnome/configure.ac
+++ b/src/frontends/gnome/configure.ac
@@ -35,8 +35,9 @@ AC_PROG_GCC_TRADITIONAL
 AC_FUNC_MEMCMP
 AC_CHECK_FUNCS(select socket uname)
 
-AC_SEARCH_LIBS([dlopen], [dl dld], [], [ac_cv_search_dlopen=])
-AC_SUBST([DL_LIBS], "$ac_cv_search_dlopen")
+LIBS=""
+AC_SEARCH_LIBS([dlopen], [dl dld], [DL_LIBS=$LIBS])
+AC_SUBST([DL_LIBS])
 
 AM_GNU_GETTEXT_VERSION([0.19])
 AM_GNU_GETTEXT([external])


### PR DESCRIPTION
This copies the AC_SEARCH_LIBS check from the main strongswan configure.ac.

When building networkmanager-strongswan with slibtool if fails.
```
ld: cannot find none: No such file or directory
ld: cannot find required: No such file or directory
```
This is because configure.ac uses AC_SEARCH_LIBS to find dlopen which sets the value of $ac_cv_search_dlopen to 'none required' which then gets set in DL_LIBS and passed to slibtool.

With GNU libtool it silently ignores the unknown arguments.

Gentoo issue: https://bugs.gentoo.org/914100