### PR TITLE
change the field type of uniqueids from bool to u_int when reading the setup section in the configuration file

### DIFF
--- a/src/starter/confread.h
+++ b/src/starter/confread.h
@@ -197,7 +197,7 @@ typedef struct starter_config starter_config_t;
 struct starter_config {
 		struct {
 				char     *charondebug;
-				bool     uniqueids;
+				u_int    uniqueids;
 				bool     cachecrls;
 				strict_t strictcrlpolicy;
 		} setup;


### PR DESCRIPTION
The member type change of uniqueids from bool to u_int is required since enums are of type u_int and the code in assign_arg in args.c line 274 assumes the field type/size is an int where as bool is a char of course.

I found this bug when I added another member to the global setup and the new member was overridden when reading the configuration file.

I intend to submit my other changes based on fixing this bug.

I tried to use the correct enum typedef from src/libcharon/config/peer_cfg.h but too many changes were required in order to fix this bug since there were typedef collisions when including the header in src/starter/confread.h

I did not want to make so many changes myself.