### PR TITLE
github: Add AWS-LC CI job

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -91,7 +91,7 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-latest, ubuntu-20.04 ]
-        test: [ botan, wolfssl, openssl, openssl-3, gcrypt ]
+        test: [ botan, wolfssl, openssl, openssl-3, openssl-awslc, gcrypt ]
         leak-detective: [ no, yes ]
         exclude:
           # test custom-built libs only on one platform
@@ -101,6 +101,8 @@ jobs:
             test: wolfssl
           - os: ubuntu-20.04
             test: openssl-3
+          - os: ubuntu-20.04
+            test: openssl-awslc
     env:
       LEAK_DETECTIVE: ${{ matrix.leak-detective || 'no' }}
       CC: ${{ matrix.compiler || 'gcc' }}

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -125,13 +125,41 @@ build_openssl()
 	fi
 }
 
+build_awslc()
+{
+	LC_REV=1.21.0
+	LC_PKG=aws-lc-$LC_REV
+	LC_DIR=$DEPS_BUILD_DIR/$LC_PKG
+	LC_SRC=https://github.com/aws/aws-lc/archive/refs/tags/v${LC_REV}.tar.gz
+	LC_BUILD=$LC_DIR/build
+	LC_INS=$DEPS_PREFIX/ssl
+
+	mkdir -p $LC_BUILD
+
+	echo "$ build_awslc()"
+
+	curl -L $LC_SRC | tar xz -C $DEPS_BUILD_DIR || exit $?
+
+	cd $LC_BUILD
+	cmake -GNinja -DCMAKE_INSTALL_PREFIX=$LC_INS ..
+	ninja
+	sudo ninja install
+}
+
 use_custom_openssl()
 {
 	CFLAGS="$CFLAGS -I$DEPS_PREFIX/ssl/include"
 	export LDFLAGS="$LDFLAGS -L$DEPS_PREFIX/ssl/lib"
 	export LD_LIBRARY_PATH="$DEPS_PREFIX/ssl/lib:$LD_LIBRARY_PATH"
 	if test "$1" = "build-deps"; then
-		build_openssl
+		case "$TEST" in
+			openssl-awslc)
+				build_awslc
+				;;
+			*)
+				build_openssl
+				;;
+		esac
 	fi
 }
 
@@ -191,6 +219,9 @@ openssl*)
 	DEPS="libssl-dev"
 	if test "$TEST" = "openssl-3"; then
 		DEPS=""
+		use_custom_openssl $1
+	elif test "$TEST" = "openssl-awslc"; then
+		DEPS="cmake ninja-build golang"
 		use_custom_openssl $1
 	elif system_uses_openssl3; then
 		prepare_system_openssl $1


### PR DESCRIPTION
AWS-LC is an OpenSSL derivative which can be used with the openssl plugin. This
PR adds a CI job that resembles the openssl-3 test case. It downloads the
source tarball for an AWS-LC release, builds that source using CMake/Ninja, and
then builds/tests strongSwan using the same technique used by openssl-3.

Related to Issue #1907
