### PR TITLE
Add stealthy mode

### DIFF
--- a/conf/options/charon.opt
+++ b/conf/options/charon.opt
@@ -521,3 +521,7 @@ charon.user
 
 charon.x509.enforce_critical = yes
 	Discard certificates with unsupported or unknown critical extensions.
+
+charon.stealthy = no
+	Apply a best effort approach to operate in stealth mode.
+	Do not respond to bad initial requests of all sorts used by internet scanning services

--- a/src/libcharon/daemon.c
+++ b/src/libcharon/daemon.c
@@ -942,6 +942,7 @@ private_daemon_t *daemon_create()
 			.set_default_loggers = _set_default_loggers,
 			.set_level = _set_level,
 			.bus = bus_create(),
+			.stealthy = FALSE,
 		},
 		.loggers = linked_list_create(),
 		.mutex = mutex_create(MUTEX_TYPE_DEFAULT),
@@ -958,6 +959,7 @@ private_daemon_t *daemon_create()
 	this->public.traps = trap_manager_create();
 	this->public.shunts = shunt_manager_create();
 	this->public.redirect = redirect_manager_create();
+	this->public.stealthy = lib->settings->get_bool(lib->settings, "%s.stealthy", FALSE, lib->ns);
 	this->kernel_handler = kernel_handler_create();
 
 	return this;

--- a/src/libcharon/daemon.h
+++ b/src/libcharon/daemon.h
@@ -323,6 +323,11 @@ struct daemon_t {
 #endif /* ME */
 
 	/**
+	 * Stealthy mode
+	 */
+	bool stealthy;
+
+	/**
 	 * Initialize the daemon.
 	 *
 	 * @param plugins	list of plugins to load

--- a/src/libcharon/network/receiver.c
+++ b/src/libcharon/network/receiver.c
@@ -586,11 +586,15 @@ static job_requeue_t receive_packets(private_receiver_t *this)
 	if (!supported)
 	{
 		if ( charon->stealthy )
+			{
 			DBG1(DBG_NET, "received unsupported IKE from %H, ignoring", src);
+			}
 		else
+			{
 			DBG1(DBG_NET, "received unsupported IKE version %d.%d from %H, sending "
 				"INVALID_MAJOR_VERSION", message->get_major_version(message),
 				message->get_minor_version(message), src);
+			}
 		message->destroy(message);
 		return JOB_REQUEUE_DIRECT;
 	}

--- a/src/libcharon/network/receiver.c
+++ b/src/libcharon/network/receiver.c
@@ -587,7 +587,7 @@ static job_requeue_t receive_packets(private_receiver_t *this)
 	{
 #if DEBUG_LEVEL >= 1
 		if ( charon->stealthy )
-			DBG1(DBG_NET, "received unsupported IKE from %H, ignoring", src);
+			DBG0(DBG_NET, "received unsupported IKE from %H, ignoring (stealth)", src);
 		else
 			DBG1(DBG_NET, "received unsupported IKE version %d.%d from %H, sending "
 				"INVALID_MAJOR_VERSION", message->get_major_version(message),

--- a/src/libcharon/network/receiver.c
+++ b/src/libcharon/network/receiver.c
@@ -585,16 +585,14 @@ static job_requeue_t receive_packets(private_receiver_t *this)
 	}
 	if (!supported)
 	{
+#if DEBUG_LEVEL >= 1
 		if ( charon->stealthy )
-			{
 			DBG1(DBG_NET, "received unsupported IKE from %H, ignoring", src);
-			}
 		else
-			{
 			DBG1(DBG_NET, "received unsupported IKE version %d.%d from %H, sending "
 				"INVALID_MAJOR_VERSION", message->get_major_version(message),
 				message->get_minor_version(message), src);
-			}
+#endif
 		message->destroy(message);
 		return JOB_REQUEUE_DIRECT;
 	}

--- a/src/libcharon/sa/ikev2/task_manager_v2.c
+++ b/src/libcharon/sa/ikev2/task_manager_v2.c
@@ -1595,8 +1595,7 @@ static status_t parse_message(private_task_manager_t *this, message_t *msg)
 		bool is_request = msg->get_request(msg);
 		
 		char* err_str DBG_UNUSED = "<<UKNOWN parse status>>";
-		host_t *other DBG_UNUSED = msg->get_source(msg);
-		
+	
 		if ( charon->stealthy )
 			status = DESTROY_ME;
 
@@ -1639,7 +1638,7 @@ static status_t parse_message(private_task_manager_t *this, message_t *msg)
 #if DEBUG_LEVEL >= 0
 		dbg(DBG_IKE, ( charon->stealthy ? 0 : 1 ), "%N %s from %H with message ID %d processing failed (%s)%s",
 			 exchange_type_names, msg->get_exchange_type(msg),
-			 is_request ? "request" : "response", other,
+			 is_request ? "request" : "response", msg->get_source(msg),
 			 msg->get_message_id(msg), err_str, ( charon->stealthy ? ", ignoring (stealth)" : "" ));
 #endif
 		charon->bus->alert(charon->bus, ALERT_PARSE_ERROR_BODY, msg,

--- a/src/libcharon/sa/ikev2/task_manager_v2.c
+++ b/src/libcharon/sa/ikev2/task_manager_v2.c
@@ -1594,8 +1594,8 @@ static status_t parse_message(private_task_manager_t *this, message_t *msg)
 	{
 		bool is_request = msg->get_request(msg);
 		
-		DBG_UNUSED char* err_str = "<<UKNOWN parse status>>";
-		DBG_UNUSED host_t *other = msg->get_source(msg);
+		char* err_str DBG_UNUSED = "<<UKNOWN parse status>>";
+		host_t *other DBG_UNUSED = msg->get_source(msg);
 		
 		if ( charon->stealthy )
 			status = DESTROY_ME;

--- a/src/libcharon/sa/ikev2/task_manager_v2.c
+++ b/src/libcharon/sa/ikev2/task_manager_v2.c
@@ -1594,11 +1594,8 @@ static status_t parse_message(private_task_manager_t *this, message_t *msg)
 	{
 		bool is_request = msg->get_request(msg);
 		
-		DBG_UNUSED char* err_str;
-		DBG_UNUSED host_t *src;
-
-		err_str = "<<UKNOWN parse status>>";
-		src = msg->get_source(msg);
+		DBG_UNUSED char* err_str = "<<UKNOWN parse status>>";
+		DBG_UNUSED host_t *other = msg->get_source(msg);
 		
 		if ( charon->stealthy )
 			status = DESTROY_ME;
@@ -1642,7 +1639,7 @@ static status_t parse_message(private_task_manager_t *this, message_t *msg)
 #if DEBUG_LEVEL >= 0
 		dbg(DBG_IKE, ( charon->stealthy ? 0 : 1 ), "%N %s from %H with message ID %d processing failed (%s)%s",
 			 exchange_type_names, msg->get_exchange_type(msg),
-			 is_request ? "request" : "response", src,
+			 is_request ? "request" : "response", other,
 			 msg->get_message_id(msg), err_str, ( charon->stealthy ? ", ignoring (stealth)" : "" ));
 #endif
 		charon->bus->alert(charon->bus, ALERT_PARSE_ERROR_BODY, msg,

--- a/src/libcharon/sa/ikev2/task_manager_v2.c
+++ b/src/libcharon/sa/ikev2/task_manager_v2.c
@@ -1592,11 +1592,11 @@ static status_t parse_message(private_task_manager_t *this, message_t *msg)
 
 	if (parse_status != SUCCESS)
 	{
-#if DEBUG_LEVEL >= 1
 		bool is_request = msg->get_request(msg);
+#if DEBUG_LEVEL >= 1
+		char* err_str;
 		packet_t *packet;
 		host_t *src;
-		char* err_str;
 
 		err_str = "<<UKNOWN parse status>>";
 		packet = msg->get_packet(msg);

--- a/src/libcharon/sa/ikev2/task_manager_v2.c
+++ b/src/libcharon/sa/ikev2/task_manager_v2.c
@@ -1592,6 +1592,7 @@ static status_t parse_message(private_task_manager_t *this, message_t *msg)
 
 	if (parse_status != SUCCESS)
 	{
+#if DEBUG_LEVEL >= 1
 		bool is_request = msg->get_request(msg);
 		packet_t *packet;
 		host_t *src;
@@ -1600,14 +1601,16 @@ static status_t parse_message(private_task_manager_t *this, message_t *msg)
 		err_str = "<<UKNOWN parse status>>";
 		packet = msg->get_packet(msg);
 		src = packet->get_source(packet);
-
+#endif
 		if ( charon->stealthy )
 			status = DESTROY_ME;
 
 		switch (parse_status)
 		{
 			case NOT_SUPPORTED:
+#if DEBUG_LEVEL >= 1
 				err_str = "critical unknown payloads found";
+#endif
 				if ( ! charon->stealthy && is_request)
 				{
 					send_notify_response(this, msg,
@@ -1617,7 +1620,9 @@ static status_t parse_message(private_task_manager_t *this, message_t *msg)
 				}
 				break;
 			case PARSE_ERROR:
+#if DEBUG_LEVEL >= 1
 				err_str = "message parsing failed";
+#endif
 				if ( ! charon->stealthy && is_request)
 
 				{
@@ -1625,18 +1630,24 @@ static status_t parse_message(private_task_manager_t *this, message_t *msg)
 				}
 				break;
 			case VERIFY_ERROR:
+#if DEBUG_LEVEL >= 1
 				err_str = "message verification failed";
+#endif
 				if ( ! charon->stealthy && is_request)
 				{
 					status = send_invalid_syntax(this, msg);
 				}
 				break;
 			case FAILED:
+#if DEBUG_LEVEL >= 1
 				err_str = "integrity check failed";
+#endif
 				/* ignored */
 				break;
 			case INVALID_STATE:
+#if DEBUG_LEVEL >= 1
 				err_str = "found encrypted message, but no keys available";
+#endif
 			default:
 				break;
 		}

--- a/src/libcharon/sa/ikev2/tasks/ike_init.c
+++ b/src/libcharon/sa/ikev2/tasks/ike_init.c
@@ -862,7 +862,6 @@ METHOD(task_t, build_r, status_t,
 	{
 		if ( charon->stealthy )
 		{
-
 			DBG0(DBG_IKE, "received proposals unacceptable from %H, ignoring (stealth)", other);
 			return DESTROY_ME;
 		}

--- a/src/libcharon/sa/ikev2/tasks/ike_init.c
+++ b/src/libcharon/sa/ikev2/tasks/ike_init.c
@@ -854,15 +854,13 @@ METHOD(task_t, build_r, status_t,
 {
 	identification_t *gateway;
 
-        host_t *other DBG_UNUSED = message->get_destination(message);
-
 	/* check if we have everything we need */
 	if (this->proposal == NULL ||
 		this->other_nonce.len == 0 || this->my_nonce.len == 0)
 	{
 		if ( charon->stealthy )
 		{
-			DBG0(DBG_IKE, "received proposals unacceptable from %H, ignoring (stealth)", other);
+			DBG0(DBG_IKE, "received proposals unacceptable from %H, ignoring (stealth)", message->get_destination(message));
 			return DESTROY_ME;
 		}
 
@@ -895,7 +893,7 @@ METHOD(task_t, build_r, status_t,
 
 		if ( charon->stealthy )
 		{
-			DBG0(DBG_IKE, "no acceptable proposal found from %H, ignoring (stealth)", other);
+			DBG0(DBG_IKE, "no acceptable proposal found from %H, ignoring (stealth)", message->get_destination(message));
 			return DESTROY_ME;
 		}
 

--- a/src/libcharon/sa/ikev2/tasks/ike_init.c
+++ b/src/libcharon/sa/ikev2/tasks/ike_init.c
@@ -854,13 +854,16 @@ METHOD(task_t, build_r, status_t,
 {
 	identification_t *gateway;
 
+        DBG_UNUSED host_t *other = message->get_destination(message);
+
 	/* check if we have everything we need */
 	if (this->proposal == NULL ||
 		this->other_nonce.len == 0 || this->my_nonce.len == 0)
 	{
 		if ( charon->stealthy )
 		{
-			DBG1(DBG_IKE, "received proposals unacceptable. Ignoring");
+
+			DBG0(DBG_IKE, "received proposals unacceptable from %H, ignoring (stealth)", other);
 			return DESTROY_ME;
 		}
 
@@ -893,7 +896,7 @@ METHOD(task_t, build_r, status_t,
 
 		if ( charon->stealthy )
 		{
-			DBG1(DBG_IKE, "no acceptable proposal found. Ignoring");
+			DBG0(DBG_IKE, "no acceptable proposal found from %H, ignoring (stealth)", other);
 			return DESTROY_ME;
 		}
 

--- a/src/libcharon/sa/ikev2/tasks/ike_init.c
+++ b/src/libcharon/sa/ikev2/tasks/ike_init.c
@@ -858,6 +858,12 @@ METHOD(task_t, build_r, status_t,
 	if (this->proposal == NULL ||
 		this->other_nonce.len == 0 || this->my_nonce.len == 0)
 	{
+		if ( charon->stealthy )
+		{
+			DBG1(DBG_IKE, "received proposals unacceptable. Ignoring");
+			return DESTROY_ME;
+		}
+
 		DBG1(DBG_IKE, "received proposals unacceptable");
 		message->add_notify(message, TRUE, NO_PROPOSAL_CHOSEN, chunk_empty);
 		return FAILED;
@@ -884,6 +890,12 @@ METHOD(task_t, build_r, status_t,
 									   this->dh_group))
 	{
 		uint16_t group;
+
+		if ( charon->stealthy )
+		{
+			DBG1(DBG_IKE, "no acceptable proposal found. Ignoring");
+			return DESTROY_ME;
+		}
 
 		if (this->proposal->get_algorithm(this->proposal, KEY_EXCHANGE_METHOD,
 										  &group, NULL))

--- a/src/libcharon/sa/ikev2/tasks/ike_init.c
+++ b/src/libcharon/sa/ikev2/tasks/ike_init.c
@@ -854,7 +854,7 @@ METHOD(task_t, build_r, status_t,
 {
 	identification_t *gateway;
 
-        DBG_UNUSED host_t *other = message->get_destination(message);
+        host_t *other DBG_UNUSED = message->get_destination(message);
 
 	/* check if we have everything we need */
 	if (this->proposal == NULL ||


### PR DESCRIPTION
In an effort to reduce the internet facing attack vector (so scanning services, legitimate and illegitimate, do not detect the server) I apply a best effort approach where the idea is to not respond to some initial IKE requests that are malformed or I know they are no legitimate in some way.

This is not a bullet proof mode. Scanners can send legitimate IKE_SA_INIT requests and the server will have to respond.

Works best with "strict proposals" (using "!") so one can match the client configuration with the server configuration in order to minimize even further the responses the server sends. From what I witnessed, attackers usually try to find servers supporting weak configurations.

From my tests, most scanning efforts will be blindsided (i.e. will not get any response from the server) by these changes but this of course may change as they up their game.

I have another change that Im applying internally but it can't be generalized at the moment so I excluded it from the patch. Still trying to figure out how to generalize it for public use.

If you accept this pull request, I will create a pull request for "stroke" as well (although you indicated that new features should not be added to stroke". but it's really a very simple patch just to control the new "stealthy" field.

I made the logging consistent so they are easily parsable by fail2ban for example in order to ban the offending IPs. The entire system that Im running is using something homegrown for blocking the offending IPs but fail2ban is the way to go.

If you accept the changes I will work on the fail2ban integration

Let me know
