### PR TITLE
Add `Wants=` dependencies to Systemd units

### DIFF
--- a/init/systemd-starter/strongswan-starter.service.in
+++ b/init/systemd-starter/strongswan-starter.service.in
@@ -1,6 +1,7 @@
 [Unit]
 Description=strongSwan IPsec IKEv1/IKEv2 daemon using ipsec.conf
 After=syslog.target network-online.target
+Wants=syslog.target network-online.target
 
 [Service]
 ExecStart=@SBINDIR@/@IPSEC_SCRIPT@ start --nofork

--- a/init/systemd/strongswan.service.in
+++ b/init/systemd/strongswan.service.in
@@ -1,6 +1,7 @@
 [Unit]
 Description=strongSwan IPsec IKEv1/IKEv2 daemon using swanctl
 After=network-online.target
+Wants=network-online.target
 
 [Service]
 Type=notify


### PR DESCRIPTION
This PR adds `Wants=` dependencies to the strongSwan Systemd units to prevent `network-online.target` and `syslog.target` from not being enabled if no other services have a `Wants=` dependency pointing to them, resulting in a possibly unwanted service startup order.