### PR TITLE
error-notify: disconnect socket on ETIMEDOUT

### DIFF
--- a/src/libcharon/plugins/error_notify/error_notify_socket.c
+++ b/src/libcharon/plugins/error_notify/error_notify_socket.c
@@ -87,6 +87,7 @@ METHOD(error_notify_socket_t, notify, void,
 			{
 				case ECONNRESET:
 				case EPIPE:
+				case ETIMEDOUT:
 					/* disconnect, remove this listener */
 					this->connected->remove_at(this->connected, enumerator);
 					stream->destroy(stream);


### PR DESCRIPTION
When encountering a timeout the error notify socket needs to be closed so that resources can be reclaimed.