### PR TITLE
testing: fix scp

### DIFF
--- a/testing/hosts/default/etc/ssh/sshd_config
+++ b/testing/hosts/default/etc/ssh/sshd_config
@@ -13,3 +13,4 @@ PrintLastLog no
 UsePAM no
 AcceptEnv LANG LC_*
 AcceptEnv LEAK_DETECTIVE_LOG
+Subsystem	sftp	/usr/lib/openssh/sftp-server

--- a/testing/scripts/load-testconfig
+++ b/testing/scripts/load-testconfig
@@ -19,6 +19,8 @@ DIR=$(dirname `readlink -f $0`)
 . $DIR/function.sh
 SSHCONF="-F $DIR/../ssh_config"
 
+set -e
+
 ##########################################################################
 # load-testconfig requires a testname as an argument
 #


### PR DESCRIPTION
On current ssh to test machines works, but
scp fails. Using lagacy scp protocol -O option
makes it work. Also this error was hidden due
to not cheking scp return code and mute all
errors. Add -e to trap script on any errors.

This fixes: https://github.com/strongswan/strongswan/issues/2309