### PR TITLE
Decoupling server code from client. Fix ~6 year old issue.

### DIFF
--- a/src/frontends/gnome/properties/nm-strongswan.c
+++ b/src/frontends/gnome/properties/nm-strongswan.c
@@ -128,13 +128,6 @@ check_validity (StrongswanPluginUiWidget *self, GError **error)
 				case NM_SETTING_SECRET_FLAG_NONE:
 				case NM_SETTING_SECRET_FLAG_AGENT_OWNED:
 					str = (char *) gtk_editable_get_text (GTK_EDITABLE (widget));
-					if (str && strlen (str) < 20) {
-						g_set_error (error,
-									 STRONGSWAN_PLUGIN_UI_ERROR,
-									 STRONGSWAN_PLUGIN_UI_ERROR_INVALID_PROPERTY,
-									 "password is too short");
-						return FALSE;
-					}
 					break;
 				default:
 					break;


### PR DESCRIPTION
Fixes: https://askubuntu.com/questions/1222523/how-to-connect-to-an-ipsec-vpn-with-a-short-20chars-psk

Server should implement config based password restriction