### PR TITLE
botan: add missing include for build flags

### DIFF
--- a/src/libstrongswan/plugins/botan/botan_util_keys.c
+++ b/src/libstrongswan/plugins/botan/botan_util_keys.c
@@ -29,6 +29,8 @@
 #include "botan_rsa_public_key.h"
 #include "botan_rsa_private_key.h"
 
+#include <botan/build.h>
+
 #include <asn1/asn1.h>
 #include <asn1/oid.h>
 


### PR DESCRIPTION
`botan/build.h` defines all `BOTAN_HAS_*` build feature flags. With botan-2 this used to included indirectly via `botan_util.h` -> `botan/ffi.h`.

Botan-3 no longer includes `botan/build.h` from `botan/ffi.h`. It must now be included explicitly. This is already done in all other places that access botans feature flags. It seemingly was forgotten here. This omission causes loading of certificates and keys to fail, even though botan supports the required crypto algorithms.