### PR TITLE
child-create: fix double free of labels after migrate

### DIFF
--- a/src/libcharon/sa/ikev2/tasks/child_create.c
+++ b/src/libcharon/sa/ikev2/tasks/child_create.c
@@ -2607,6 +2607,8 @@ METHOD(task_t, migrate, void,
 	this->proposals = NULL;
 	this->tsi = NULL;
 	this->tsr = NULL;
+	this->labels_i = NULL;
+	this->labels_r = NULL;
 	this->ke = NULL;
 	this->nonceg = NULL;
 	this->child_sa = NULL;


### PR DESCRIPTION
If a migrate of a child-create occurs then labels_i and labels_r are freed, but the pointers are left set. If the task is subsequently destroyed without being reused, then both of these will be double freed.

Fix this by setting labels_i and labels_r to NULL in the migrate method after freeing, similar to other fields that are freed.