### PR TITLE
init: put strongswan-starter.service behind USE_FILE_CONFIG

### DIFF
--- a/init/Makefile.am
+++ b/init/Makefile.am
@@ -3,7 +3,9 @@ SUBDIRS =
 
 if USE_LEGACY_SYSTEMD
 if USE_CHARON
+if USE_FILE_CONFIG
   SUBDIRS += systemd-starter
+endif
 endif
 endif
 


### PR DESCRIPTION
stroke is no longer enabled by default, but the systemd unit still is copied on `make install`. Fix that.