### PR TITLE
openssl: Require minimum version 3.0.0 for HKDF

### DIFF
--- a/src/libstrongswan/plugins/openssl/openssl_plugin.c
+++ b/src/libstrongswan/plugins/openssl/openssl_plugin.c
@@ -496,8 +496,10 @@ METHOD(plugin_t, get_features, int,
 			PLUGIN_PROVIDE(SIGNER, AUTH_HMAC_SHA2_512_256),
 			PLUGIN_PROVIDE(SIGNER, AUTH_HMAC_SHA2_512_512),
 #endif
-#if OPENSSL_VERSION_NUMBER >= 0x10101000L
-		/* HKDF is available since 1.1.0, expand-only mode only since 1.1.1 */
+#if OPENSSL_VERSION_NUMBER >= 0x30000000L
+		/* HKDF is available since 1.1.0, expand-only mode only since 1.1.1,
+		 * but 3.0.0 is required to support larger MODP groups and nonces
+		 * with its 2048 byte buffer size */
 		PLUGIN_REGISTER(KDF, openssl_kdf_create),
 			PLUGIN_PROVIDE(KDF, KDF_PRF),
 			PLUGIN_PROVIDE(KDF, KDF_PRF_PLUS),


### PR DESCRIPTION
Context: https://github.com/strongswan/strongswan/issues/1255

OpenSSL's HKDF can't process larger MODP groups and nonces with its 1024 byte buffer size in older versions. 3.0.0+ has a sufficient buffer size of 2048 bytes, so require it for OpenSSL's HKDF to be registered over strongSwan's KDF plugin. This will prevent issues during rekeys where a shared secret and nonces are concatenated to form a seed that may potentially be too large.