### PR TITLE
rfc/fix: tolerate non-default IPv4 IHLs

### DIFF
--- a/src/libcharon/plugins/dhcp/dhcp_socket.c
+++ b/src/libcharon/plugins/dhcp/dhcp_socket.c
@@ -720,24 +720,24 @@ dhcp_socket_t *dhcp_socket_create()
 	int on = 1, rcvbuf = 0;
 
 #if !defined(__APPLE__) && !defined(__FreeBSD__)
-	const size_t skip_ip4 = sizeof(struct iphdr);
-	const size_t skip_udp = skip_ip4 + sizeof(struct udphdr);
+	const size_t skip_udp = sizeof(struct udphdr);
 	struct sock_filter dhcp_filter_code[] = {
 		BPF_STMT(BPF_LD+BPF_B+BPF_ABS, offsetof(struct iphdr, protocol)),
-		BPF_JUMP(BPF_JMP+BPF_JEQ+BPF_K, IPPROTO_UDP, 0, 16),
-		BPF_STMT(BPF_LD+BPF_H+BPF_ABS, skip_ip4 + offsetof(struct udphdr, source)),
+		BPF_JUMP(BPF_JMP+BPF_JEQ+BPF_K, IPPROTO_UDP, 0, 17),
+		BPF_STMT(BPF_LDX+BPF_B+BPF_MSH, 0),
+		BPF_STMT(BPF_LD+BPF_H+BPF_IND, offsetof(struct udphdr, source)),
 		BPF_JUMP(BPF_JMP+BPF_JEQ+BPF_K, DHCP_SERVER_PORT, 0, 14),
-		BPF_STMT(BPF_LD+BPF_H+BPF_ABS, skip_ip4 + offsetof(struct udphdr, dest)),
+		BPF_STMT(BPF_LD+BPF_H+BPF_IND, offsetof(struct udphdr, dest)),
 		BPF_JUMP(BPF_JMP+BPF_JEQ+BPF_K, DHCP_CLIENT_PORT, 2, 0),
 		BPF_JUMP(BPF_JMP+BPF_JEQ+BPF_K, DHCP_SERVER_PORT, 1, 0),
 		BPF_JUMP(BPF_JMP+BPF_JA, 10, 0, 0),
-		BPF_STMT(BPF_LD+BPF_B+BPF_ABS, skip_udp + offsetof(dhcp_t, opcode)),
+		BPF_STMT(BPF_LD+BPF_B+BPF_IND, skip_udp + offsetof(dhcp_t, opcode)),
 		BPF_JUMP(BPF_JMP+BPF_JEQ+BPF_K, BOOTREPLY, 0, 8),
-		BPF_STMT(BPF_LD+BPF_B+BPF_ABS, skip_udp + offsetof(dhcp_t, hw_type)),
+		BPF_STMT(BPF_LD+BPF_B+BPF_IND, skip_udp + offsetof(dhcp_t, hw_type)),
 		BPF_JUMP(BPF_JMP+BPF_JEQ+BPF_K, ARPHRD_ETHER, 0, 6),
-		BPF_STMT(BPF_LD+BPF_B+BPF_ABS, skip_udp + offsetof(dhcp_t, hw_addr_len)),
+		BPF_STMT(BPF_LD+BPF_B+BPF_IND, skip_udp + offsetof(dhcp_t, hw_addr_len)),
 		BPF_JUMP(BPF_JMP+BPF_JEQ+BPF_K, 6, 0, 4),
-		BPF_STMT(BPF_LD+BPF_W+BPF_ABS, skip_udp + offsetof(dhcp_t, magic_cookie)),
+		BPF_STMT(BPF_LD+BPF_W+BPF_IND, skip_udp + offsetof(dhcp_t, magic_cookie)),
 		BPF_JUMP(BPF_JMP+BPF_JEQ+BPF_K, 0x63825363, 0, 2),
 		BPF_STMT(BPF_LD+BPF_W+BPF_LEN, 0),
 		BPF_STMT(BPF_RET+BPF_A, 0),


### PR DESCRIPTION
This modifies the eBPF to load the IPv4 Header Length field rather than relying on a fixed size. I used tcpdump BPF output as reference: 

```bash
$ tcpdump -d -i br-lan.xxxx ip and '((udp port 67) or (udp port 68))'
(000) ldh      [12]
(001) jeq      #0x800           jt 2    jf 14
(002) ldb      [23]
(003) jeq      #0x11            jt 4    jf 14
(004) ldh      [20]
(005) jset     #0x1fff          jt 14   jf 6
(006) ldxb     4*([14]&0xf)
(007) ldh      [x + 14]
(008) jeq      #0x43            jt 13   jf 9
(009) jeq      #0x44            jt 13   jf 10
(010) ldh      [x + 16]
(011) jeq      #0x43            jt 13   jf 12
(012) jeq      #0x44            jt 13   jf 14
(013) ret      #262144
(014) ret      #0
```

This loads the IHL into the index register and removes the iphdr length from all other subsequent offsets.

I haven't rewrote this for the non-Linux implementation however.

Discovered as part of openwrt/packages#25801