### PR TITLE
ikev2: Handle more error notifications after IKE_AUTH by deleting IKE_SA

### DIFF
--- a/src/libcharon/sa/ikev2/task_manager_v2.c
+++ b/src/libcharon/sa/ikev2/task_manager_v2.c
@@ -1269,6 +1269,7 @@ static status_t process_request(private_task_manager_t *this,
 									task = (task_t*)ike_auth_lifetime_create(
 															this->ike_sa, FALSE);
 									break;
+								case INVALID_SYNTAX:
 								case AUTHENTICATION_FAILED:
 									/* initiator failed to authenticate us.
 									 * We use ike_delete to handle this, which


### PR DESCRIPTION
When serving as a responder and receiving an INFORMATIONAL exchange containing INVALID_SYNTAX or UNSUPPORTED_CRITICAL_PAYLOAD right after IKE_AUTH, the IKE_SA should probably be deleted. Currently, it only gets deleted after receiving AUTHENTICATION_FAILED. RFC7296 section 2.21.2 says:

```
 In an IKE_AUTH exchange, or in the INFORMATIONAL exchange immediately
 following it (in case an error happened when processing a response to
 IKE_AUTH), the UNSUPPORTED_CRITICAL_PAYLOAD, INVALID_SYNTAX, and
 AUTHENTICATION_FAILED notifications are the only ones to cause the
 IKE SA to be deleted or not created, without a Delete payload.
```