### PR TITLE
Improve compatibility with Microsoft RAS service

### DIFF
--- a/src/libcharon/plugins/socket_default/socket_default_socket.c
+++ b/src/libcharon/plugins/socket_default/socket_default_socket.c
@@ -770,8 +770,7 @@ static int open_socket(private_socket_default_socket_t *this,
 	}
 
 	/* enable UDP decapsulation for NAT-T sockets */
-	if (port == &this->natt &&
-		!charon->kernel->enable_udp_decap(charon->kernel, skt, family,
+	if (!charon->kernel->enable_udp_decap(charon->kernel, skt, family,
 										  this->natt))
 	{
 		DBG1(DBG_NET, "enabling UDP decapsulation for %s on port %d failed",


### PR DESCRIPTION
Some Microsoft Windows RAS services behave erratically and send the ESP and IKE reply back to the UDP encapsulation port the initial IKE SA_INIT was sent from instead of the port used for IKE SA_AUTH later on.

tcpdump output:
```
IP <client-ip>.47547 > <server-ip>.4500: UDP-encap: ESP(spi=0xfd4e5fc2,seq=0x139b), length 116
IP <server-ip>.4500 > <client-ip>.57962: UDP-encap: ESP(spi=0xccc5e213,seq=0x21ff), length 196
```

For socket_dynamic, this was fixed by b3b74e4 Set UDP encapsulation option on all sockets in 2010, but socket_default has only set the UDP_ENCAP option for the NATT port since the very beginning in aaefeaf.

Improve compatibility by setting UDP_ENCAP unconditionally. This fixes the connectivity issue.