### PR TITLE
Float to NAT-T port early

### DIFF
--- a/src/libcharon/sa/ikev2/tasks/ike_natd.c
+++ b/src/libcharon/sa/ikev2/tasks/ike_natd.c
@@ -330,7 +330,7 @@ METHOD(task_t, build_i, status_t,
 {
 	notify_payload_t *notify;
 	ike_cfg_t *ike_cfg;
-	host_t *host;
+	host_t *host, *dst;
 
 	if (this->hasher == NULL)
 	{
@@ -339,6 +339,11 @@ METHOD(task_t, build_i, status_t,
 	}
 
 	ike_cfg = this->ike_sa->get_ike_cfg(this->ike_sa);
+	dst = message->get_destination(message);
+	if (dst->get_port(dst) != IKEV2_UDP_PORT)
+	{
+		this->ike_sa->float_ports(this->ike_sa);
+	}
 
 	host = message->get_source(message);
 	if (!host->is_anyaddr(host) || force_encap(ike_cfg))


### PR DESCRIPTION
With force_encap, some Microsoft Windows RAS services behave errneous and send the ESP packets and IKE AUTH reply back to IKE SA_INIT UDP encapsulation port used instead of the port used for IKE SA_AUTH later on.

tcpdump output:
```
IP <client-ip>.47547 > <server-ip>.4500: UDP-encap: ESP(spi=0xfd4e5fc2,seq=0x139b), length 116
IP <server-ip>.4500 > <client-ip>.57962: UDP-encap: ESP(spi=0xccc5e213,seq=0x21ff), length 196
```

Avoid this by floating early to the local nat-t port if force_encap is enabled.