### PR TITLE
vici: fix missing configuration payload - off-by-one error in ip pools

### DIFF
--- a/src/libcharon/plugins/vici/vici_attribute.c
+++ b/src/libcharon/plugins/vici/vici_attribute.c
@@ -258,7 +258,7 @@ static bool have_vips_from_pool(mem_pool_t *pool, linked_list_t *vips)
 		{
 			current = host->get_address(host);
 			if (chunk_compare(current, start) >= 0 &&
-				chunk_compare(current, end) < 0)
+				chunk_compare(current, end) <= 0)
 			{
 				found = TRUE;
 				break;


### PR DESCRIPTION
### System

- OS: e.g. Gentoo Linux
- strongSwan version(s): 5.7.2
- Tested/confirmed with latest version: not tested, but the issue is still in the master codebase

### Bug Description

During IKE_AUTH the configured configuration payload e.g. DNS server or net mask is not passed to the IKEv2 initiator (road warrior scenario) when the last IP address of an IP pool is assigned as virtual IP address.

The bug is located in the vici plugin which manages the configured IP pools. The plugin is registered as attribute provider to the charon and checks during the creation of an so called attribute enumerator, wether any of the assigned virtual IP addresses are inside of the configured IP pool(s) or not. This check calculates the start and end addresses of the IP pool and compares them with each assigned virtual IP address. The comparison does not take the end address into account. This patch will fix it, so that the end address is inclusive.

### To Reproduce

Given the following pool configuration in swanctl.conf:

```
pools {
  rw_pool {
    addrs = 10.10.1.0/30
    netmask = 255.255.255.252
    dns = 8.8.8.8, 8.8.4.4
  }
}
```

A first road warrior client receives the IP address 10.10.1.1 (first in the IP pool) and the internal netmask, DNS1, and DNS2 are successfully transmitted.

For a second road warrior client, the IP address 10.10.1.2 is assigned (last available IP address in the IP pool). Here, the netmask and DNS server information are missing in the IKE_AUTH response.

### Expected Behaviour

Netmask and DNS server information must be send in the IKE_AUTH response to both roadwarrior clients.

### Logs/Backtraces

The IKE_AUTH repsonse can be observed in the logs.

Correct response with netmask and DNS server:

`parsed IKE_AUTH response 1 [ IDr CERT AUTH CPRP(ADDR MASK DNS DNS) SA TSi TSr N(AUTH_LFT) ]`

Incorrect response, netmask and DNS server are missing:

`parsed IKE_AUTH response 1 [ IDr CERT AUTH CPRP(ADDR) SA TSi TSr N(AUTH_LFT) ]`

### Additional context

The error could be traced down to the following [line of code](https://github.com/strongswan/strongswan/blob/9d4decbde8e7538a84e1c425e96d84b248437ae1/src/libcharon/plugins/vici/vici_attribute.c#L261) and identified as follows:

`if (chunk_compare(current, start) >= 0 && chunk_compare(current, end) < 0)`

should be instead:

`if (chunk_compare(current, start) >= 0 && chunk_compare(current, end) <= 0)`