### PR TITLE
wolfssl FIPS: unlock the key when necessary

### DIFF
--- a/src/libstrongswan/plugins/wolfssl/wolfssl_ec_diffie_hellman.c
+++ b/src/libstrongswan/plugins/wolfssl/wolfssl_ec_diffie_hellman.c
@@ -219,6 +219,7 @@ METHOD(key_exchange_t, set_seed, bool,
 static bool compute_shared_key(private_wolfssl_ec_diffie_hellman_t *this)
 {
 	word32 len;
+	int ret;
 #ifdef USE_RNG_FOR_TIMING_RESISTANCE
 	WC_RNG rng;
 
@@ -237,8 +238,11 @@ static bool compute_shared_key(private_wolfssl_ec_diffie_hellman_t *this)
 	this->shared_secret = chunk_alloc(this->keysize);
 	len = this->shared_secret.len;
 
-	if (wc_ecc_shared_secret(&this->key, &this->pubkey, this->shared_secret.ptr,
-							 &len) != 0)
+	PRIVATE_KEY_UNLOCK();
+	ret = wc_ecc_shared_secret(&this->key, &this->pubkey,
+	        this->shared_secret.ptr, &len);
+	PRIVATE_KEY_LOCK();
+	if (ret != 0)
 	{
 		DBG1(DBG_LIB, "ECDH shared secret computation failed");
 		chunk_clear(&this->shared_secret);

--- a/src/libstrongswan/plugins/wolfssl/wolfssl_ec_private_key.c
+++ b/src/libstrongswan/plugins/wolfssl/wolfssl_ec_private_key.c
@@ -339,9 +339,15 @@ static private_wolfssl_ec_private_key_t *create_empty(void)
 		.ref = 1,
 	);
 
-	if (wc_InitRng(&this->rng) < 0)
+    if (wc_ecc_init(&this->ec) != 0) {
+        DBG1(DBG_LIB, "EC key init failed");
+        free(this);
+        return NULL;
+    }
+	if (wc_InitRng(&this->rng) != 0)
 	{
 		DBG1(DBG_LIB, "RNG init failed");
+        wc_ecc_free(&this->ec);
 		free(this);
 		return NULL;
 	}


### PR DESCRIPTION
Wrap the API that requires it in PRIVATE_KEY_UNLOCK/PRIVATE_KEY_LOCK. This can't be done at plugin initialization because it needs to be done for every thread. Strongswan doesn't have on thread creation callbacks for plugins so we need to wrap each direct call.

Tested with this. `test_threading.c` creates new threads so we are testing a cryptographic operation in a new thread. It fails with wolfSSL FIPS without this commit (with FIPS_PRIVATE_KEY_LOCKED_E).
```
diff --git a/src/libstrongswan/tests/suites/test_threading.c b/src/libstrongswan/tests/suites/test_threading.c
index cd0101a51..70fd15faf 100644
--- a/src/libstrongswan/tests/suites/test_threading.c
+++ b/src/libstrongswan/tests/suites/test_threading.c
@@ -546,6 +546,34 @@ static void *rwlock_run(refcount_t *refs)
        }

        rwlock->write_lock(rwlock);
+       {
+           key_exchange_t *a = NULL, *b = NULL;
+           u_char seed[96];
+           chunk_t a_priv, b_priv, a_pub, b_pub, a_sec, b_sec;
+           a_pub = b_pub = a_sec = b_sec = chunk_empty;
+           memset(seed, 12, sizeof(seed));
+           a = lib->crypto->create_ke(lib->crypto, MODP_2048_BIT);
+           ck_assert(a != NULL);
+           b = lib->crypto->create_ke(lib->crypto, MODP_2048_BIT);
+           ck_assert(b != NULL);
+        /* the seed is the concatenation of both DH private keys */
+        a_priv = chunk_create(seed, sizeof(seed)/2);
+        b_priv = chunk_create(seed + sizeof(seed)/2, sizeof(seed)/2);
+        ck_assert(a->set_seed(a, a_priv, NULL));
+        ck_assert(b->set_seed(b, b_priv, NULL));
+        ck_assert(a->get_public_key(a, &a_pub));
+        ck_assert(b->set_public_key(b, a_pub));
+        ck_assert(b->get_shared_secret(b, &b_sec));
+        ck_assert(b->get_public_key(b, &b_pub));
+        ck_assert(a->set_public_key(a, b_pub));
+        ck_assert(a->get_shared_secret(a, &a_sec));
+        DESTROY_IF(a);
+        DESTROY_IF(b);
+        chunk_free(&a_pub);
+        chunk_free(&b_pub);
+        chunk_free(&a_sec);
+        chunk_free(&b_sec);
+       }
        ck_assert_int_eq(*refs, 0);
        sched_yield();
        rwlock->unlock(rwlock);
```

Also contains a small fix for correct ecc initialization. This passes all tests when configured with `--enable-pki --enable-wolfssl --enable-pem --enable-pkcs1 --enable-pkcs8 --enable-x509 --enable-constraints --enable-test-vectors --disable-openssl`.