### PR TITLE
openssl: Fix AWS-LC build

### DIFF
--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -132,7 +132,7 @@ build_openssl()
 
 build_awslc()
 {
-	LC_REV=1.48.5
+	LC_REV=1.51.2
 	LC_PKG=aws-lc-$LC_REV
 	LC_DIR=$DEPS_BUILD_DIR/$LC_PKG
 	LC_SRC=https://github.com/aws/aws-lc/archive/refs/tags/v${LC_REV}.tar.gz

--- a/src/libstrongswan/plugins/openssl/openssl_crypter.c
+++ b/src/libstrongswan/plugins/openssl/openssl_crypter.c
@@ -102,7 +102,7 @@ static char* lookup_algorithm(uint16_t ikev2_algo, size_t *key_size)
 /**
  * Do the actual en/decryption in an EVP context
  */
-static bool crypt(private_openssl_crypter_t *this, chunk_t data, chunk_t iv,
+static bool crypt_data(private_openssl_crypter_t *this, chunk_t data, chunk_t iv,
 				  chunk_t *dst, int enc)
 {
 	EVP_CIPHER_CTX *ctx;
@@ -149,13 +149,13 @@ static bool crypt(private_openssl_crypter_t *this, chunk_t data, chunk_t iv,
 METHOD(crypter_t, decrypt, bool,
 	private_openssl_crypter_t *this, chunk_t data, chunk_t iv, chunk_t *dst)
 {
-	return crypt(this, data, iv, dst, 0);
+	return crypt_data(this, data, iv, dst, 0);
 }
 
 METHOD(crypter_t, encrypt, bool,
 	private_openssl_crypter_t *this, chunk_t data, chunk_t iv, chunk_t *dst)
 {
-	return crypt(this, data, iv, dst, 1);
+	return crypt_data(this, data, iv, dst, 1);
 }
 
 METHOD(crypter_t, get_block_size, size_t,


### PR DESCRIPTION
The `crypt` function defined in `openssl_crypter.c` conflicts with the `crypt` function defined in `unistd.h` and triggers a compilation error when building against the latest version of AWS-LC. This [PR](https://github.com/aws/aws-lc/pull/2321) introduced the new transitive of `unistd.h` include to `bio.h`.

This PR simply renames the function to avoid the error. There are identically named `crypt` functions in similar source files like `openssl_aead`. I did not rename things exhaustively, if that's preferred I can do that just let me know.