### PR TITLE
openssl: Init salt for KDF check too

### DIFF
--- a/src/libstrongswan/plugins/openssl/openssl_kdf.c
+++ b/src/libstrongswan/plugins/openssl/openssl_kdf.c
@@ -199,6 +199,7 @@ kdf_t *openssl_kdf_create(key_derivation_function_t algo, va_list args)
 		/* use a lengthy key to test the implementation below to make sure the
 		 * algorithms are usable, see openssl_hmac.c for details */
 		.key = chunk_clone(chunk_from_str("00000000000000000000000000000000")),
+		.salt = chunk_clone(chunk_from_str("0000000000000000")),
 	);
 
 	if (!this->hasher ||


### PR DESCRIPTION
Fixes

charon: 11[IKE] KDF_PRF with PRF_HMAC_SHA2_256 not supported
charon: 11[IKE] key derivation failed

during IKE handshake and

charon: 00[LIB] enabled  KDF_PRF[openssl]: unable to apply any available test vectors

during running the test vectors from the test vector plugin.