### PR TITLE
whitelist: doubling the id length

### DIFF
--- a/src/libcharon/plugins/whitelist/whitelist_msg.h
+++ b/src/libcharon/plugins/whitelist/whitelist_msg.h
@@ -53,7 +53,7 @@ struct whitelist_msg_t {
 	/** message type */
 	int type;
 	/** null terminated identity */
-	char id[128];
+	char id[256];
 } __attribute__((packed));
 
 #endif /** WHITELIST_MSG_H_ @}*/


### PR DESCRIPTION
Hello!

I've recently run into a situation where it's very likely that the current 128 bytes limit on whitelist id field might not be sufficient.

As an internal logic dictates that I have to deal with automatically generated certs with its subject attributes being something similar to:
C=KR,ST=Seoul,O=Some Alien Institution,OU=Area 51,CN=some user identification hex string
where CN hexstring could extend to maximum 64 bytes, which makes it 128 characters for CN value alone.

Would it be okay to double it?