### PR TITLE
ml: disable versioning for shared object

### DIFF
--- a/src/libstrongswan/plugins/ml/Makefile.am
+++ b/src/libstrongswan/plugins/ml/Makefile.am
@@ -17,3 +17,5 @@ libstrongswan_ml_la_SOURCES = \
 	ml_plugin.h ml_plugin.c \
 	ml_poly.c ml_poly.h \
 	ml_utils.c ml_utils.h
+
+libstrongswan_ml_la_LDFLAGS = -module -avoid-version


### PR DESCRIPTION
Avoid generating versioned shared objects which would need to be installed along with the version-independent symlink by specifying "-avoid-version" in the libtool LDFLAGS for the plugin. Avoid any unwanted surprises by also specifying the "-module" option, making the LDFLAGS consistent with all other libstrongswan plugins.