### PR TITLE
list-conns: Include local and remote ports

### DIFF
--- a/src/libcharon/plugins/vici/README.md
+++ b/src/libcharon/plugins/vici/README.md
@@ -882,6 +882,8 @@ _list-conns_ command.
 			remote_addrs = [
 				<list of valid remote IKE endpoint addresses>
 			]
+			local_port = <local IKE endpoint port>
+			remote_port = <remote IKE endpoint port>
 			version = <IKE version as string, IKEv1|IKEv2 or 0 for any>
 			reauth_time = <IKE_SA reauthentication interval in seconds>
 			rekey_time = <IKE_SA rekeying interval in seconds>

--- a/src/libcharon/plugins/vici/vici_query.c
+++ b/src/libcharon/plugins/vici/vici_query.c
@@ -956,6 +956,11 @@ CALLBACK(list_conns, vici_message_t*,
 		tokens->destroy(tokens);
 		b->end_list(b);
 
+		b->add_kv(b, "local_port", "%u",
+			ike_cfg->get_my_port(ike_cfg));
+		b->add_kv(b, "remote_port", "%u",
+			ike_cfg->get_other_port(ike_cfg));
+
 		b->add_kv(b, "version", "%N", ike_version_names,
 			peer_cfg->get_ike_version(peer_cfg));
 		b->add_kv(b, "reauth_time", "%u",

--- a/src/swanctl/commands/list_conns.c
+++ b/src/swanctl/commands/list_conns.c
@@ -223,17 +223,17 @@ CALLBACK(conn_sn, int,
 }
 
 CALLBACK(conn_list, int,
-	hashtable_t *sa, vici_res_t *res, char *name, void *value, int len)
+	hashtable_t *ike, vici_res_t *res, char *name, void *value, int len)
 {
 	if (chunk_printable(chunk_create(value, len), NULL, ' '))
 	{
 		if (streq(name, "local_addrs"))
 		{
-			printf("  local:  %.*s\n", len, value);
+			printf("  local:  %.*s[%s]\n", len, value, ike->get(ike, "local_port"));
 		}
 		if (streq(name, "remote_addrs"))
 		{
-			printf("  remote: %.*s\n", len, value);
+			printf("  remote: %.*s[%s]\n", len, value, ike->get(ike, "remote_port"));
 		}
 	}
 	return 0;
@@ -243,16 +243,20 @@ CALLBACK(conns, int,
 	void *null, vici_res_t *res, char *name)
 {
 	int ret;
-	char *version, *reauth_time, *rekey_time, *dpd_delay, *ppk_id, *ppk_req;
+	char *version, *reauth_time, *rekey_time, *dpd_delay, *ppk_id, *ppk_req, *local_port, *remote_port;
 	hashtable_t *ike;
 
 	version     = vici_find_str(res, "", "%s.version", name);
 	reauth_time = vici_find_str(res, "0", "%s.reauth_time", name);
 	rekey_time  = vici_find_str(res, "0", "%s.rekey_time", name);
 	dpd_delay   = vici_find_str(res, "0", "%s.dpd_delay", name);
+	local_port  = vici_find_str(res, "0", "%s.local_port", name);
+	remote_port = vici_find_str(res, "0", "%s.remote_port", name);
 
 	ike = hashtable_create(hashtable_hash_str, hashtable_equals_str, 1);
 	free(ike->put(ike,"dpd_delay", strdup(dpd_delay)));
+	free(ike->put(ike,"local_port", strdup(local_port)));
+	free(ike->put(ike,"remote_port", strdup(remote_port)));
 
 	printf("%s: %s, ", name, version);
 	if (streq(version, "IKEv1"))


### PR DESCRIPTION
In order to get the **configured** local and remote ports for a connection, which may differ from the actually used ports in the SA, they need to be exposed in the `list-conns` data.

This PR adds these items from the connection in the `vici` plugin and `swanctl` output.

The output of `swanctl --list-conns` will include them in square brackets with the local and remote addresses:
```
  local:  10.133.2.1[4500]
  remote: 10.133.6.2[4500]
```