### PR TITLE
Prevent DNS resolution for mismatched %any4/%any6 macros (fixes #2880)

### DIFF
--- a/src/libstrongswan/networking/host.c
+++ b/src/libstrongswan/networking/host.c
@@ -460,7 +460,14 @@ host_t *host_create_from_dns(char *string, int af, uint16_t port)
 {
 	host_t *this;
 
-	this = host_create_from_string_and_family(string, af, port);
+	if ((af == AF_INET && streq(string, "%any6")) ||
+ 	   (af == AF_INET6 && streq(string, "%any4")))
+	{
+    		return NULL;
+	} else
+	{
+		this = host_create_from_string_and_family(string, af, port);
+	}
 	if (!this)
 	{
 		this = lib->hosts->resolve(lib->hosts, string, af);


### PR DESCRIPTION
This PR adds a check in host_create_from_dns() to skip host creation and DNS resolution for %any4/%any6 macros when the address family does not match. This prevents unnecessary DNS lookups and log noise.