### PR TITLE
Update ipsec_sa_mgr.c

### DIFF
--- a/src/libipsec/ipsec_sa_mgr.c
+++ b/src/libipsec/ipsec_sa_mgr.c
@@ -228,6 +228,7 @@ static bool wait_for_entry(private_ipsec_sa_mgr_t *this,
 	if (entry->awaits_deletion)
 	{
 		/* others may still be waiting, */
+		entry->locked = FALSE;
 		entry->condvar->signal(entry->condvar);
 		return FALSE;
 	}


### PR DESCRIPTION
reset entry locked flag before signaling the condition var, fix potential dead lock when deleting child_sa