### PR TITLE
credential-manage: fix leaked signature params

### DIFF
--- a/src/libstrongswan/credentials/credential_manager.c
+++ b/src/libstrongswan/credentials/credential_manager.c
@@ -788,6 +788,7 @@ static bool verify_trust_chain(private_credential_manager_t *this,
 					DBG1(DBG_CFG, "  self-signed certificate \"%Y\" is not "
 						 "trusted", current->get_subject(current));
 					issuer->destroy(issuer);
+					signature_params_destroy(scheme);
 					call_hook(this, CRED_HOOK_UNTRUSTED_ROOT, current);
 					break;
 				}


### PR DESCRIPTION
A cloned `signature_params_t` structure was not destroyed when not added to the authentication.