### PR TITLE
trap-manager: Use latest seq when creating an acquire entry

### DIFF
--- a/src/libcharon/sa/trap_manager.c
+++ b/src/libcharon/sa/trap_manager.c
@@ -579,12 +579,12 @@ METHOD(trap_manager_t, acquire, void,
 	}
 	if (!acquire)
 	{
+		seq = data->seq = data->seq ?: ref_get_nonzero(&this->acquire_seq);
 		INIT(acquire,
 			.dst = host,
 			.reqid = reqid,
 			.data = kernel_acquire_data_clone(data),
 		);
-		seq = data->seq = data->seq ?: ref_get_nonzero(&this->acquire_seq);
 		this->acquires->insert_last(this->acquires, acquire);
 	}
 	else if (data->seq && data->seq != acquire->data->seq)


### PR DESCRIPTION
When using PFKey and receiving an acquire, `data->seq` is set to `0` and a non-zero reference is fetched as a sequence number. However the fetch is done after cloning `data` leading to the sequence number within the new acquire entry to be `0`. Later when `complete()` is called, the acquire is not found by its sequence number leading to a growing number of stale acquire entries.