### PR TITLE
OSS-Fuzz: Add new fuzzer targeting libipsec implementation

### DIFF
--- a/fuzz/.gitignore
+++ b/fuzz/.gitignore
@@ -1,5 +1,6 @@
 fuzz_certs
 fuzz_crls
+fuzz_esp
 fuzz_ids
 fuzz_ike
 fuzz_ocsp_req

--- a/fuzz/Makefile.am
+++ b/fuzz/Makefile.am
@@ -1,6 +1,7 @@
 AM_CPPFLAGS = @CPPFLAGS@ \
 	@FUZZING_CFLAGS@ \
 	-I$(top_srcdir)/src/libcharon \
+	-I$(top_srcdir)/src/libipsec \
 	-I$(top_srcdir)/src/libstrongswan \
 	-I$(top_srcdir)/src/libimcv \
 	-I$(top_srcdir)/src/libtncif \
@@ -32,8 +33,12 @@ ike_ldflags = \
 	$(top_builddir)/src/libradius/.libs/libradius.a \
 	$(fuzz_ldflags)
 
+esp_ldflags = \
+	$(top_builddir)/src/libipsec/.libs/libipsec.a \
+	$(fuzz_ldflags)
+
 FUZZ_TARGETS=fuzz_certs fuzz_crls fuzz_ocsp_req fuzz_ocsp_rsp \
-	fuzz_ids fuzz_pa_tnc fuzz_pb_tnc fuzz_ike
+	fuzz_ids fuzz_pa_tnc fuzz_pb_tnc fuzz_ike fuzz_esp
 
 all-local: $(FUZZ_TARGETS)
 
@@ -62,6 +67,9 @@ fuzz_pb_tnc: fuzz_pb_tnc.c ${libfuzzer}
 
 fuzz_ike: fuzz_ike.c ${libfuzzer}
 	$(CC) $(AM_CPPFLAGS) $(CFLAGS) -o $@ $< $(ike_ldflags)
+
+fuzz_esp: fuzz_esp.c ${libfuzzer}
+	$(CC) $(AM_CPPFLAGS) $(CFLAGS) -o $@ $< $(esp_ldflags)
 
 noinst_LIBRARIES = libFuzzerLocal.a
 libFuzzerLocal_a_SOURCES = libFuzzerLocal.c

--- a/fuzz/fuzz_esp.c
+++ b/fuzz/fuzz_esp.c
@@ -1,0 +1,116 @@
+/*
+ * Copyright (C) 2026 Arthur SC Chan
+ *
+ * Copyright (C) secunet Security Networks AG
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation; either version 2 of the License, or (at your
+ * option) any later version.  See <http://www.fsf.org/copyleft/gpl.txt>.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * for more details.
+ */
+
+#include <library.h>
+#include <ipsec.h>
+#include <esp_packet.h>
+#include <esp_context.h>
+#include <ip_packet.h>
+#include <networking/packet.h>
+#include <networking/host.h>
+
+int LLVMFuzzerInitialize(int *argc, char ***argv)
+{
+	dbg_default_set_level(-1);
+	library_init(NULL, "fuzz_esp");
+	libipsec_init();
+
+	if (!lib->plugins->load(lib->plugins, PLUGINS))
+	{
+		return 1;
+	}
+
+	return 0;
+}
+
+int LLVMFuzzerTestOneInput(const uint8_t *buf, size_t len)
+{
+	esp_packet_t *esp_packet;
+	esp_context_t *esp_ctx_out, *esp_ctx_in;
+	ip_packet_t *plaintext_ip;
+	host_t *src, *dst;
+	uint32_t spi = htonl(0x12345678);
+	chunk_t fixed_enc_key, fixed_int_key;
+
+	/* Fixed encryption key (not from fuzzer input) */
+	fixed_enc_key = chunk_from_chars(
+		0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
+		0x08, 0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F);
+
+	/* Fixed integrity key (not from fuzzer input) */
+	fixed_int_key = chunk_from_chars(
+		0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17,
+		0x18, 0x19, 0x1A, 0x1B, 0x1C, 0x1D, 0x1E, 0x1F);
+
+	/* Create IP packet from fuzzer input (plaintext to encrypt) */
+	plaintext_ip = ip_packet_create(chunk_clone(chunk_create((u_char*)buf, len)));
+	if (!plaintext_ip)
+	{
+		return 0;
+	}
+
+	/* Create hosts for ESP packet */
+	src = host_create_from_string("192.0.2.1", 4500);
+	dst = host_create_from_string("192.0.2.2", 4500);
+
+	/* Create ESP packet from plaintext payload */
+	esp_packet = esp_packet_create_from_payload(src, dst, plaintext_ip);
+	if (!esp_packet)
+	{
+		src->destroy(src);
+		dst->destroy(dst);
+		return 0;
+	}
+
+	/* Create outbound ESP context */
+	esp_ctx_out = esp_context_create(ENCR_AES_CBC, fixed_enc_key,
+									  AUTH_HMAC_SHA2_256_128, fixed_int_key, FALSE);
+	if (!esp_ctx_out)
+	{
+		esp_packet->destroy(esp_packet);
+		src->destroy(src);
+		dst->destroy(dst);
+		return 0;
+	}
+
+	/* Encrypt to create valid ESP packet */
+	if (esp_packet->encrypt(esp_packet, esp_ctx_out, spi) == SUCCESS)
+	{
+		/* Create inbound ESP context */
+		esp_ctx_in = esp_context_create(ENCR_AES_CBC, fixed_enc_key,
+										 AUTH_HMAC_SHA2_256_128, fixed_int_key, TRUE);
+		if (esp_ctx_in)
+		{
+			/* Decrypt and parse */
+			if (esp_packet->decrypt(esp_packet, esp_ctx_in) == SUCCESS)
+			{
+				/* Access next header after decryption */
+				esp_packet->get_next_header(esp_packet);
+			}
+
+			esp_ctx_in->destroy(esp_ctx_in);
+		}
+	}
+
+	/* Cleanup */
+	esp_ctx_out->destroy(esp_ctx_out);
+	esp_packet->destroy(esp_packet);
+	src->destroy(src);
+	dst->destroy(dst);
+
+	return 0;
+}
+

--- a/fuzz/fuzz_esp.c
+++ b/fuzz/fuzz_esp.c
@@ -66,7 +66,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *buf, size_t len)
 	src = host_create_from_string("192.0.2.1", 4500);
 	dst = host_create_from_string("192.0.2.2", 4500);
 
-	/* Create ESP packet from plaintext payload */
+	/* Create ESP packet from plaintext payload (takes ownership of src/dst) */
 	esp_packet = esp_packet_create_from_payload(src, dst, plaintext_ip);
 	if (!esp_packet)
 	{
@@ -81,8 +81,6 @@ int LLVMFuzzerTestOneInput(const uint8_t *buf, size_t len)
 	if (!esp_ctx_out)
 	{
 		esp_packet->destroy(esp_packet);
-		src->destroy(src);
-		dst->destroy(dst);
 		return 0;
 	}
 
@@ -108,8 +106,6 @@ int LLVMFuzzerTestOneInput(const uint8_t *buf, size_t len)
 	/* Cleanup */
 	esp_ctx_out->destroy(esp_ctx_out);
 	esp_packet->destroy(esp_packet);
-	src->destroy(src);
-	dst->destroy(dst);
 
 	return 0;
 }

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -432,7 +432,7 @@ freebsd)
 fuzzing)
 	CFLAGS="$CFLAGS -DNO_CHECK_MEMWIPE"
 	CONFIG="--enable-fuzzing --enable-static --disable-shared --disable-scripts
-			--enable-imc-test --enable-tnccs-20 --enable-eap-radius"
+			--enable-imc-test --enable-tnccs-20 --enable-eap-radius --enable-libipsec"
 	# don't run any of the unit tests
 	export TESTS_RUNNERS=
 	# prepare corpora


### PR DESCRIPTION
This PR adds a new fuzzer targeting libipsec esp implementation. This PR also fixes `script/test.sh` to enable libipsec for the new fuzzer build.

Remark: This is the second in a series of PRs intended to expand fuzzing coverage for the StrongSwan project. Subsequent PRs will continue to address further coverage gaps and enhance fuzzing effectiveness, thereby improving the detection of issues across the codebase.