### PR TITLE
Support remote-psk option for charon-nm.

### DIFF
--- a/src/charon-nm/nm/nm_creds.h
+++ b/src/charon-nm/nm/nm_creds.h
@@ -74,6 +74,14 @@ struct nm_creds_t {
 	void (*set_pin)(nm_creds_t *this, chunk_t keyid, char *pin);
 
 	/**
+	 * Set the pre-shared key for remote peer authentication.
+	 *
+	 * @param id		ID of the remote peer
+	 * @param psk		pre-shared key
+	 */
+	void (*set_remote_psk)(nm_creds_t *this, identification_t *id, char *psk);
+
+	/**
 	 * Set the certificate and private key to use for client authentication.
 	 *
 	 * @param cert		client certificate


### PR DESCRIPTION
NetworkManager .nmconnection profiles can now contain a "remote-psk" option, which, if set to some non-empty password/key, configures a preshared key to use to authenticate the gateway independently of the client authentication.

Consider this plain strongswan/charon configuration:

```
  connections {
 
    swivpn {
      remote_addrs = 1.2.3.4
      vips = 0.0.0.0
 
      local {   
        auth = eap-mschapv2
        eap_id = phip
      }
      remote {    
        auth = psk
        id = 1.2.3.4
      }
      children {
        swivpn {
          remote_ts  = 0.0.0.0/0  
          start_action = start   
        }  
      }  
    }  
  }  
 
  secrets {
    ike-swivpn {
      id = 1.2.3.4
      secret = TheVPNPSK
    }
    eap-phip { 
      id = phip
      secret = "TheUserPassword"
    }
  }
```

Local (client) authentication is done using EAP-MSCHAPv2, while the gateway is authenticated using a preshared key (PSK). This PR allows the same configuration to be used with a NetworkManager profile. The matching `/etc/NetworkManager/system-connections/swivpn.nmconnection` would look like:

```
[connection]
id=swivpn
uuid=aaa-bbb-ccc
type=vpn

[vpn]
address=1.2.3.4
encap=yes
ipcomp=no
remote-psk=TheVPNPSK
method=eap
password-flags=0
proposal=no
user=phip
virtual=yes
service-type=org.freedesktop.NetworkManager.strongswan

[vpn-secrets]
password=TheUserPassword

[ipv4]
method=auto

[ipv6]
addr-gen-mode=default
method=auto

[proxy]
```

Please note that this PR *only adds support to charon-nm* to process such extended profile files. It does *not add an option to the GUI to graphically create such a profile*.

I made this extension based on an immediate need by myself, so it is a rather rigid solution. I'd also be happy to see something more flexible implemented, as other people might have different requirements for asymmetric authentication. This change only supports the case of a PSK for the gateway and some (other) authentication for the client/user/roadwarrior, which is the default on FortiGate firewalls for their FortiClient software. See also this discussion: https://github.com/strongswan/strongswan/discussions/3000

Side note: An initial version of this update was generated using an AI tool, with subsequent review and refinement. This process allowed me to implement the change much more quickly than if I first needed to go through the whole source code to find the right spots to change.