### PR TITLE
utils/string.c: fix -Werror=discarded-qualifiers with GCC 15

### DIFF
--- a/src/libstrongswan/utils/utils/string.c
+++ b/src/libstrongswan/utils/utils/string.c
@@ -29,7 +29,7 @@ char* translate(char *str, const char *from, const char *to)
 	}
 	while (pos && *pos)
 	{
-		char *match;
+		const char *match;
 		if ((match = strchr(from, *pos)) != NULL)
 		{
 			*pos = to[match - from];
@@ -70,7 +70,7 @@ char* strreplace(const char *str, const char *search, const char *replace)
 	{
 		len = strlen(str);
 	}
-	found = strstr(str, search);
+	found = (char*)strstr(str, search);
 	if (!found)
 	{
 		return (char*)str;
@@ -86,7 +86,7 @@ char* strreplace(const char *str, const char *search, const char *replace)
 		dst += rlen;
 		pos = found + slen;
 	}
-	while ((found = strstr(pos, search)));
+	while ((found = (char*)strstr(pos, search)));
 	strcpy(dst, pos);
 	return res;
 }


### PR DESCRIPTION
## Problem

GCC 15 tightened its built-in declarations for `strchr()` and `strstr()` so
that the return type propagates `const` from the first argument. This causes
`-Werror=discarded-qualifiers` on three assignments in
`src/libstrongswan/utils/utils/string.c`.

## Changes

**`translate()`** — `match` is assigned from `strchr(from, *pos)` where `from`
is `const char *`, so `strchr()` now returns `const char *`. Since `match` is
only used for pointer arithmetic (`match - from`), declaring it `const char *`
is correct and safe.

**`strreplace()`** — `found` is assigned from `strstr()` twice (lines ~73 and
~89). The first argument in both cases derives from a `const char *` parameter,
so `strstr()` now returns `const char *`. Adding an explicit `(char*)` cast
matches the established pattern already used throughout the rest of the
function (e.g. lines 52, 58, 65, 79).

## Testing

Verified that these fixes eliminate all `-Werror=discarded-qualifiers` errors
on GCC 15 (Wolfi/Chainguard Linux) while building strongSwan 6.0.4 with
`-Werror`.