### PR TITLE
fix: null dereference in asn1_build_object() when malloc fails

### DIFF
--- a/src/libstrongswan/asn1/asn1.c
+++ b/src/libstrongswan/asn1/asn1.c
@@ -790,6 +790,11 @@ u_char* asn1_build_object(chunk_t *object, asn1_t type, size_t datalen)
 	/* allocate memory for the asn.1 TLV object */
 	object->len = 1 + length.len + datalen;
 	object->ptr = malloc(object->len);
+	if (!object->ptr)
+	{
+		*object = chunk_empty;
+		return NULL;
+	}
 
 	/* set position pointer at the start of the object */
 	pos = object->ptr;


### PR DESCRIPTION
malloc() return value was not checked. If allocation fails, pos is set to NULL and the subsequent *pos++ = type dereferences it, crashing the process.

Added a null check that sets the object to chunk_empty and returns NULL on allocation failure.