### PR TITLE
xauth-generic: add XAUTH_PASSCODE fall-through to XAUTH_NEXT_PIN

### DIFF
--- a/src/libcharon/plugins/xauth_generic/xauth_generic.c
+++ b/src/libcharon/plugins/xauth_generic/xauth_generic.c
@@ -84,6 +84,7 @@ METHOD(xauth_method_t, process_peer, status_t,
 							PLV1_CONFIGURATION_ATTRIBUTE, XAUTH_USER_NAME,
 							this->peer->get_encoding(this->peer)));
 				break;
+			case XAUTH_PASSCODE:
 			case XAUTH_NEXT_PIN:
 				type = SHARED_PIN;
 				/* FALL */


### PR DESCRIPTION
`xauth-generic`'s peer side silently returns an empty `CFG_REPLY` when the server issues a `CPRQ` that contains an `XAUTH_PASSCODE` (IANA class/type 16522) attribute, because `process_peer()` only knows about `XAUTH_USER_PASSWORD` (16521) and `XAUTH_NEXT_PIN` (16527). Any other attribute falls through to `default: break;`.

FortiGate dialup VPNs rely on `XAUTH_PASSCODE` to deliver a dynamic *Email Code* (or FortiToken value) after the permanent password has been validated. Since strongSwan answers with no `XAUTH_PASSCODE` attribute, the FortiGate tears the IKE_SA down with a DELETE after retransmits.

## Change

Add `case XAUTH_PASSCODE:` as a fall-through to `case XAUTH_NEXT_PIN:` so the shared-key lookup uses `SHARED_PIN`. This mirrors how upstream already treats `NEXT_PIN` and makes `charon-cmd`'s credential callback prompt the user (`PIN:`) for a fresh value, rather than returning the cached `SHARED_EAP` password from the previous round.

```diff
@@ -84,6 +84,7 @@ METHOD(xauth_method_t, process_peer, status_t,
 						PLV1_CONFIGURATION_ATTRIBUTE, XAUTH_USER_NAME,
 						this->peer->get_encoding(this->peer)));
 				break;
+			case XAUTH_PASSCODE:
 			case XAUTH_NEXT_PIN:
 				type = SHARED_PIN;
 				/* FALL */
```

## Scope

- Single-line addition to the peer path. Server path and all existing attribute handling are untouched.
- No new dependencies, no config changes, no user-visible behaviour change for existing PSK/XAuth deployments without 2FA.
- `SHARED_PIN` is a distinct credential namespace from `SHARED_EAP`, which is essential here: without this, any cached response from the first XAuth round would be re-sent for the PASSCODE round.

## Test setup

- Fedora 43, strongSwan 6.0.2 (Fedora's RPM with only this plugin rebuilt from source and dropped in `/usr/lib64/strongswan/plugins/`).
- FortiGate dialup in *Aggressive Mode* + `aes128-sha1-modp1536` for both IKE and ESP, PSK + XAuth + Email Code.
- Client tool: `charon-cmd --profile ikev1-xauth-psk-am`.

### Observed exchange (without the patch)

```
parsed TRANSACTION request [ HASH CPRQ(X_TYPE X_CODE X_MSG) ]
XAuth message: Email Code
generating TRANSACTION response [ HASH CP ]        ← empty, no attrs
peer did not initiate expected exchange, reestablishing IKE_SA
```

### Observed exchange (with the patch)

```
parsed TRANSACTION request [ HASH CPRQ(X_TYPE X_CODE X_MSG) ]
XAuth message: Email Code
PIN:                                               ← interactive prompt
generating TRANSACTION response [ HASH CPRP(X_CODE) ]
parsed TRANSACTION request [ HASH CPS(X_STATUS) ]
XAuth authentication of '<user>' (myself) successful
CHILD_SA cmd{1} established with SPIs ... and TS VIP/32 === <subnet>
```

## Compatibility

Verified on two additional FortiGate deployments that do **not** use the PASSCODE challenge (classic PSK + XAuth only): behaviour is identical to the unpatched plugin, since `XAUTH_PASSCODE` never appears in the request.

## CLA

I'll sign the strongSwan CLA as soon as the bot requests it.
