### PR TITLE
vici: Include proposals in connection listings

### DIFF
--- a/src/libcharon/plugins/vici/README.md
+++ b/src/libcharon/plugins/vici/README.md
@@ -893,6 +893,9 @@ _list-conns_ command.
 			version = <IKE version as string, IKEv1|IKEv2 or 0 for any>
 			reauth_time = <IKE_SA reauthentication interval in seconds>
 			rekey_time = <IKE_SA rekeying interval in seconds>
+			proposals = [
+				<list of configured IKE proposals>
+			]
 
 			local*, remote* = { # multiple local and remote auth sections
 				class = <authentication type>
@@ -921,6 +924,12 @@ _list-conns_ command.
 					rekey_time = <CHILD_SA rekeying interval in seconds>
 					rekey_bytes = <CHILD_SA rekeying interval in bytes>
 					rekey_packets = <CHILD_SA rekeying interval in packets>
+					esp_proposals = [
+						<list of configured ESP proposals>
+					]
+					ah_proposals = [
+						<list of configured AH proposals>
+					]
 					local-ts = [
 						<list of local traffic selectors>
 					]

--- a/src/libcharon/plugins/vici/vici_query.c
+++ b/src/libcharon/plugins/vici/vici_query.c
@@ -209,6 +209,29 @@ static void list_label(vici_builder_t *b, child_sa_t *child, child_cfg_t *cfg)
 }
 
 /**
+ * List proposals for a config
+ */
+static void list_proposals(vici_builder_t *b, linked_list_t *proposals,
+						   char *label, protocol_id_t protocol)
+{
+	enumerator_t *enumerator;
+	proposal_t *proposal;
+
+	b->begin_list(b, label);
+	enumerator = proposals->create_enumerator(proposals);
+	while (enumerator->enumerate(enumerator, &proposal))
+	{
+		if (protocol == PROTO_NONE ||
+			proposal->get_protocol(proposal) == protocol)
+		{
+			b->add_li(b, "%P", proposal);
+		}
+	}
+	enumerator->destroy(enumerator);
+	b->end_list(b);
+}
+
+/**
  * List additional key exchanges
  */
 static void list_ake(vici_builder_t *b, proposal_t *proposal)
@@ -1006,6 +1029,10 @@ CALLBACK(list_conns, vici_message_t*,
 		b->add_kv(b, "unique", "%N", unique_policy_names,
 				  peer_cfg->get_unique_policy(peer_cfg));
 
+		list = ike_cfg->get_proposals(ike_cfg);
+		list_proposals(b, list, "proposals", PROTO_NONE);
+		list->destroy_offset(list, offsetof(proposal_t, destroy));
+
 		dpd_delay = peer_cfg->get_dpd(peer_cfg);
 		if (dpd_delay)
 		{
@@ -1051,6 +1078,11 @@ CALLBACK(list_conns, vici_message_t*,
 					  child_cfg->get_dpd_action(child_cfg));
 			b->add_kv(b, "close_action", "%N", action_names,
 					  child_cfg->get_close_action(child_cfg));
+
+			list = child_cfg->get_proposals(child_cfg, FALSE);
+			list_proposals(b, list, "esp_proposals", PROTO_ESP);
+			list_proposals(b, list, "ah_proposals", PROTO_AH);
+			list->destroy_offset(list, offsetof(proposal_t, destroy));
 
 			b->begin_list(b, "local-ts");
 			list = child_cfg->get_traffic_selectors(child_cfg, TRUE, NULL);


### PR DESCRIPTION
## Summary
This adds configured proposal output to VICI `list-conns` / `list-conn` responses.

Our workflow validates received configuration by comparing it with the runtime configuration that was already committed to VICI via `load-conn`. Previously, fields such as IKE `proposals` and child `esp_proposals` / `ah_proposals` could be provided to VICI, but could not be read back from the connection listing API.

With this change, the information submitted through VICI can also be retrieved through VICI, making round-trip config validation possible.

## Changes
- Emit IKE `proposals` in `list-conn` output.
- Emit child `esp_proposals` and `ah_proposals` in `list-conn` output.
- Document the new fields in the VICI README.

## Note
Any feedback is appreciated. I have compiled and tested this locally to the best of my ability.

Looking at the contributing guidelines, I expect a bot will tell me how to proceed with the signed CLA.