### PR TITLE
OSS-Fuzz: Add fuzzer targets ssh key parsing

### DIFF
--- a/fuzz/.gitignore
+++ b/fuzz/.gitignore
@@ -11,5 +11,7 @@ fuzz_ocsp_rsp_def
 fuzz_pa_tnc
 fuzz_pb_tnc
 fuzz_radius
+fuzz_sshkey_cus
+fuzz_sshkey_def
 fuzz_tls
 fuzz_vici

--- a/fuzz/Makefile.am
+++ b/fuzz/Makefile.am
@@ -54,7 +54,7 @@ tls_ldflags = \
 
 # fuzzers that use crypto plugins in a significant way
 fuzzers_with_plugins = \
-	fuzz_certs fuzz_crls fuzz_ocsp_req fuzz_ocsp_rsp
+	fuzz_certs fuzz_crls fuzz_ocsp_req fuzz_ocsp_rsp fuzz_sshkey
 
 fuzzers_with_def = $(fuzzers_with_plugins:%=%_def)
 fuzzers_with_cus = $(fuzzers_with_plugins:%=%_cus)
@@ -90,6 +90,12 @@ fuzz_ocsp_rsp_def: fuzz_ocsp_rsp.c ${libfuzzer}
 	$(CC) $(fuzz_cppflags_def) $(CFLAGS) -o $@ $< $(fuzz_ldflags)
 
 fuzz_ocsp_rsp_cus: fuzz_ocsp_rsp.c ${libfuzzer}
+	$(CC) $(fuzz_cppflags_cus) $(CFLAGS) -o $@ $< $(fuzz_ldflags)
+
+fuzz_sshkey_def: fuzz_sshkey.c ${libfuzzer}
+	$(CC) $(fuzz_cppflags_def) $(CFLAGS) -o $@ $< $(fuzz_ldflags)
+
+fuzz_sshkey_cus: fuzz_sshkey.c ${libfuzzer}
 	$(CC) $(fuzz_cppflags_cus) $(CFLAGS) -o $@ $< $(fuzz_ldflags)
 
 fuzz_pa_tnc: fuzz_pa_tnc.c ${libfuzzer}

--- a/fuzz/fuzz_sshkey.c
+++ b/fuzz/fuzz_sshkey.c
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2026 Arthur SC Chan
+ *
+ * Copyright (C) secunet Security Networks AG
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation; either version 2 of the License, or (at your
+ * option) any later version.  See <http://www.fsf.org/copyleft/gpl.txt>.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * for more details.
+ */
+
+#include <library.h>
+#include <utils/debug.h>
+
+int LLVMFuzzerTestOneInput(const uint8_t *buf, size_t len)
+{
+	public_key_t *key;
+	chunk_t chunk;
+
+	dbg_default_set_level(-1);
+	library_init(NULL, "fuzz_sshkey");
+	if (!lib->plugins->load(lib->plugins, PLUGINS))
+	{
+		return 1;
+	}
+
+	chunk = chunk_create((u_char*)buf, len);
+	key = lib->creds->create(lib->creds, CRED_PUBLIC_KEY, KEY_ANY,
+							 BUILD_BLOB_SSHKEY, chunk, BUILD_END);
+	DESTROY_IF(key);
+
+	lib->plugins->unload(lib->plugins);
+	library_deinit();
+	return 0;
+}


### PR DESCRIPTION
This PR adds a new fuzzer targets sshkeys parsing, with fc and fd plugin lists.