### PR TITLE
OSS-Fuzz: Add fuzzer for libipsec esp

### DIFF
--- a/fuzz/.gitignore
+++ b/fuzz/.gitignore
@@ -2,6 +2,7 @@ fuzz_certs_cus
 fuzz_certs_def
 fuzz_crls_cus
 fuzz_crls_def
+fuzz_esp
 fuzz_ids
 fuzz_ike
 fuzz_ocsp_req_cus

--- a/fuzz/Makefile.am
+++ b/fuzz/Makefile.am
@@ -8,7 +8,8 @@ AM_CPPFLAGS = @CPPFLAGS@ \
 	-I$(top_srcdir)/src/libtls \
 	-I$(top_srcdir)/src/libtnccs \
 	-I$(top_srcdir)/src/libtnccs/plugins/tnccs_20 \
-	-I$(top_srcdir)/src/libradius
+	-I$(top_srcdir)/src/libradius \
+	-I$(top_srcdir)/src/libipsec
 
 fuzz_cppflags_def = ${AM_CPPFLAGS} \
 	-DPLUGINS="\"${fd_plugins}\""
@@ -52,6 +53,10 @@ tls_ldflags = \
 	$(top_builddir)/src/libtls/.libs/libtls.a \
 	$(fuzz_ldflags)
 
+ipsec_ldflags = \
+	$(top_builddir)/src/libipsec/.libs/libipsec.a \
+	$(fuzz_ldflags)
+
 # fuzzers that use crypto plugins in a significant way
 fuzzers_with_plugins = \
 	fuzz_certs fuzz_crls fuzz_ocsp_req fuzz_ocsp_rsp
@@ -60,7 +65,8 @@ fuzzers_with_def = $(fuzzers_with_plugins:%=%_def)
 fuzzers_with_cus = $(fuzzers_with_plugins:%=%_cus)
 
 fuzzers_no_plugins = \
-	fuzz_ids fuzz_ike fuzz_pa_tnc fuzz_pb_tnc fuzz_radius fuzz_tls fuzz_vici
+	fuzz_esp fuzz_ids fuzz_ike fuzz_pa_tnc fuzz_pb_tnc fuzz_radius fuzz_tls \
+	fuzz_vici
 
 ALL_FUZZERS=$(fuzzers_with_def) $(fuzzers_with_cus) $(fuzzers_no_plugins)
 
@@ -100,6 +106,9 @@ fuzz_pb_tnc: fuzz_pb_tnc.c ${libfuzzer}
 
 fuzz_ids: fuzz_ids.c ${libfuzzer}
 	$(CC) $(AM_CPPFLAGS) $(CFLAGS) -o $@ $< $(fuzz_ldflags)
+
+fuzz_esp: fuzz_esp.c ${libfuzzer}
+	$(CC) $(AM_CPPFLAGS) $(CFLAGS) -o $@ $< $(ipsec_ldflags)
 
 fuzz_ike: fuzz_ike.c ${libfuzzer}
 	$(CC) $(AM_CPPFLAGS) $(CFLAGS) -o $@ $< $(charon_ldflags)

--- a/fuzz/fuzz_esp.c
+++ b/fuzz/fuzz_esp.c
@@ -1,0 +1,80 @@
+/*
+ * Copyright (C) 2026 Arthur SC Chan
+ *
+ * Copyright (C) secunet Security Networks AG
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation; either version 2 of the License, or (at your
+ * option) any later version.  See <http://www.fsf.org/copyleft/gpl.txt>.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * for more details.
+ */
+
+#include <library.h>
+#include <utils/debug.h>
+#include <networking/host.h>
+#include <networking/packet.h>
+#include <ip_packet.h>
+#include <esp_packet.h>
+
+static host_t *src_v4;
+static host_t *dst_v4;
+
+int LLVMFuzzerInitialize(int *argc, char ***argv)
+{
+	dbg_default_set_level(-1);
+	library_init(NULL, "fuzz_esp");
+
+	/* Synthetic endpoints used only to wrap chunks into packet_t. */
+	src_v4 = host_create_from_string("192.0.2.1", 4500);
+	dst_v4 = host_create_from_string("192.0.2.2", 4500);
+	return 0;
+}
+
+int LLVMFuzzerTestOneInput(const uint8_t *buf, size_t len)
+{
+	ip_packet_t *ip;
+	esp_packet_t *esp;
+	packet_t *packet;
+	chunk_t chunk;
+	uint32_t spi;
+
+	if (len < 20)
+	{
+		return 0;
+	}
+
+	chunk = chunk_create((u_char*)buf, len);
+
+	/* Outer IP header parser. */
+	ip = ip_packet_create(chunk_clone(chunk));
+	if (ip)
+	{
+		ip->get_version(ip);
+		ip->get_next_header(ip);
+		ip->get_source(ip);
+		ip->get_destination(ip);
+		ip->get_encoding(ip);
+		ip->get_payload(ip);
+		ip->destroy(ip);
+	}
+
+	/* (2) ESP framing parser. */
+	packet = packet_create_from_data(
+		src_v4->clone(src_v4),
+		dst_v4->clone(dst_v4),
+		chunk_clone(chunk));
+	esp = esp_packet_create_from_packet(packet);
+	if (esp)
+	{
+		esp->parse_header(esp, &spi);
+		esp->get_source(esp);
+		esp->get_destination(esp);
+		esp->destroy(esp);
+	}
+	return 0;
+}


### PR DESCRIPTION
This PR redesigns the fuzz_esp in #2995 targeting only parsing functions from libipsec.