### PR TITLE
fix: Select the CA matching the 4th packet and place it into the 5th …

### DIFF
--- a/src/libcharon/sa/ikev1/tasks/isakmp_cert_pre.c
+++ b/src/libcharon/sa/ikev1/tasks/isakmp_cert_pre.c
@@ -378,6 +378,10 @@ static void build_certreqs(private_isakmp_cert_pre_t *this, message_t *message)
 		}
 		enumerator->destroy(enumerator);
 	}
+        if (!message->get_payload(message, PLV1_CERTREQ))
+        {
+        	add_certreqs(this,this->ike_sa->get_auth_cfg(this->ike_sa, TRUE), message);
+        }
 	if (!message->get_payload(message, PLV1_CERTREQ))
 	{
 		/* otherwise add all trusted CA certificates */


### PR DESCRIPTION
Match against the CA from the certreq in the 4th packet, and place only the matching corresponding CA in the 5th packet. This avoids injecting all CAs, which would cause validation failures on third-party vendors due to extraneous CA entries.