### PR TITLE
Support DNS search domains (INTERNAL_DNS_DOMAIN)

### DIFF
--- a/conf/plugins/attr.opt
+++ b/conf/plugins/attr.opt
@@ -7,8 +7,8 @@ charon.plugins.attr.<attr>
 	subnet or arbitrary value.
 
 	**<attr>** can be either _address_, _netmask_, _dns_, _nbns_, _dhcp_,
-	_subnet_, _split-include_, _split-exclude_ or the numeric identifier of the
-	attribute type. The assigned value can be an IPv4/IPv6 address, a subnet in
-	CIDR notation or an arbitrary value depending on the attribute type.  For
-	some attribute types multiple values may be specified as a comma separated
-	list.
+	_subnet_, _split-include_, _split-exclude_, _dns-domain_ or the numeric
+	identifier of the attribute type. The assigned value can be an IPv4/IPv6
+	address, a subnet in CIDR notation or an arbitrary value depending on the
+	attribute type.  For some attribute types multiple values may be specified
+	as a comma separated list.

--- a/conf/plugins/updown.opt
+++ b/conf/plugins/updown.opt
@@ -1,7 +1,9 @@
 charon.plugins.updown.dns_handler = no
-	Whether the updown script should handle assigned DNS servers (if enabled
-	they can't be handled by other plugins, like resolve).
+	Whether the updown script should handle assigned DNS servers and search
+	domains (if enabled they can't be handled by other plugins, like resolve).
 
-	Whether the updown script should handle DNS servers assigned via IKEv1 Mode
-	Config or IKEv2 Config Payloads (if enabled they can't be handled by other
-	plugins, like resolve)
+	Whether the updown script should handle DNS servers and search domains
+	assigned via IKEv1 Mode Config or IKEv2 Config Payloads. The servers are
+	passed to the script in PLUTO_DNS4_* and PLUTO_DNS6_*, the search domains
+	in PLUTO_DNS_DOMAIN_* (if enabled they can't be handled by other plugins,
+	like resolve).

--- a/src/_updown/_updown.in
+++ b/src/_updown/_updown.in
@@ -135,6 +135,11 @@
 #              responder, $i enumerates from 1 to the number of servers per
 #              address family.
 #
+#       PLUTO_DNS_DOMAIN_$i
+#              contains a DNS search domain (INTERNAL_DNS_DOMAIN) received
+#              from a responder, $i enumerates from 1 to the number of
+#              domains. Used for split-DNS configurations.
+#
 
 # define a minimum PATH environment in case it is not set
 PATH="/sbin:/bin:/usr/sbin:/usr/bin:@sbindir@"

--- a/src/libcharon/plugins/attr/attr_provider.c
+++ b/src/libcharon/plugins/attr/attr_provider.c
@@ -178,6 +178,17 @@ static void add_legacy_entry(private_attr_provider_t *this, char *key, int nr,
 }
 
 /**
+ * Format of an attribute's value(s), determines how the configured value is
+ * parsed. Defaults to ATTR_VALUE_ADDR for keys that don't specify one.
+ */
+typedef enum {
+	/** IPv4/IPv6 address, optionally with a subnet mask */
+	ATTR_VALUE_ADDR,
+	/** arbitrary string */
+	ATTR_VALUE_STRING,
+} attr_value_type_t;
+
+/**
  * Key to attribute type mappings, for v4 and v6 attributes
  */
 typedef struct {
@@ -185,6 +196,7 @@ typedef struct {
 	configuration_attribute_type_t v4;
 	configuration_attribute_type_t v6;
 	ike_version_t ike;
+	attr_value_type_t value;
 } attribute_type_key_t;
 
 static attribute_type_key_t keys[] = {
@@ -198,6 +210,7 @@ static attribute_type_key_t keys[] = {
 	{"p-cscf",			P_CSCF_IP4_ADDRESS,		P_CSCF_IP6_ADDRESS,		IKEV2},
 	{"split-include",	UNITY_SPLIT_INCLUDE,	UNITY_SPLIT_INCLUDE,	IKEV1},
 	{"split-exclude",	UNITY_LOCAL_LAN,		UNITY_LOCAL_LAN,		IKEV1},
+	{"dns-domain",		INTERNAL_DNS_DOMAIN,	INTERNAL_DNS_DOMAIN,	IKE_ANY,	ATTR_VALUE_STRING},
 };
 
 /**
@@ -260,13 +273,17 @@ static void load_entries(private_attr_provider_t *this)
 			host = host_create_from_string(token, 0);
 			if (!host)
 			{
-				if (mapped)
+				if (mapped && mapped->value != ATTR_VALUE_STRING)
 				{
 					DBG1(DBG_CFG, "invalid host in key %s: %s", key, token);
 					continue;
 				}
-				/* store numeric attributes that are no IP addresses as strings */
+				/* store attributes that are not IP addresses as strings */
 				data = chunk_clone(chunk_from_str(token));
+				if (mapped)
+				{
+					type = mapped->v4;
+				}
 			}
 			else
 			{

--- a/src/libcharon/plugins/resolve/resolve_handler.c
+++ b/src/libcharon/plugins/resolve/resolve_handler.c
@@ -71,6 +71,11 @@ struct private_resolve_handler_t {
 	 * Reference counting for DNS servers dns_server_t
 	 */
 	hashtable_t *servers;
+
+	/**
+	 * Reference counting for DNS search domains dns_domain_t
+	 */
+	hashtable_t *domains;
 };
 
 /**
@@ -91,6 +96,16 @@ typedef struct {
 } dns_server_t;
 
 /**
+ * Reference counting for DNS search domains
+ */
+typedef struct {
+	/** DNS search domain */
+	char *domain;
+	/** reference count */
+	u_int refcount;
+} dns_domain_t;
+
+/**
  * Hash DNS server address
  */
 static u_int dns_server_hash(const void *key)
@@ -109,14 +124,31 @@ static bool dns_server_equals(const void *a, const void *b)
 }
 
 /**
- * Writes the given nameservers to resolv.conf
+ * Convert a received DNS domain attribute to a sanitized, NUL-terminated
+ * string. The value is responder-controlled and gets written to resolv.conf,
+ * so replace any non-printable bytes (e.g. a newline that would otherwise
+ * inject a nameserver line).
  */
-static bool write_nameservers(private_resolve_handler_t *this,
-							  hashtable_t *servers)
+static char *sanitize_domain(chunk_t data)
+{
+	chunk_t sane;
+	char *domain;
+
+	chunk_printable(data, &sane, '?');
+	domain = strndup(sane.ptr, sane.len);
+	chunk_free(&sane);
+	return domain;
+}
+
+/**
+ * Writes the current set of nameservers and search domains to resolv.conf
+ */
+static bool write_resolv_conf(private_resolve_handler_t *this)
 {
 	FILE *in, *out;
 	enumerator_t *enumerator;
 	dns_server_t *dns;
+	dns_domain_t *dom;
 	char line[1024];
 	bool handled = FALSE;
 
@@ -127,16 +159,29 @@ static bool write_nameservers(private_resolve_handler_t *this,
 	if (out)
 	{
 		/* write our current set of servers */
-		enumerator = servers->create_enumerator(servers);
+		enumerator = this->servers->create_enumerator(this->servers);
 		while (enumerator->enumerate(enumerator, NULL, &dns))
 		{
 			fprintf(out, "nameserver %H" RESOLV_CONF_SUFFIX "\n", dns->server);
 		}
 		enumerator->destroy(enumerator);
 
+		/* write our current set of search domains as a single line */
+		if (this->domains->get_count(this->domains))
+		{
+			fprintf(out, "search");
+			enumerator = this->domains->create_enumerator(this->domains);
+			while (enumerator->enumerate(enumerator, NULL, &dom))
+			{
+				fprintf(out, " %s", dom->domain);
+			}
+			enumerator->destroy(enumerator);
+			fprintf(out, RESOLV_CONF_SUFFIX "\n");
+		}
+
 		if (in)
 		{
-			/* copy the rest of the file, except our previous servers */
+			/* copy the rest of the file, except our previous entries */
 			while (fgets(line, sizeof(line), in))
 			{
 				if (!strstr(line, RESOLV_CONF_SUFFIX "\n"))
@@ -158,18 +203,19 @@ static bool write_nameservers(private_resolve_handler_t *this,
 }
 
 /**
- * Install the given nameservers by invoking resolvconf. If the table is empty,
- * remove the config.
+ * Install the current set of nameservers and search domains by invoking
+ * resolvconf. If there are none, remove the config.
  */
-static bool invoke_resolvconf(private_resolve_handler_t *this,
-							  hashtable_t *servers)
+static bool invoke_resolvconf(private_resolve_handler_t *this)
 {
 	process_t *process;
 	enumerator_t *enumerator;
 	dns_server_t *dns;
+	dns_domain_t *dom;
 	FILE *shell;
 	int in, out, retval;
-	bool install = servers->get_count(servers);
+	bool install = this->servers->get_count(this->servers) ||
+				   this->domains->get_count(this->domains);
 
 	process = process_start_shell(NULL, install ? &in : NULL, &out,
 								  NULL, "2>&1 %s %s %s", this->resolvconf,
@@ -183,12 +229,24 @@ static bool invoke_resolvconf(private_resolve_handler_t *this,
 		shell = fdopen(in, "w");
 		if (shell)
 		{
-			enumerator = servers->create_enumerator(servers);
+			enumerator = this->servers->create_enumerator(this->servers);
 			while (enumerator->enumerate(enumerator, NULL, &dns))
 			{
 				fprintf(shell, "nameserver %H\n", dns->server);
 			}
 			enumerator->destroy(enumerator);
+
+			if (this->domains->get_count(this->domains))
+			{
+				fprintf(shell, "search");
+				enumerator = this->domains->create_enumerator(this->domains);
+				while (enumerator->enumerate(enumerator, NULL, &dom))
+				{
+					fprintf(shell, " %s", dom->domain);
+				}
+				enumerator->destroy(enumerator);
+				fprintf(shell, "\n");
+			}
 			fclose(shell);
 		}
 		else
@@ -237,6 +295,67 @@ static bool invoke_resolvconf(private_resolve_handler_t *this,
 	return process->wait(process, &retval) && retval == EXIT_SUCCESS;
 }
 
+/**
+ * Install a received DNS search domain, reference counting duplicates.
+ */
+static bool handle_domain(private_resolve_handler_t *this, chunk_t data)
+{
+	dns_domain_t *found;
+	char *domain;
+	bool handled;
+
+	if (!data.len)
+	{
+		return FALSE;
+	}
+	domain = sanitize_domain(data);
+
+	this->mutex->lock(this->mutex);
+	found = this->domains->get(this->domains, domain);
+	if (!found)
+	{
+		INIT(found,
+			.domain = domain,
+			.refcount = 1,
+		);
+		this->domains->put(this->domains, found->domain, found);
+
+		if (this->resolvconf)
+		{
+			DBG1(DBG_IKE, "installing DNS search domain %s via resolvconf",
+				 domain);
+			handled = invoke_resolvconf(this);
+		}
+		else
+		{
+			DBG1(DBG_IKE, "installing DNS search domain %s to %s", domain,
+				 this->file);
+			handled = write_resolv_conf(this);
+		}
+		if (!handled)
+		{
+			this->domains->remove(this->domains, found->domain);
+			free(found->domain);
+			free(found);
+		}
+	}
+	else
+	{
+		DBG1(DBG_IKE, "DNS search domain %s already installed, increasing "
+			 "refcount", domain);
+		found->refcount++;
+		handled = TRUE;
+		free(domain);
+	}
+	this->mutex->unlock(this->mutex);
+
+	if (!handled)
+	{
+		DBG1(DBG_IKE, "adding DNS search domain failed");
+	}
+	return handled;
+}
+
 METHOD(attribute_handler_t, handle, bool,
 	private_resolve_handler_t *this, ike_sa_t *ike_sa,
 	configuration_attribute_type_t type, chunk_t data)
@@ -253,6 +372,8 @@ METHOD(attribute_handler_t, handle, bool,
 		case INTERNAL_IP6_DNS:
 			addr = host_create_from_chunk(AF_INET6, data, 0);
 			break;
+		case INTERNAL_DNS_DOMAIN:
+			return handle_domain(this, data);
 		default:
 			return FALSE;
 	}
@@ -276,12 +397,12 @@ METHOD(attribute_handler_t, handle, bool,
 		if (this->resolvconf)
 		{
 			DBG1(DBG_IKE, "installing DNS server %H via resolvconf", addr);
-			handled = invoke_resolvconf(this, this->servers);
+			handled = invoke_resolvconf(this);
 		}
 		else
 		{
 			DBG1(DBG_IKE, "installing DNS server %H to %s", addr, this->file);
-			handled = write_nameservers(this, this->servers);
+			handled = write_resolv_conf(this);
 		}
 		if (!handled)
 		{
@@ -307,6 +428,50 @@ METHOD(attribute_handler_t, handle, bool,
 	return handled;
 }
 
+/**
+ * Release a previously installed DNS search domain.
+ */
+static void release_domain(private_resolve_handler_t *this, chunk_t data)
+{
+	dns_domain_t *found;
+	char *domain;
+
+	domain = sanitize_domain(data);
+
+	this->mutex->lock(this->mutex);
+	found = this->domains->get(this->domains, domain);
+	if (found)
+	{
+		if (--found->refcount > 0)
+		{
+			DBG1(DBG_IKE, "DNS search domain %s still used, decreasing "
+				 "refcount", domain);
+		}
+		else
+		{
+			this->domains->remove(this->domains, found->domain);
+			free(found->domain);
+			free(found);
+
+			if (this->resolvconf)
+			{
+				DBG1(DBG_IKE, "removing DNS search domain %s via resolvconf",
+					 domain);
+				invoke_resolvconf(this);
+			}
+			else
+			{
+				DBG1(DBG_IKE, "removing DNS search domain %s from %s", domain,
+					 this->file);
+				write_resolv_conf(this);
+			}
+		}
+	}
+	this->mutex->unlock(this->mutex);
+
+	free(domain);
+}
+
 METHOD(attribute_handler_t, release, void,
 	private_resolve_handler_t *this, ike_sa_t *ike_sa,
 	configuration_attribute_type_t type, chunk_t data)
@@ -323,6 +488,9 @@ METHOD(attribute_handler_t, release, void,
 		case INTERNAL_IP6_DNS:
 			family = AF_INET6;
 			break;
+		case INTERNAL_DNS_DOMAIN:
+			release_domain(this, data);
+			return;
 		default:
 			return;
 	}
@@ -346,13 +514,13 @@ METHOD(attribute_handler_t, release, void,
 			if (this->resolvconf)
 			{
 				DBG1(DBG_IKE, "removing DNS server %H via resolvconf", addr);
-				invoke_resolvconf(this, this->servers);
+				invoke_resolvconf(this);
 			}
 			else
 			{
 				DBG1(DBG_IKE, "removing DNS server %H from %s", addr,
 					 this->file);
-				write_nameservers(this, this->servers);
+				write_resolv_conf(this);
 			}
 		}
 	}
@@ -371,6 +539,8 @@ typedef struct {
 	bool v4;
 	/** request IPv6 DNS? */
 	bool v6;
+	/** request DNS search domains? */
+	bool domain;
 } attribute_enumerator_t;
 
 METHOD(enumerator_t, attribute_enumerate, bool,
@@ -392,6 +562,13 @@ METHOD(enumerator_t, attribute_enumerate, bool,
 		*type = INTERNAL_IP6_DNS;
 		*data = chunk_empty;
 		this->v6 = FALSE;
+		return TRUE;
+	}
+	if (this->domain)
+	{
+		*type = INTERNAL_DNS_DOMAIN;
+		*data = chunk_empty;
+		this->domain = FALSE;
 		return TRUE;
 	}
 	return FALSE;
@@ -425,6 +602,10 @@ METHOD(attribute_handler_t, create_attribute_enumerator, enumerator_t*,
 	linked_list_t *vips)
 {
 	attribute_enumerator_t *enumerator;
+	bool v4, v6;
+
+	v4 = has_host_family(vips, AF_INET);
+	v6 = has_host_family(vips, AF_INET6);
 
 	INIT(enumerator,
 		.public = {
@@ -432,8 +613,9 @@ METHOD(attribute_handler_t, create_attribute_enumerator, enumerator_t*,
 			.venumerate = _attribute_enumerate,
 			.destroy = (void*)free,
 		},
-		.v4 = has_host_family(vips, AF_INET),
-		.v6 = has_host_family(vips, AF_INET6),
+		.v4 = v4,
+		.v6 = v6,
+		.domain = v4 || v6,
 	);
 	return &enumerator->public;
 }
@@ -442,6 +624,7 @@ METHOD(resolve_handler_t, destroy, void,
 	private_resolve_handler_t *this)
 {
 	this->servers->destroy(this->servers);
+	this->domains->destroy(this->domains);
 	this->mutex->destroy(this->mutex);
 	free(this);
 }
@@ -465,6 +648,7 @@ resolve_handler_t *resolve_handler_create()
 		},
 		.mutex = mutex_create(MUTEX_TYPE_DEFAULT),
 		.servers = hashtable_create(dns_server_hash, dns_server_equals, 4),
+		.domains = hashtable_create(hashtable_hash_str, hashtable_equals_str, 4),
 		.file = lib->settings->get_str(lib->settings,
 								"%s.plugins.resolve.file", RESOLV_CONF, lib->ns),
 		.resolvconf = lib->settings->get_str(lib->settings,

--- a/src/libcharon/plugins/updown/updown_handler.c
+++ b/src/libcharon/plugins/updown/updown_handler.c
@@ -49,8 +49,10 @@ struct private_updown_handler_t {
 typedef struct {
 	/** unique IKE_SA identifier */
 	u_int id;
-	/** list of DNS attributes, as host_t */
+	/** list of DNS server attributes, as host_t */
 	linked_list_t *dns;
+	/** list of DNS search domains, as char* */
+	linked_list_t *domains;
 } attributes_t;
 
 /**
@@ -59,7 +61,24 @@ typedef struct {
 static void attributes_destroy(attributes_t *this)
 {
 	this->dns->destroy_offset(this->dns, offsetof(host_t, destroy));
+	this->domains->destroy_function(this->domains, free);
 	free(this);
+}
+
+/**
+ * Convert a received DNS domain attribute to a sanitized, NUL-terminated
+ * string. The value is responder-controlled and ends up in the updown
+ * script's environment, so replace any non-printable bytes.
+ */
+static char *sanitize_domain(chunk_t data)
+{
+	chunk_t sane;
+	char *domain;
+
+	chunk_printable(data, &sane, '?');
+	domain = strndup(sane.ptr, sane.len);
+	chunk_free(&sane);
+	return domain;
 }
 
 METHOD(attribute_handler_t, handle, bool,
@@ -68,7 +87,8 @@ METHOD(attribute_handler_t, handle, bool,
 {
 	attributes_t *current, *attr = NULL;
 	enumerator_t *enumerator;
-	host_t *host;
+	host_t *host = NULL;
+	char *domain = NULL;
 
 	switch (type)
 	{
@@ -78,10 +98,16 @@ METHOD(attribute_handler_t, handle, bool,
 		case INTERNAL_IP6_DNS:
 			host = host_create_from_chunk(AF_INET6, data, 0);
 			break;
+		case INTERNAL_DNS_DOMAIN:
+			if (data.len)
+			{
+				domain = sanitize_domain(data);
+			}
+			break;
 		default:
 			return FALSE;
 	}
-	if (!host)
+	if (!host && !domain)
 	{
 		return FALSE;
 	}
@@ -102,10 +128,18 @@ METHOD(attribute_handler_t, handle, bool,
 		INIT(attr,
 			.id = ike_sa->get_unique_id(ike_sa),
 			.dns = linked_list_create(),
+			.domains = linked_list_create(),
 		);
 		this->attrs->insert_last(this->attrs, attr);
 	}
-	attr->dns->insert_last(attr->dns, host);
+	if (host)
+	{
+		attr->dns->insert_last(attr->dns, host);
+	}
+	else
+	{
+		attr->domains->insert_last(attr->domains, domain);
+	}
 	this->lock->unlock(this->lock);
 
 	return TRUE;
@@ -116,10 +150,11 @@ METHOD(attribute_handler_t, release, void,
 	configuration_attribute_type_t type, chunk_t data)
 {
 	attributes_t *attr;
-	enumerator_t *enumerator, *servers;
+	enumerator_t *enumerator, *servers, *domains;
 	host_t *host;
+	char *domain, *sane = NULL;
 	bool found = FALSE;
-	int family;
+	int family = AF_UNSPEC;
 
 	switch (type)
 	{
@@ -128,6 +163,9 @@ METHOD(attribute_handler_t, release, void,
 			break;
 		case INTERNAL_IP6_DNS:
 			family = AF_INET6;
+			break;
+		case INTERNAL_DNS_DOMAIN:
+			sane = sanitize_domain(data);
 			break;
 		default:
 			return;
@@ -139,20 +177,39 @@ METHOD(attribute_handler_t, release, void,
 	{
 		if (attr->id == ike_sa->get_unique_id(ike_sa))
 		{
-			servers = attr->dns->create_enumerator(attr->dns);
-			while (servers->enumerate(servers, &host))
+			if (sane)
 			{
-				if (host->get_family(host) == family &&
-					chunk_equals(data, host->get_address(host)))
+				domains = attr->domains->create_enumerator(attr->domains);
+				while (domains->enumerate(domains, &domain))
 				{
-					attr->dns->remove_at(attr->dns, servers);
-					host->destroy(host);
-					found = TRUE;
-					break;
+					if (streq(domain, sane))
+					{
+						attr->domains->remove_at(attr->domains, domains);
+						free(domain);
+						found = TRUE;
+						break;
+					}
 				}
+				domains->destroy(domains);
 			}
-			servers->destroy(servers);
-			if (attr->dns->get_count(attr->dns) == 0)
+			else
+			{
+				servers = attr->dns->create_enumerator(attr->dns);
+				while (servers->enumerate(servers, &host))
+				{
+					if (host->get_family(host) == family &&
+						chunk_equals(data, host->get_address(host)))
+					{
+						attr->dns->remove_at(attr->dns, servers);
+						host->destroy(host);
+						found = TRUE;
+						break;
+					}
+				}
+				servers->destroy(servers);
+			}
+			if (attr->dns->get_count(attr->dns) == 0 &&
+				attr->domains->get_count(attr->domains) == 0)
 			{
 				this->attrs->remove_at(this->attrs, enumerator);
 				attributes_destroy(attr);
@@ -166,13 +223,19 @@ METHOD(attribute_handler_t, release, void,
 	}
 	enumerator->destroy(enumerator);
 	this->lock->unlock(this->lock);
+	free(sane);
 }
 
-METHOD(updown_handler_t, create_dns_enumerator, enumerator_t*,
-	private_updown_handler_t *this, u_int id)
+/**
+ * Create an enumerator over the DNS servers (host_t) or search domains (char*)
+ * of the current IKE_SA. Holds the read lock until the enumerator is destroyed.
+ */
+static enumerator_t *create_enumerator(private_updown_handler_t *this,
+									   bool domains)
 {
 	attributes_t *attr;
 	enumerator_t *enumerator;
+	linked_list_t *list;
 	ike_sa_t *ike_sa;
 
 	ike_sa = charon->bus->get_sa(charon->bus);
@@ -187,9 +250,9 @@ METHOD(updown_handler_t, create_dns_enumerator, enumerator_t*,
 	{
 		if (attr->id == ike_sa->get_unique_id(ike_sa))
 		{
+			list = domains ? attr->domains : attr->dns;
 			enumerator->destroy(enumerator);
-			return enumerator_create_cleaner(
-										attr->dns->create_enumerator(attr->dns),
+			return enumerator_create_cleaner(list->create_enumerator(list),
 										(void*)this->lock->unlock, this->lock);
 		}
 	}
@@ -199,6 +262,17 @@ METHOD(updown_handler_t, create_dns_enumerator, enumerator_t*,
 	return enumerator_create_empty();
 }
 
+METHOD(updown_handler_t, create_dns_enumerator, enumerator_t*,
+	private_updown_handler_t *this, u_int id)
+{
+	return create_enumerator(this, FALSE);
+}
+
+METHOD(updown_handler_t, create_domain_enumerator, enumerator_t*,
+	private_updown_handler_t *this, u_int id)
+{
+	return create_enumerator(this, TRUE);
+}
 
 METHOD(updown_handler_t, destroy, void,
 	private_updown_handler_t *this)
@@ -223,6 +297,7 @@ updown_handler_t *updown_handler_create()
 				.create_attribute_enumerator = (void*)enumerator_create_empty,
 			},
 			.create_dns_enumerator = _create_dns_enumerator,
+			.create_domain_enumerator = _create_domain_enumerator,
 			.destroy = _destroy,
 		},
 		.attrs = linked_list_create(),

--- a/src/libcharon/plugins/updown/updown_handler.h
+++ b/src/libcharon/plugins/updown/updown_handler.h
@@ -45,6 +45,14 @@ struct updown_handler_t {
 	enumerator_t* (*create_dns_enumerator)(updown_handler_t *this, u_int id);
 
 	/**
+	 * Create an enumerator over received DNS search domains.
+	 *
+	 * @param id		unique IKE_SA identifier to get attributes for
+	 * @return			enumerator over char*
+	 */
+	enumerator_t* (*create_domain_enumerator)(updown_handler_t *this, u_int id);
+
+	/**
 	 * Destroy a updown_handler_t.
 	 */
 	void (*destroy)(updown_handler_t *this);

--- a/src/libcharon/plugins/updown/updown_listener.c
+++ b/src/libcharon/plugins/updown/updown_listener.c
@@ -170,6 +170,28 @@ static void push_dns_env(private_updown_listener_t *this, ike_sa_t *ike_sa,
 }
 
 /**
+ * Push variables for handled DNS search domains
+ */
+static void push_domain_env(private_updown_listener_t *this, ike_sa_t *ike_sa,
+							char *envp[], u_int count)
+{
+	enumerator_t *enumerator;
+	char *domain;
+	int i = 0;
+
+	if (this->handler)
+	{
+		enumerator = this->handler->create_domain_enumerator(this->handler,
+											ike_sa->get_unique_id(ike_sa));
+		while (enumerator->enumerate(enumerator, &domain))
+		{
+			push_env(envp, count, "PLUTO_DNS_DOMAIN_%d=%s", ++i, domain);
+		}
+		enumerator->destroy(enumerator);
+	}
+}
+
+/**
  * Push variables for local/remote virtual IPs
  */
 static void push_vip_env(private_updown_listener_t *this, ike_sa_t *ike_sa,
@@ -381,6 +403,7 @@ static void invoke_once(private_updown_listener_t *this, ike_sa_t *ike_sa,
 		push_env(envp, countof(envp), "PLUTO_IPCOMP=1");
 	}
 	push_dns_env(this, ike_sa, envp, countof(envp));
+	push_domain_env(this, ike_sa, envp, countof(envp));
 	if (config->has_option(config, OPT_HOSTACCESS))
 	{
 		push_env(envp, countof(envp), "PLUTO_HOST_ACCESS=1");

--- a/testing/tests/ikev2/rw-dns-domain/description.txt
+++ b/testing/tests/ikev2/rw-dns-domain/description.txt
@@ -1,0 +1,7 @@
+The roadwarrior <b>carol</b> sets up a connection to gateway <b>moon</b>, requesting a
+<b>virtual IP</b> via the IKEv2 configuration payload. Gateway <b>moon</b> assigns an
+address from pool <b>rw_pool</b> and, via the <b>attr</b> plugin, pushes a DNS server
+(<b>INTERNAL_IP4_DNS</b>) plus two DNS search domains (<b>INTERNAL_DNS_DOMAIN</b>):
+<b>strongswan.org</b> and <b>example.com</b>. The <b>resolve</b> plugin on <b>carol</b>
+installs the nameserver and writes a single <b>search</b> line listing both domains to
+<b>/etc/resolv.conf</b>.

--- a/testing/tests/ikev2/rw-dns-domain/evaltest.dat
+++ b/testing/tests/ikev2/rw-dns-domain/evaltest.dat
@@ -1,0 +1,7 @@
+carol::cat /var/log/daemon.log::installing DNS server PH_IP_WINNETOU to /etc/resolv.conf::YES
+carol::cat /var/log/daemon.log::installing DNS search domain strongswan.org to /etc/resolv.conf::YES
+carol::cat /var/log/daemon.log::installing DNS search domain example.com to /etc/resolv.conf::YES
+carol::cat /etc/resolv.conf::nameserver PH_IP_WINNETOU::YES
+carol::cat /etc/resolv.conf::search strongswan.org example.com::YES
+carol::swanctl --list-sas --raw 2> /dev/null::home.*version=2 state=ESTABLISHED.*local-vips=\[10.3.0.1].*child-sas.*home.*state=INSTALLED::YES
+moon:: swanctl --list-sas --raw 2> /dev/null::rw.*state=ESTABLISHED.*remote-vips=\[10.3.0.1]::YES

--- a/testing/tests/ikev2/rw-dns-domain/hosts/carol/etc/strongswan.conf
+++ b/testing/tests/ikev2/rw-dns-domain/hosts/carol/etc/strongswan.conf
@@ -1,0 +1,9 @@
+# /etc/strongswan.conf - strongSwan configuration file
+
+swanctl {
+  load = pem pkcs1 pubkey openssl random
+}
+
+charon-systemd {
+  load = random nonce openssl pem pkcs1 revocation curl kernel-netlink socket-default updown vici resolve
+}

--- a/testing/tests/ikev2/rw-dns-domain/hosts/carol/etc/swanctl/swanctl.conf
+++ b/testing/tests/ikev2/rw-dns-domain/hosts/carol/etc/swanctl/swanctl.conf
@@ -1,0 +1,25 @@
+connections {
+   home {
+      local_addrs  = 192.168.0.100
+      remote_addrs = 192.168.0.1
+      vips = 0.0.0.0
+      local {
+         auth = pubkey
+         certs = carolCert.pem
+         id = carol@strongswan.org
+      }
+      remote {
+         auth = pubkey
+         id = moon.strongswan.org
+      }
+      children {
+         home {
+            remote_ts = 0.0.0.0/0
+            updown = /usr/local/libexec/ipsec/_updown iptables
+            esp_proposals = aes128gcm128-x25519
+         }
+      }
+      version = 2
+      proposals = aes128-sha256-x25519
+   }
+}

--- a/testing/tests/ikev2/rw-dns-domain/hosts/moon/etc/iptables.rules
+++ b/testing/tests/ikev2/rw-dns-domain/hosts/moon/etc/iptables.rules
@@ -1,0 +1,28 @@
+*filter
+
+# default policy is DROP
+-P INPUT DROP
+-P OUTPUT DROP
+-P FORWARD DROP
+
+# allow esp
+-A INPUT  -i eth0 -p 50 -j ACCEPT
+-A OUTPUT -o eth0 -p 50 -j ACCEPT
+
+# allow IKE
+-A INPUT  -i eth0 -p udp --sport 500 --dport 500 -j ACCEPT
+-A OUTPUT -o eth0 -p udp --dport 500 --sport 500 -j ACCEPT
+
+# allow MobIKE
+-A INPUT  -i eth0 -p udp --sport 4500 --dport 4500 -j ACCEPT
+-A OUTPUT -o eth0 -p udp --dport 4500 --sport 4500 -j ACCEPT
+
+# allow crl fetch from winnetou
+-A INPUT  -i eth0 -p tcp --sport 80 -s PH_IP_WINNETOU -j ACCEPT
+-A OUTPUT -o eth0 -p tcp --dport 80 -d PH_IP_WINNETOU -j ACCEPT
+
+# allow ssh
+-A INPUT  -p tcp --dport 22 -j ACCEPT
+-A OUTPUT -p tcp --sport 22 -j ACCEPT
+
+COMMIT

--- a/testing/tests/ikev2/rw-dns-domain/hosts/moon/etc/strongswan.conf
+++ b/testing/tests/ikev2/rw-dns-domain/hosts/moon/etc/strongswan.conf
@@ -1,0 +1,16 @@
+# /etc/strongswan.conf - strongSwan configuration file
+
+swanctl {
+  load = pem pkcs1 pubkey openssl random
+}
+
+charon-systemd {
+  load = random nonce openssl pem pkcs1 revocation curl kernel-netlink socket-default updown vici attr
+
+  plugins {
+    attr {
+      dns = PH_IP_WINNETOU
+      dns-domain = strongswan.org, example.com
+    }
+  }
+}

--- a/testing/tests/ikev2/rw-dns-domain/hosts/moon/etc/swanctl/swanctl.conf
+++ b/testing/tests/ikev2/rw-dns-domain/hosts/moon/etc/swanctl/swanctl.conf
@@ -1,0 +1,29 @@
+connections {
+   rw {
+      local_addrs  = 192.168.0.1
+      pools = rw_pool
+      local {
+         auth = pubkey
+         certs = moonCert.pem
+         id = moon.strongswan.org
+      }
+      remote {
+         auth = pubkey
+      }
+      children {
+         rw {
+            local_ts  = 0.0.0.0/0
+            updown = /usr/local/libexec/ipsec/_updown iptables
+            esp_proposals = aes128gcm128-x25519
+         }
+      }
+      version = 2
+      proposals = aes128-sha256-x25519
+   }
+}
+
+pools {
+   rw_pool {
+      addrs = 10.3.0.0/24
+   }
+}

--- a/testing/tests/ikev2/rw-dns-domain/posttest.dat
+++ b/testing/tests/ikev2/rw-dns-domain/posttest.dat
@@ -1,0 +1,4 @@
+moon::systemctl stop strongswan
+carol::systemctl stop strongswan
+moon::iptables-restore < /etc/iptables.flush
+carol::iptables-restore < /etc/iptables.flush

--- a/testing/tests/ikev2/rw-dns-domain/pretest.dat
+++ b/testing/tests/ikev2/rw-dns-domain/pretest.dat
@@ -1,0 +1,7 @@
+moon::iptables-restore < /etc/iptables.rules
+carol::iptables-restore < /etc/iptables.rules
+moon::systemctl start strongswan
+carol::systemctl start strongswan
+moon::expect-connection rw
+carol::expect-connection home
+carol::swanctl --initiate --child home 2> /dev/null

--- a/testing/tests/ikev2/rw-dns-domain/test.conf
+++ b/testing/tests/ikev2/rw-dns-domain/test.conf
@@ -1,0 +1,25 @@
+#!/bin/bash
+#
+# This configuration file provides information on the
+# guest instances used for this test
+
+# All guest instances that are required for this test
+#
+VIRTHOSTS="moon carol winnetou"
+
+# Corresponding block diagram
+#
+DIAGRAM="c-m-w.png"
+
+# Guest instances on which tcpdump is to be started
+#
+TCPDUMPHOSTS="moon"
+
+# Guest instances on which IPsec is started
+# Used for IPsec logging purposes
+#
+IPSECHOSTS="moon carol"
+
+# charon controlled by swanctl
+#
+SWANCTL=1


### PR DESCRIPTION
Adds end-to-end handling of RFC 8598 INTERNAL_DNS_DOMAIN search domains.

This PR defines attribute 25 so that it can be reference with a proper name, not just the numerical identifier.

It also adds support in the updown plugin exposing the domains as `PLUTO_DNS_DOMAIN_0`, `PLUTO_DNS_DOMAIN_1`, `PLUTO_DNS_DOMAIN_N`.

...and adds appropriate support in the resolve plugin:

```
nameserver 8.8.8.8
search strongswan.org example.com
```

Also tested on macOS Sequoia 15.7.7, which to my genuine surprise accepted the domain list, and seemed to use the values correctly to enable split-horizon DNS!

