### PR TITLE
tls-socket: Don't leave the read buffer armed after read calls

### DIFF
--- a/src/libtls/tls_socket.c
+++ b/src/libtls/tls_socket.c
@@ -231,13 +231,7 @@ static bool exchange(private_tls_socket_t *this, bool wr, bool block)
 		if (in < 0)
 		{
 			if (errno == EAGAIN || errno == EWOULDBLOCK)
-			{
-				if (this->app.in_done == 0)
-				{
-					/* reading, nothing got yet, and call would block */
-					errno = EWOULDBLOCK;
-					this->app.in_done = -1;
-				}
+			{	/* would block, read() signals this if no data was received */
 				return TRUE;
 			}
 			return FALSE;
@@ -262,6 +256,8 @@ static bool exchange(private_tls_socket_t *this, bool wr, bool block)
 METHOD(tls_socket_t, read_, ssize_t,
 	private_tls_socket_t *this, void *buf, size_t len, bool block)
 {
+	ssize_t done;
+
 	if (this->app.cache.len)
 	{
 		size_t cache;
@@ -284,16 +280,18 @@ METHOD(tls_socket_t, read_, ssize_t,
 	this->app.in.ptr = buf;
 	this->app.in.len = len;
 	this->app.in_done = 0;
-	if (exchange(this, FALSE, block))
+	done = exchange(this, FALSE, block) ? this->app.in_done : -1;
+	/* disarm the read buffer: application data processed outside of a read
+	 * call (e.g. by a write driving a handshake) must go to the cache, not
+	 * through a stale pointer into the caller's buffer */
+	this->app.in = chunk_empty;
+	this->app.in_done = 0;
+	if (done == 0 && !this->eof)
 	{
-		if (!this->app.in_done && !this->eof)
-		{
-			errno = EWOULDBLOCK;
-			return -1;
-		}
-		return this->app.in_done;
+		errno = EWOULDBLOCK;
+		return -1;
 	}
-	return -1;
+	return done;
 }
 
 METHOD(tls_socket_t, write_, ssize_t,


### PR DESCRIPTION
# tls-socket: Fix wild pointer write when data arrives outside of read calls

`tls_socket_t` flags a would-block condition on a non-blocking read by
setting `app.in_done = -1`. `in_done` is a `size_t`, so it is left at
`SIZE_MAX` while `app.in` still points into the buffer of the completed
`read()` call.

If application data is then processed outside of a read call — for
instance while `write()` drives a rekeying handshake, or on the next poll
round of `splice()`, which pairs non-blocking reads with writes — the
`process()` callback calculates

```c
len = min(reader->remaining(reader), this->in.len - this->in_done);
```

where `in.len - SIZE_MAX` wraps around to `in.len + 1`, so `len` is
non-zero and the data is copied with
`memcpy(this->in.ptr + SIZE_MAX, ...)` — a write through a wild pointer
just below a caller buffer that may no longer exist (e.g. an expired stack
frame).

There is a second, milder facet of the same root cause: even without the
would-block marker, a partially filled read buffer stays armed after
`read()` returns. Application data processed outside of a read call is
written through a stale pointer into the caller's buffer and then silently
discarded when the next read call resets `in_done`.

## Fix

Disarm the read buffer whenever `read()` returns. Application data
processed outside of a read call then always takes the existing cache path
in `process()` and is returned by the next read call. The `-1` marker
becomes unnecessary since `read()` already signals `EWOULDBLOCK` itself
when no data was received; error signaling is unchanged in all paths.

## Testing

The full `tls_tests` suite passes. The corruption was originally caught by
an out-of-tree user of `tls_socket_t` on non-blocking sockets, where
interleaved reads and writes made the stale `SIZE_MAX` offset reachable in
practice.
