### PR TITLE
pkcs11: add ML-DSA key and signature support

### DIFF
--- a/src/libstrongswan/plugins/pkcs11/pkcs11.h
+++ b/src/libstrongswan/plugins/pkcs11/pkcs11.h
@@ -380,6 +380,7 @@ typedef unsigned long ck_key_type_t;
 #define CKK_GOST28147           (0x32UL)
 #define CKK_EC_EDWARDS          (0x40UL)
 #define CKK_EC_MONTGOMERY       (0x41UL)
+#define CKK_ML_DSA              (0x4aUL)
 #define CKK_VENDOR_DEFINED      (1UL << 31)
 
 
@@ -499,6 +500,12 @@ typedef unsigned long ck_attribute_type_t;
 #define CKA_OTP_TIME                    (0x22FUL)
 #define CKA_ALLOWED_MECHANISMS          (CKF_ARRAY_ATTRIBUTE | 0x600UL)
 #define CKA_PROFILE_ID                  (0x601UL)
+#define CKA_PARAMETER_SET               (0x61dUL)
+
+#define CKP_ML_DSA_44                   (1UL)
+#define CKP_ML_DSA_65                   (2UL)
+#define CKP_ML_DSA_87                   (3UL)
+
 #define CKA_VENDOR_DEFINED              (1UL << 31)
 
 
@@ -790,6 +797,9 @@ typedef unsigned long ck_mechanism_type_t;
 #define CKM_AES_KEY_WRAP                (0x2109UL)
 #define CKM_AES_KEY_WRAP_PAD            (0x210AUL)
 #define CKM_XEDDSA                      (0x4029UL)
+
+#define CKM_ML_DSA_KEY_PAIR_GEN         (0x1cUL)
+#define CKM_ML_DSA                      (0x1dUL)
 
 
 #define CKM_VENDOR_DEFINED              (1UL << 31)

--- a/src/libstrongswan/plugins/pkcs11/pkcs11_private_key.c
+++ b/src/libstrongswan/plugins/pkcs11/pkcs11_private_key.c
@@ -194,6 +194,12 @@ CK_MECHANISM_PTR pkcs11_signature_scheme_to_mech(pkcs11_library_t *p11,
 		 KEY_ECDSA, 384,									HASH_SHA384},
 		{SIGN_ECDSA_521,				{CKM_ECDSA,				NULL, 0},
 		 KEY_ECDSA, 521,									HASH_SHA512},
+		{SIGN_ML_DSA_44,				{CKM_ML_DSA,			NULL, 0},
+		 KEY_ML_DSA_44, 0,									HASH_UNKNOWN},
+		{SIGN_ML_DSA_65,				{CKM_ML_DSA,			NULL, 0},
+		 KEY_ML_DSA_65, 0,									HASH_UNKNOWN},
+		{SIGN_ML_DSA_87,				{CKM_ML_DSA,			NULL, 0},
+		 KEY_ML_DSA_87, 0,									HASH_UNKNOWN},
 	};
 
 	CK_MECHANISM_PTR mechanism;
@@ -492,6 +498,18 @@ METHOD(private_key_t, sign, bool,
 	if (this->type == KEY_ECDSA)
 	{	/* signature is twice the length of the base point order */
 		len *= 2;
+	}
+	else if (this->type == KEY_ML_DSA_44)
+	{
+		len = 2420;
+	}
+	else if (this->type == KEY_ML_DSA_65)
+	{
+		len = 3309;
+	}
+	else if (this->type == KEY_ML_DSA_87)
+	{
+		len = 4627;
 	}
 	buf = malloc(len);
 	rv = this->lib->f->C_Sign(session, data.ptr, data.len, buf, &len);
@@ -877,6 +895,41 @@ static bool find_key(private_pkcs11_private_key_t *this, chunk_t keyid)
 				this->object = object;
 				found = TRUE;
 				break;
+			case CKK_ML_DSA:
+			{
+				CK_ULONG param_set = 0;
+				CK_ATTRIBUTE ps_attr[] = {
+					{CKA_PARAMETER_SET, &param_set, sizeof(param_set)},
+				};
+				if (this->lib->f->C_GetAttributeValue(this->session,
+						object, ps_attr, 1) == CKR_OK)
+				{
+					switch (param_set)
+					{
+						case CKP_ML_DSA_44:
+							this->type = KEY_ML_DSA_44;
+							found = TRUE;
+							break;
+						case CKP_ML_DSA_65:
+							this->type = KEY_ML_DSA_65;
+							found = TRUE;
+							break;
+						case CKP_ML_DSA_87:
+							this->type = KEY_ML_DSA_87;
+							found = TRUE;
+							break;
+					}
+				}
+				if (found)
+				{
+					if (attr[1].ulValueLen != CK_UNAVAILABLE_INFORMATION)
+					{
+						this->reauth = reauth;
+					}
+					this->object = object;
+				}
+				break;
+			}
 			default:
 				DBG1(DBG_CFG, "PKCS#11 key type %d not supported", type);
 				break;

--- a/src/libstrongswan/plugins/pkcs11/pkcs11_public_key.c
+++ b/src/libstrongswan/plugins/pkcs11/pkcs11_public_key.c
@@ -510,6 +510,56 @@ METHOD(public_key_t, get_fingerprint, bool,
 			return encode_rsa(this, type, this, fp);
 		case KEY_ECDSA:
 			return fingerprint_ecdsa(this, type, fp);
+		case KEY_ML_DSA_44:
+		case KEY_ML_DSA_65:
+		case KEY_ML_DSA_87:
+		{
+			hasher_t *hasher;
+			chunk_t asn1, key_bytes;
+			int oid;
+
+			switch (this->type)
+			{
+				case KEY_ML_DSA_44:
+					oid = OID_ML_DSA_44;
+					break;
+				case KEY_ML_DSA_65:
+					oid = OID_ML_DSA_65;
+					break;
+				default:
+					oid = OID_ML_DSA_87;
+					break;
+			}
+			if (!this->lib->get_ck_attribute(this->lib, this->session,
+						this->object, CKA_VALUE, &key_bytes))
+			{
+				return FALSE;
+			}
+			switch (type)
+			{
+				case KEYID_PUBKEY_SHA1:
+					asn1 = key_bytes;
+					break;
+				case KEYID_PUBKEY_INFO_SHA1:
+					asn1 = public_key_info_encode(key_bytes, oid);
+					chunk_free(&key_bytes);
+					break;
+				default:
+					chunk_free(&key_bytes);
+					return FALSE;
+			}
+			hasher = lib->crypto->create_hasher(lib->crypto, HASH_SHA1);
+			if (!hasher || !hasher->allocate_hash(hasher, asn1, fp))
+			{
+				DESTROY_IF(hasher);
+				chunk_clear(&asn1);
+				return FALSE;
+			}
+			hasher->destroy(hasher);
+			chunk_clear(&asn1);
+			lib->encoding->cache(lib->encoding, type, this, fp);
+			return TRUE;
+		}
 		default:
 			return FALSE;
 	}
@@ -926,6 +976,32 @@ static private_pkcs11_public_key_t *find_key_by_keyid(pkcs11_library_t *p11,
 					chunk_free(&n);
 					key_type = KEY_RSA;
 					found = TRUE;
+				}
+				break;
+			}
+			case CKK_ML_DSA:
+			{
+				CK_ULONG param_set = 0;
+				CK_ATTRIBUTE ps_attr[] = {
+					{CKA_PARAMETER_SET, &param_set, sizeof(param_set)},
+				};
+				if (p11->f->C_GetAttributeValue(session, object, ps_attr, 1) == CKR_OK)
+				{
+					switch (param_set)
+					{
+						case CKP_ML_DSA_44:
+							key_type = KEY_ML_DSA_44;
+							found = TRUE;
+							break;
+						case CKP_ML_DSA_65:
+							key_type = KEY_ML_DSA_65;
+							found = TRUE;
+							break;
+						case CKP_ML_DSA_87:
+							key_type = KEY_ML_DSA_87;
+							found = TRUE;
+							break;
+					}
 				}
 				break;
 			}


### PR DESCRIPTION
pkcs11: Enable ML-DSA signing and key lookup via PKCS#11 v3.2.