### PR TITLE
feat: Only look up service names for TCP/UDP/SCTP/DCCP

### DIFF
--- a/src/libstrongswan/selectors/traffic_selector.c
+++ b/src/libstrongswan/selectors/traffic_selector.c
@@ -312,7 +312,7 @@ int traffic_selector_printf_hook(printf_hook_data_t *data,
 
 		if (this->from_port == this->to_port)
 		{
-			struct servent *serv;
+			struct servent *serv = NULL;
 
 			if (this->protocol == IPPROTO_ICMP ||
 				this->protocol == IPPROTO_ICMPV6)
@@ -321,7 +321,24 @@ int traffic_selector_printf_hook(printf_hook_data_t *data,
 			}
 			else
 			{
-				serv = getservbyport(htons(this->from_port), serv_proto);
+				/* only TCP/UDP/SCTP/DCCP have a service-name namespace in
+				 * /etc/services.  Skipping the lookup for other protocols
+				 * (e.g. GRE, whose port is a key, not a service) avoids a
+				 * pointless per-selector scan of /etc/services that can never
+				 * match; the output is unchanged as those always fell back to
+				 * the numeric port. */
+				if (this->protocol == IPPROTO_TCP ||
+					this->protocol == IPPROTO_UDP ||
+#ifdef IPPROTO_SCTP
+					this->protocol == IPPROTO_SCTP ||
+#endif
+#ifdef IPPROTO_DCCP
+					this->protocol == IPPROTO_DCCP ||
+#endif
+					FALSE)
+				{
+					serv = getservbyport(htons(this->from_port), serv_proto);
+				}
 				if (serv)
 				{
 					written += print_in_hook(data, "%s", serv->s_name);


### PR DESCRIPTION
# traffic-selector: Only look up service names for TCP/UDP/SCTP/DCCP

## Summary

The traffic-selector `%R` printf hook renders a port by resolving it to a service name with `getservbyport(3)`. That call scans `/etc/services` on every invocation, but only TCP/UDP/SCTP/DCCP have a service-name namespace there. For
any other protocol the lookup can never match, and the hook already falls back to printing the numeric port — so the scan is pure overhead.

This gates the `getservbyport()` call on the protocols that actually have service names. Output is unchanged.

## Motivation

GRE is the case that motivated this. A GRE traffic selector's 16-bit port field is a key, not a service port, so `getservbyport(htons(key), "gre")` always misses and the selector renders numerically regardless. When a component renders many GRE selectors this scan runs on every one for no benefit.

We hit this in production with a VICI client that polls `list-sas` on a short interval: `vici_query` serializes each SA's traffic selectors via `%R`, so every poll triggers a `getservbyport()` per selector. The traffic is all GRE, and the host's NSS backend does not cache the services database, so each lookup rescans `/etc/services` end to end resulting in a noticeable CPU hit.

Note the cost is independent of `charon`'s log level: the `vici_query` `%R` formatting runs whether or not the selector is ever  logged, so log-level tuning does not address it.

## Change

In `traffic_selector_printf_hook()`, only call `getservbyport()` when the protocol is TCP, UDP, SCTP or DCCP; otherwise print the numeric port directly (the pre-existing fallback). `IPPROTO_SCTP` / `IPPROTO_DCCP` are `#ifdef`-guarded since they are not defined on all supported platforms.