### PR TITLE
Couple of test suite fixes specific to windows

### DIFF
--- a/src/libstrongswan/tests/suites/test_fetch_http.c
+++ b/src/libstrongswan/tests/suites/test_fetch_http.c
@@ -165,7 +165,7 @@ static bool servicing(void *data, stream_t *stream)
 
 	t = time(NULL);
 	gmtime_r(&t, &tm);
-	strftime(buf, sizeof(buf), "%a, %d %b %Y %T %z", &tm);
+	strftime(buf, sizeof(buf), "Date: %a, %d %b %Y %T GMT\r\n", &tm);
 	may_fail(test, stream->write_all(stream, buf, strlen(buf)));
 	snprintf(buf, sizeof(buf), "Server: strongSwan unit test\r\n");
 	may_fail(test, stream->write_all(stream, buf, strlen(buf)));

--- a/src/libstrongswan/tests/suites/test_settings.c
+++ b/src/libstrongswan/tests/suites/test_settings.c
@@ -24,7 +24,7 @@
 #include <collections/linked_list.h>
 
 #ifdef WIN32
-static char *path = "C:\\Windows\\Temp\\strongswan-settings-test";
+static char *path = "strongswan-settings-test";
 #else
 static char *path = "/tmp/strongswan-settings-test";
 #endif
@@ -558,10 +558,10 @@ START_TEST(test_key_value_enumerator)
 END_TEST
 
 #ifdef WIN32
-# define include1 "C:\\Windows\\Temp\\strongswan-settings-test-include1"
-# define include1_str "C:\\\\Windows\\\\Temp\\\\strongswan-settings-test-include1"
-# define include2 "C:\\Windows\\Temp\\strongswan-settings-test-include2"
-# define include2_str "C:\\\\Windows\\\\Temp\\\\strongswan-settings-test-include2"
+# define include1 "strongswan-settings-test-include1"
+# define include1_str include1
+# define include2 "strongswan-settings-test-include2"
+# define include2_str include2
 #else
 # define include1 "/tmp/strongswan-settings-test-include1"
 # define include1_str include1


### PR DESCRIPTION
Looks like Linux and Mac clients accepted the malformed header but WinHTTP rejected it. Simple fix for that in src/libstrongswan/tests/suites/test_fetch_http.c

Next was Windows filesystem permissions. By default, unprivileged users cannot list files in the windows temp directory. There really isn't a reason to try and use this path. I suppose one could get the user's temp directory and use that, but there is really no reason not to just do locally.

Both tests should be unaffected on Linux/Mac. 