### PR TITLE
charon-nm: Add EAP-TTLS authentication method

### DIFF
--- a/src/charon-nm/nm/nm_service.c
+++ b/src/charon-nm/nm/nm_service.c
@@ -789,6 +789,10 @@ static bool add_auth_cfg_pw(NMStrongswanPluginPrivate *priv,
 	auth = auth_cfg_create();
 	auth->add(auth, AUTH_RULE_AUTH_CLASS,
 			  streq(method, "psk") ? AUTH_CLASS_PSK : AUTH_CLASS_EAP);
+	if (streq(method, "eap-ttls"))
+	{
+		auth->add(auth, AUTH_RULE_EAP_TYPE, EAP_TTLS);
+	}
 	/* in case EAP-PEAP or EAP-TTLS is used we currently accept any identity */
 	auth->add(auth, AUTH_RULE_AAA_IDENTITY,
 			  identification_create_from_string("%any"));
@@ -1044,6 +1048,7 @@ static gboolean connect_(NMVpnServicePlugin *plugin, NMConnection *connection,
 		}
 	}
 	else if (streq(method, "eap") ||
+			 streq(method, "eap-ttls") ||
 			 streq(method, "psk"))
 	{
 		if (!add_auth_cfg_pw(priv, vpn, peer_cfg, err))
@@ -1248,6 +1253,7 @@ static gboolean need_secrets(NMVpnServicePlugin *plugin, NMConnection *connectio
 			}
 		}
 		else if (streq(method, "eap") ||
+				 streq(method, "eap-ttls") ||
 				 streq(method, "psk"))
 		{
 			need_secret = !nm_setting_vpn_get_secret(settings, "password");


### PR DESCRIPTION
## Summary

Add support for the `eap-ttls` method string in the NetworkManager IKEv2 backend (`charon-nm`), mapping it to `AUTH_RULE_EAP_TYPE=EAP_TTLS` instead of plain EAP.

## Reason for the change

Several university and enterprise VPN gateways (e.g. UFSC's `vpn.ufsc.br`) require IKEv2 with an **EAP-TTLS** outer method wrapping an **MSCHAPv2** inner authentication, distinct from plain EAP. `charon-nm` currently only exposes a generic `eap` method (which maps to `eap-mschapv2`), so NetworkManager users with such gateways have no way to configure the connection and must fall back to manual `swanctl` configuration.

This is part of a 3-layer patch set — the other two layers add the corresponding UI option to the desktop VPN editors:

- **plasma-nm** (KDE): ✅ already merged, see [plasma/plasma-nm!636](https://invent.kde.org/plasma/plasma-nm/-/merge_requests/636), targeting Plasma 6.8
- **network-manager-strongswan** (GTK, GNOME/XFCE/etc): patch ready, not yet submitted

All patches, plus build instructions for any desktop environment, are consolidated at https://github.com/wyllianbs/vpn-eap-ttls-linux while reviews are pending. This continues the discussion from #3134.

## Changes

- `src/charon-nm/nm/nm_service.c`: recognize `method == "eap-ttls"` and set `AUTH_RULE_EAP_TYPE` to `EAP_TTLS` on the peer's auth config; treat `eap-ttls` the same as `eap`/`psk` for username/password handling.

## Test plan

- Built strongSwan with `--enable-nm` on Debian 13 (trixie)
- Configured a NetworkManager IKEv2 connection with `method=eap-ttls`, username and password
- Verified the connection successfully negotiates EAP-TTLS/MSCHAPv2 against a real gateway (UFSC university VPN)