### PR TITLE
nm/gnome: Add EAP-TTLS authentication method

### DIFF
--- a/src/frontends/gnome/properties/nm-strongswan.c
+++ b/src/frontends/gnome/properties/nm-strongswan.c
@@ -211,6 +211,11 @@ static void update_sensitive (StrongswanPluginUiWidgetPrivate *priv)
 			update_pass_field (priv, TRUE);
 			update_cert_fields (priv, FALSE);
 			break;
+		case 4:
+			update_user_field (priv, TRUE);
+			update_pass_field (priv, TRUE);
+			update_cert_fields (priv, FALSE);
+			break;
 	}
 
 }
@@ -434,6 +439,7 @@ init_plugin_ui (StrongswanPluginUiWidget *self, NMConnection *connection, GError
 	gtk_combo_box_text_append_text (GTK_COMBO_BOX_TEXT (widget), _("Certificate"));
 	gtk_combo_box_text_append_text (GTK_COMBO_BOX_TEXT (widget), _("EAP-TLS"));
 	gtk_combo_box_text_append_text (GTK_COMBO_BOX_TEXT (widget), _("Pre-shared key"));
+	gtk_combo_box_text_append_text (GTK_COMBO_BOX_TEXT (widget), _("EAP-TTLS"));
 	if (method) {
 		if (g_strcmp0 (method, "eap") == 0) {
 			gtk_combo_box_set_active (GTK_COMBO_BOX (widget), 0);
@@ -450,6 +456,9 @@ init_plugin_ui (StrongswanPluginUiWidget *self, NMConnection *connection, GError
 		}
 		if (g_strcmp0 (method, "psk") == 0) {
 			gtk_combo_box_set_active (GTK_COMBO_BOX (widget), 3);
+		}
+		if (g_strcmp0 (method, "eap-ttls") == 0) {
+			gtk_combo_box_set_active (GTK_COMBO_BOX (widget), 4);
 		}
 	}
 	if (gtk_combo_box_get_active (GTK_COMBO_BOX (widget)) == -1)
@@ -716,6 +725,11 @@ update_connection (NMVpnEditor *iface,
 			save_entry (settings, priv->builder, "user-entry", "user");
 			save_password_and_flags (settings, priv->builder, "passwd-entry", "password");
 			str = "psk";
+			break;
+		case 4:
+			save_entry (settings, priv->builder, "user-entry", "user");
+			save_password_and_flags (settings, priv->builder, "passwd-entry", "password");
+			str = "eap-ttls";
 			break;
 	}
 	nm_setting_vpn_add_data_item (settings, "method", str);


### PR DESCRIPTION
## Summary

Add an "EAP-TTLS" entry to the GTK NetworkManager VPN editor (`src/frontends/gnome`), reusing the existing EAP username/password fields and setting `method=eap-ttls` in the connection's VPN data, mirroring the existing EAP/PSK handling.

## Reason for the change

Several university and enterprise VPN gateways (e.g. UFSC's `vpn.ufsc.br`) require IKEv2 with **EAP-TTLS/MSCHAPv2** authentication, distinct from plain EAP. Without this, GNOME/XFCE/other GTK-based desktop users have no GUI way to select this method — the only options today are the DBus API/`nmcli` directly (setting `method=eap-ttls`), or manual `swanctl` configuration.

This is part of a 3-layer patch set:

- **plasma-nm** (KDE): ✅ already merged, see [plasma/plasma-nm!636](https://invent.kde.org/plasma/plasma-nm/-/merge_requests/636), targeting Plasma 6.8
- **charon-nm**: proposed in #3135 (see discussion in #3134) — this is what actually negotiates EAP-TTLS with the gateway; this GTK frontend patch alone just sets the `method` string, the same way plasma-nm's already-merged patch does for KDE

All patches, plus build instructions for any desktop environment, are consolidated at https://github.com/wyllianbs/vpn-eap-ttls-linux while reviews are pending.

## Changes

- `src/frontends/gnome/properties/nm-strongswan.c`: add "EAP-TTLS" combo box entry (reusing the EAP username/password fields), recognize/save `method=eap-ttls`.

## Test plan

- Verified the "EAP-TTLS" option appears in the GNOME Settings VPN editor and correctly shows/saves the username+password fields
- Combined with the charon-nm patch from #3135, successfully connects to a real IKEv2/EAP-TTLS gateway (UFSC university VPN)