### PR TITLE
kernel-netlink: Ignore source addresses with a smaller scope than the destination

### DIFF
--- a/src/libcharon/plugins/kernel_netlink/kernel_netlink_net.c
+++ b/src/libcharon/plugins/kernel_netlink/kernel_netlink_net.c
@@ -921,6 +921,12 @@ static host_t *get_matching_address(private_kernel_netlink_net_t *this,
 	iface_entry_t *iface;
 	addr_entry_t *addr, *best = NULL;
 	bool candidate_matched = FALSE;
+	u_char scope_dest = 0;
+
+	if (dest)
+	{
+		scope_dest = get_scope(dest);
+	}
 
 	ifaces = this->ifaces->create_enumerator(this->ifaces);
 	while (ifaces->enumerate(ifaces, &iface))
@@ -933,6 +939,12 @@ static host_t *get_matching_address(private_kernel_netlink_net_t *this,
 				if (addr->refcount ||
 					addr->ip->get_family(addr->ip) != family)
 				{	/* ignore virtual IP addresses and ensure family matches */
+					continue;
+				}
+				if (dest && get_scope(addr->ip) < scope_dest)
+				{	/* ignore addresses of a smaller scope than the destination,
+					 * e.g. link-local addresses for global destinations, which
+					 * the kernel wouldn't use as source address either */
 					continue;
 				}
 				if (net.ptr && !host_in_subnet(addr->ip, net, mask))


### PR DESCRIPTION
`get_matching_address()` returns the first usable address on an interface even if its scope is too small for the destination. `is_address_better()` implements RFC 6724 rule 2 (prefer appropriate scope), but it is only consulted once an interface offers more than one candidate — so an interface that has nothing but a link-local address yields that address for global destinations.

On a router with an unnumbered tunnel interface (IPv4 link-local `169.254.0.6/31`), `get_route()` picks a route over that interface, finds no `RTA_PREFSRC`, falls through to `get_interface_address()` and gets `169.254.0.6`. charon then sends `IKE_SA_INIT` from a link-local address to a global unicast peer and no tunnel can be established. The kernel would never select such a source address itself.

With this change the address is skipped, `get_route()` continues with the next matching route, and the source address ends up the same one the kernel uses.

This is the secondary issue described in #3138. It is independent of #3121 and does not fix the underlying problem there (the userspace route lookup ignoring `ip rule`), but it removes a clearly wrong source address from the candidate set in the cases where the dump-based lookup is still used.

### Testing

Reproduction in a network namespace, where `wan` carries the default route, `tun0` is an unnumbered tunnel with only a link-local address, and table 100 holds a more specific route to the peer while the RPDB restricts that table to an unrelated prefix:

```sh
ip netns add swtest
ip -n swtest link set lo up
ip -n swtest link add wan  type dummy
ip -n swtest link add tun0 type dummy
ip -n swtest link set wan up
ip -n swtest link set tun0 up
ip -n swtest addr add 198.51.100.2/24 dev wan
ip -n swtest addr add 169.254.0.6/31  dev tun0
ip -n swtest route add default via 198.51.100.1 dev wan
ip -n swtest route add 203.0.113.0/24 dev tun0 table 100
ip -n swtest rule  add to 192.0.2.0/24 lookup 100 pref 32764
```

The kernel's own answer:

```
# ip netns exec swtest ip route get 203.0.113.5
203.0.113.5 via 198.51.100.1 dev wan src 198.51.100.2 uid 0
```

Initiating a connection to `203.0.113.5` with no `local_addrs`, before:

```
[IKE] initiating IKE_SA test[1] to 203.0.113.5
[NET] sending packet: from 169.254.0.6[500] to 203.0.113.5[500] (972 bytes)
[IKE] retransmit 1 of request with message ID 0
[NET] sending packet: from 169.254.0.6[500] to 203.0.113.5[500] (972 bytes)
```

after:

```
[IKE] initiating IKE_SA test[1] to 203.0.113.5
[NET] sending packet: from 198.51.100.2[500] to 203.0.113.5[500] (972 bytes)
[IKE] retransmit 1 of request with message ID 0
[NET] sending packet: from 198.51.100.2[500] to 203.0.113.5[500] (972 bytes)
```

A link-local destination still gets the link-local source, so reaching a peer on the unnumbered link keeps working:

```
[IKE] initiating IKE_SA test[1] to 169.254.0.7
[NET] sending packet: from 169.254.0.6[500] to 169.254.0.7[500] (972 bytes)
```

`make check` passes.
