### PR TITLE
nm: Four independent fixes for charon-nm and the editor

### DIFF
--- a/src/charon-nm/nm/nm_creds.c
+++ b/src/charon-nm/nm/nm_creds.c
@@ -348,13 +348,25 @@ METHOD(nm_creds_t, load_ca_dir, void,
 	}
 }
 
+/**
+ * Wipe and free a secret string
+ */
+static void wipe_and_free(char *secret)
+{
+	if (secret)
+	{
+		memwipe(secret, strlen(secret));
+		free(secret);
+	}
+}
+
 METHOD(nm_creds_t, set_username_password, void,
 	private_nm_creds_t *this, identification_t *id, char *password)
 {
 	this->lock->write_lock(this->lock);
 	DESTROY_IF(this->user);
 	this->user = id->clone(id);
-	free(this->pass);
+	wipe_and_free(this->pass);
 	this->pass = strdupnull(password);
 	this->lock->unlock(this->lock);
 }
@@ -363,7 +375,7 @@ METHOD(nm_creds_t, set_key_password, void,
 	private_nm_creds_t *this, char *password)
 {
 	this->lock->write_lock(this->lock);
-	free(this->keypass);
+	wipe_and_free(this->keypass);
 	this->keypass = strdupnull(password);
 	this->lock->unlock(this->lock);
 }
@@ -372,7 +384,7 @@ METHOD(nm_creds_t, set_pin, void,
 	private_nm_creds_t *this, chunk_t keyid, char *pin)
 {
 	this->lock->write_lock(this->lock);
-	free(this->keypass);
+	wipe_and_free(this->keypass);
 	free(this->keyid.ptr);
 	this->keypass = strdupnull(pin);
 	this->keyid = chunk_clone(keyid);
@@ -400,8 +412,8 @@ METHOD(nm_creds_t, clear, void,
 		cert->destroy(cert);
 	}
 	DESTROY_IF(this->user);
-	free(this->pass);
-	free(this->keypass);
+	wipe_and_free(this->pass);
+	wipe_and_free(this->keypass);
 	free(this->keyid.ptr);
 	DESTROY_IF(this->usercert);
 	DESTROY_IF(this->key);

--- a/src/charon-nm/nm/nm_service.c
+++ b/src/charon-nm/nm/nm_service.c
@@ -931,6 +931,9 @@ static gboolean connect_(NMVpnServicePlugin *plugin, NMConnection *connection,
 	ike.force_encap = streq(str, "yes");
 	str = nm_setting_vpn_get_data_item(vpn, "ipcomp");
 	child.options |= streq(str, "yes") ? OPT_IPCOMP : 0;
+	str = nm_setting_vpn_get_data_item(vpn, "dpd-delay");
+	/* dpd_action is set above, but without a delay no DPD is ever sent */
+	peer.dpd = settings_value_as_time((char*)str, 0);
 
 	/**
 	 * Register credentials

--- a/src/frontends/gnome/properties/nm-strongswan.c
+++ b/src/frontends/gnome/properties/nm-strongswan.c
@@ -670,6 +670,40 @@ save_cert (NMSettingVpn *settings, GtkBuilder *builder)
 	}
 }
 
+/*
+ * Data items the editor presents and therefore owns.  Everything else on the
+ * connection was set some other way (nmcli, a hand-written keyfile) and must
+ * survive a save.
+ */
+static const char *editor_managed_keys[] = {
+	"address", "certificate", "cert-source", "encap", "esp", "ike", "ipcomp",
+	"local-identity", "local-ts", "method", "proposal", "remote-identity",
+	"remote-ts", "server-port", "user", "usercert", "userkey", "virtual",
+	/* secrets and the flags that accompany them */
+	"password", "password-flags",
+};
+
+/*
+ * Copy one data item across unless the editor owns that key.  Owned keys are
+ * skipped rather than copied, otherwise clearing a field in the UI would be
+ * silently undone by the value it used to have.
+ */
+static void
+carry_over_unmanaged (const char *key, const char *value, gpointer user_data)
+{
+	NMSettingVpn *settings = user_data;
+	guint i;
+
+	for (i = 0; i < G_N_ELEMENTS (editor_managed_keys); i++)
+	{
+		if (g_strcmp0 (key, editor_managed_keys[i]) == 0)
+		{
+			return;
+		}
+	}
+	nm_setting_vpn_add_data_item (settings, key, value);
+}
+
 static gboolean
 update_connection (NMVpnEditor *iface,
 				   NMConnection *connection,
@@ -677,7 +711,7 @@ update_connection (NMVpnEditor *iface,
 {
 	StrongswanPluginUiWidget *self = STRONGSWAN_PLUGIN_UI_WIDGET (iface);
 	StrongswanPluginUiWidgetPrivate *priv = STRONGSWAN_PLUGIN_UI_WIDGET_GET_PRIVATE (self);
-	NMSettingVpn *settings;
+	NMSettingVpn *settings, *existing;
 	GtkWidget *widget;
 	gboolean active;
 	char *str;
@@ -754,6 +788,17 @@ update_connection (NMVpnEditor *iface,
 
 	save_entry (settings, priv->builder, "local-ts-entry", "local-ts");
 	save_entry (settings, priv->builder, "remote-ts-entry", "remote-ts");
+
+	/* This function builds a fresh NMSettingVpn from the widgets, so a data
+	 * item with no widget behind it would be dropped here, silently
+	 * discarding configuration made with nmcli.  Carry those over from the
+	 * connection being edited. */
+	existing = nm_connection_get_setting_vpn (connection);
+	if (existing)
+	{
+		nm_setting_vpn_foreach_data_item (existing, carry_over_unmanaged,
+										  settings);
+	}
 
 	nm_connection_add_setting (connection, NM_SETTING (settings));
 	return TRUE;

--- a/src/frontends/gnome/properties/nm-strongswan.c
+++ b/src/frontends/gnome/properties/nm-strongswan.c
@@ -811,14 +811,23 @@ dispose (GObject *object)
 	StrongswanPluginUiWidgetPrivate *priv = STRONGSWAN_PLUGIN_UI_WIDGET_GET_PRIVATE (plugin);
 	GtkWidget *widget;
 
-	widget = GTK_WIDGET (gtk_builder_get_object (priv->builder, "passwd-entry"));
-	g_signal_handlers_disconnect_by_func (G_OBJECT (widget), G_CALLBACK (password_storage_changed_cb), plugin);
+	if (priv->builder)
+	{
+		widget = GTK_WIDGET (gtk_builder_get_object (priv->builder, "passwd-entry"));
+		g_signal_handlers_disconnect_by_func (G_OBJECT (widget), G_CALLBACK (password_storage_changed_cb), plugin);
+	}
 
 	if (priv->widget)
+	{
 		g_object_unref (priv->widget);
+		priv->widget = NULL;
+	}
 
 	if (priv->builder)
+	{
 		g_object_unref (priv->builder);
+		priv->builder = NULL;
+	}
 
 	G_OBJECT_CLASS (strongswan_plugin_ui_widget_parent_class)->dispose (object);
 }


### PR DESCRIPTION
Four unrelated fixes in charon-nm and the NM editor. They do not depend on each
other -- take or drop individually.

- **Wipe secrets before freeing them.** The user password and private key
  passphrase were freed without being cleared.

- **Keep connection data items the editor has no widget for.**
  `update_connection()` rebuilds the VPN setting from the widgets, so anything
  else is silently dropped on save. Not hypothetical: `remote-ts` was readable by
  charon-nm from 2020 and only gained a field in 2025, so for that whole period an
  nmcli-configured connection lost its traffic selectors the first time anyone
  opened it in the GUI.

- **Add a per-connection `dpd-delay`.** `peer_cfg_create_t.dpd` is left
  zero-filled, so no NM connection runs a periodic liveness check despite the
  child config setting `dpd_action`; a gateway that vanishes without a DELETE is
  only noticed at the next rekeying. `charon-nm.check_current_path` does not cover
  this -- it fires once from the roam handler, catching the client moving rather
  than the gateway going away. Unset gives 0, so nothing changes unless
  configured. Keyfile/nmcli only, as `remote-ts` was.

- **Make `dispose()` idempotent.** It dereferenced `priv->builder` before checking
  it, and left both pointers set after unreffing them.

Tested on Ubuntu 24.04 and built against master. `dpd-delay` was verified in
isolation on an otherwise pristine 5.9.13 tree: with `dpd-delay=10` on a
`method=eap` connection DPD fires every 10 s; with the item absent, nothing is
sent. The editor fix was verified by driving `update_connection()` directly.
